### PR TITLE
ci: track solver performance regressions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -46,16 +46,16 @@ jobs:
           uv venv --python 3.11
           uv pip install -e '.[dynamiqs]' -c ci-constraints-3.11.txt
 
-      - name: Resolve exact base
+      - name: Resolve exact main
         id: comparison
         env:
-          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          EVENT_MAIN_SHA: ${{ github.event_name == 'push' && github.event.before || '' }}
         run: |
-          if [[ -z "$EVENT_BASE_SHA" || "$EVENT_BASE_SHA" == "0000000000000000000000000000000000000000" ]]; then
-            EVENT_BASE_SHA=$(git rev-parse HEAD^)
+          if [[ -z "$EVENT_MAIN_SHA" || "$EVENT_MAIN_SHA" == "0000000000000000000000000000000000000000" ]]; then
+            EVENT_MAIN_SHA=$(git rev-parse origin/main)
           fi
-          git cat-file -e "${EVENT_BASE_SHA}^{commit}"
-          echo "base_sha=$EVENT_BASE_SHA" >> "$GITHUB_OUTPUT"
+          git cat-file -e "${EVENT_MAIN_SHA}^{commit}"
+          echo "main_sha=$EVENT_MAIN_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Record environment
         run: |
@@ -69,7 +69,7 @@ jobs:
         id: benchmark
         run: |
           uv run --no-sync python benchmarks/closed_system.py run \
-            --base-ref "${{ steps.comparison.outputs.base_sha }}" \
+            --main-ref "${{ steps.comparison.outputs.main_sha }}" \
             --rungs "$BENCHMARK_RUNGS" \
             --build-repeat "$BUILD_REPEAT" \
             --warmup 1 \

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,102 @@
+name: benchmark
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: benchmark-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  closed-system:
+    name: closed-system overhead
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      BENCHMARK_RUNGS: ${{ github.event_name == 'push' && '1,2,3,4,5,6,7' || '1,3,5,7' }}
+      BUILD_REPEAT: ${{ github.event_name == 'push' && '5' || '3' }}
+      SOLVE_REPEAT: ${{ github.event_name == 'push' && '7' || '5' }}
+      JAX_ENABLE_X64: "true"
+      XLA_PYTHON_CLIENT_PREALLOCATE: "false"
+      MPLCONFIGDIR: /tmp/quchip-matplotlib
+    steps:
+      - name: Check out exact head
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            ci-constraints-3.11.txt
+
+      - name: Install benchmark environment
+        run: |
+          uv venv --python 3.11
+          uv pip install -e '.[dynamiqs]' -c ci-constraints-3.11.txt
+
+      - name: Resolve exact base
+        id: comparison
+        env:
+          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          if [[ -z "$EVENT_BASE_SHA" || "$EVENT_BASE_SHA" == "0000000000000000000000000000000000000000" ]]; then
+            EVENT_BASE_SHA=$(git rev-parse HEAD^)
+          fi
+          git cat-file -e "${EVENT_BASE_SHA}^{commit}"
+          echo "base_sha=$EVENT_BASE_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Record environment
+        run: |
+          mkdir -p benchmark-output
+          uv run --no-sync python --version > benchmark-output/environment.txt
+          uv pip freeze >> benchmark-output/environment.txt
+          uname -a >> benchmark-output/environment.txt
+          lscpu >> benchmark-output/environment.txt
+
+      - name: Run benchmark
+        id: benchmark
+        run: |
+          uv run --no-sync python benchmarks/closed_system.py run \
+            --base-ref "${{ steps.comparison.outputs.base_sha }}" \
+            --rungs "$BENCHMARK_RUNGS" \
+            --build-repeat "$BUILD_REPEAT" \
+            --warmup 1 \
+            --solve-repeat "$SOLVE_REPEAT" \
+            --out benchmark-output/closed-system.json
+
+      - name: Render report
+        id: report
+        run: |
+          uv run --no-sync python benchmarks/closed_system.py report \
+            --data benchmark-output/closed-system.json \
+            --out-dir benchmark-output \
+            --summary benchmark-output/summary.md
+
+      - name: Upload benchmark bundle
+        id: upload
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: closed-system-${{ github.event_name }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: benchmark-output
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Publish job summary
+        if: ${{ !cancelled() && steps.report.outcome == 'success' }}
+        run: |
+          cat benchmark-output/summary.md >> "$GITHUB_STEP_SUMMARY"
+          printf '\n[Download JSON, environment, samples, and plots](%s)\n' \
+            "${{ steps.upload.outputs.artifact-url }}" >> "$GITHUB_STEP_SUMMARY"

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Reproducible performance measurements for quchip development."""

--- a/benchmarks/closed_system.py
+++ b/benchmarks/closed_system.py
@@ -1,0 +1,540 @@
+"""Compare quchip with direct QuTiP and dynamiqs closed-system solves."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import io
+import json
+import os
+import platform
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+import numpy as np
+
+os.environ.setdefault("MPLCONFIGDIR", str(Path(tempfile.gettempdir()) / "quchip-matplotlib"))
+
+LEVELS = 3
+BASE_FREQ = 5.0
+FREQ_STEP = 0.1
+ANHARMONICITY = -0.25
+COUPLING_G = 0.01
+DRIVE_AMP = 0.02
+DRIVE_SIGMAS = 3.0
+PULSE_DURATION = 40.0
+N_TIMES = 401
+ATOL = 1e-8
+RTOL = 1e-6
+MAX_STEPS = 1_000_000
+PARITY_TOL = 1e-5
+TWO_PI = 2.0 * np.pi
+
+
+def frequencies(n: int) -> list[float]:
+    """Return the frequency ladder used by every implementation."""
+    return [BASE_FREQ + FREQ_STEP * index for index in range(n)]
+
+
+def time_grid() -> np.ndarray:
+    """Return the shared pulse sampling grid."""
+    return np.linspace(0.0, PULSE_DURATION, N_TIMES)
+
+
+def gaussian_envelope(t: Any, *, xp: Any = np) -> Any:
+    """Evaluate the shared Gaussian control envelope."""
+    center = PULSE_DURATION / 2.0
+    sigma = PULSE_DURATION / (2.0 * DRIVE_SIGMAS)
+    return xp.exp(-((t - center) ** 2) / (2.0 * sigma**2))
+
+
+def _timed(call: Callable[[], Any]) -> tuple[float, Any]:
+    start = time.perf_counter()
+    result = call()
+    return time.perf_counter() - start, result
+
+
+def _qutip_site(op: Any, index: int, n: int, levels: int) -> Any:
+    import qutip as qt
+
+    operators = [qt.qeye(levels)] * n
+    operators[index] = op
+    return qt.tensor(operators)
+
+
+def _build_native_qutip(n: int, levels: int) -> dict[str, Any]:
+    import qutip as qt
+
+    lowering = qt.destroy(levels)
+    number = qt.num(levels)
+    a_ops = [_qutip_site(lowering, index, n, levels) for index in range(n)]
+    n_ops = [_qutip_site(number, index, n, levels) for index in range(n)]
+    hamiltonian: list[Any] = [
+        sum(
+            (TWO_PI * (ANHARMONICITY / 2.0) * (op * op - op) for op in n_ops),
+            0 * n_ops[0],
+        )
+    ]
+    angular_detuning = TWO_PI * FREQ_STEP
+    minus = qt.coefficient(lambda t: np.exp(-1j * angular_detuning * t))
+    plus = qt.coefficient(lambda t: np.exp(1j * angular_detuning * t))
+    envelope = qt.coefficient(lambda t: gaussian_envelope(t))
+    for index in range(n - 1):
+        exchange = TWO_PI * COUPLING_G * (a_ops[index].dag() * a_ops[index + 1])
+        hamiltonian.extend(([exchange, minus], [exchange.dag(), plus]))
+    drive_op = TWO_PI * (DRIVE_AMP / 2.0) * (1j * (a_ops[0] - a_ops[0].dag()))
+    hamiltonian.append([drive_op, envelope])
+    options = {"atol": ATOL, "rtol": RTOL, "nsteps": MAX_STEPS, "store_states": False}
+    return {
+        "runner": qt.SESolver(qt.QobjEvo(hamiltonian), options=options),
+        "state": qt.tensor([qt.basis(levels, 0)] * n),
+        "observables": n_ops,
+    }
+
+
+def _solve_native_qutip(model: dict[str, Any]) -> np.ndarray:
+    result = model["runner"].run(model["state"], time_grid(), e_ops=model["observables"])
+    return np.real(np.asarray(result.expect))
+
+
+def _dynamiqs_site(op: Any, index: int, n: int, levels: int) -> Any:
+    import dynamiqs as dq
+
+    return dq.tensor(*[op if site == index else dq.eye(levels) for site in range(n)])
+
+
+def _build_native_dynamiqs(n: int, levels: int) -> dict[str, Any]:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import dynamiqs as dq
+    import jax.numpy as jnp
+
+    lowering = dq.destroy(levels)
+    number = dq.number(levels)
+    a_ops = [_dynamiqs_site(lowering, index, n, levels) for index in range(n)]
+    n_ops = [_dynamiqs_site(number, index, n, levels) for index in range(n)]
+    state = dq.tensor(*[dq.fock(levels, 0) for _ in range(n)])
+    method = dq.method.Tsit5(rtol=RTOL, atol=ATOL, max_steps=MAX_STEPS)
+    options = dq.Options(save_states=False, progress_meter=False)
+
+    @jax.jit
+    def solve(amplitude: Any) -> Any:
+        hamiltonian: Any = 0.0 * n_ops[0]
+        for op in n_ops:
+            hamiltonian = hamiltonian + TWO_PI * (ANHARMONICITY / 2.0) * (op @ op - op)
+        angular_detuning = TWO_PI * FREQ_STEP
+        for index in range(n - 1):
+            exchange = TWO_PI * COUPLING_G * (dq.dag(a_ops[index]) @ a_ops[index + 1])
+            hamiltonian = hamiltonian + dq.modulated(
+                lambda t, w=angular_detuning: jnp.exp(-1j * w * t), exchange
+            )
+            hamiltonian = hamiltonian + dq.modulated(
+                lambda t, w=angular_detuning: jnp.exp(1j * w * t), dq.dag(exchange)
+            )
+        drive_op = 1j * (a_ops[0] - dq.dag(a_ops[0]))
+        hamiltonian = hamiltonian + dq.modulated(
+            lambda t: (TWO_PI * amplitude / 2.0) * gaussian_envelope(t, xp=jnp) + 0.0j,
+            drive_op,
+        )
+        result = dq.sesolve(
+            hamiltonian,
+            state,
+            time_grid(),
+            exp_ops=n_ops,
+            method=method,
+            options=options,
+        )
+        return result.expects
+
+    return {"solve": solve}
+
+
+def _solve_native_dynamiqs(model: dict[str, Any]) -> np.ndarray:
+    return np.real(np.asarray(model["solve"](DRIVE_AMP)))
+
+
+def _build_quchip(n: int, levels: int, family: str) -> tuple[Any, list[str]]:
+    import quchip
+    from quchip import Capacitive, ChargeDrive, Chip, DuffingTransmon, Gaussian, QuantumSequence
+    from quchip.engine import solve_problem
+
+    del quchip, solve_problem
+    freqs = frequencies(n)
+    devices: list[Any] = [
+        DuffingTransmon(
+            freq=freq,
+            anharmonicity=ANHARMONICITY,
+            levels=levels,
+            label=f"q{index}",
+        )
+        for index, freq in enumerate(freqs)
+    ]
+    for device, freq in zip(devices, freqs):
+        device.reference_freq = freq
+    couplings: list[Any] = [
+        Capacitive(devices[index], devices[index + 1], g=COUPLING_G) for index in range(n - 1)
+    ]
+    chip = Chip(
+        devices,
+        couplings or None,
+        frame={device: freq for device, freq in zip(devices, freqs)},
+        rwa=True,
+        backend=family,
+    )
+    drive = ChargeDrive(devices[0], label="d0")
+    chip.wire(drive)
+    sequence = QuantumSequence(chip)
+    sequence.schedule(
+        drive,
+        envelope=Gaussian(duration=PULSE_DURATION, sigmas=DRIVE_SIGMAS, amplitude=DRIVE_AMP),
+        freq=freqs[0],
+    )
+    if family == "qutip":
+        options: dict[str, Any] = {"atol": ATOL, "rtol": RTOL, "nsteps": MAX_STEPS, "store_states": False}
+    else:
+        import dynamiqs as dq
+
+        options = {
+            "method": dq.method.Tsit5(rtol=RTOL, atol=ATOL, max_steps=MAX_STEPS),
+            "store_states": False,
+        }
+    problem = sequence.build_problem(
+        tlist=time_grid(),
+        e_ops=chip.e_ops(**{device.label: "n" for device in devices}),  # type: ignore[arg-type]
+        initial_state=chip.bare_state(**{device.label: 0 for device in devices}),
+        options=options,
+    )
+    return problem, [device.label for device in devices]
+
+
+def _solve_quchip(model: tuple[Any, list[str]]) -> np.ndarray:
+    from quchip.engine import solve_problem
+
+    problem, labels = model
+    result = solve_problem(problem, check_truncation=False)
+    return np.stack([np.real(np.asarray(result.expect(label))) for label in labels])
+
+
+def _worker(args: argparse.Namespace) -> None:
+    row: dict[str, Any] = {
+        "N": args.n,
+        "levels": args.levels,
+        "dim": args.levels**args.n,
+        "family": args.family,
+        "path": args.path,
+    }
+    try:
+        build_call: Callable[[], Any]
+        solve: Callable[[Any], np.ndarray]
+        if args.family == "qutip":
+            import qutip
+
+            del qutip
+        else:
+            import dynamiqs
+            import jax
+
+            del dynamiqs, jax
+        if args.path == "native":
+            if args.family == "qutip":
+                build, solve = _build_native_qutip, _solve_native_qutip
+            else:
+                build, solve = _build_native_dynamiqs, _solve_native_dynamiqs
+
+            def build_call() -> Any:
+                return build(args.n, args.levels)
+
+        else:
+            import quchip
+
+            imported = Path(quchip.__file__).resolve()
+            expected = Path(args.source_root).resolve()
+            if not imported.is_relative_to(expected):
+                raise RuntimeError(f"loaded quchip from {imported}, expected it under {expected}")
+
+            def build_call() -> Any:
+                return _build_quchip(args.n, args.levels, args.family)
+
+            solve = _solve_quchip
+
+        cold_build_s, model = _timed(build_call)
+        first_solve_s, traces = _timed(lambda: solve(model))
+        for _ in range(args.warmup):
+            solve(model)
+        warm_samples = [_timed(lambda: solve(model))[0] for _ in range(args.solve_repeat)]
+        build_samples = [_timed(build_call)[0] for _ in range(args.build_repeat)]
+        np.save(args.trace_out, traces)
+        row.update(
+            cold_build_s=cold_build_s,
+            build_s=float(np.median(build_samples)),
+            build_samples_s=build_samples,
+            first_solve_s=first_solve_s,
+            warm_solve_s=float(np.median(warm_samples)),
+            warm_samples_s=warm_samples,
+        )
+        if args.reference:
+            reference = np.load(args.reference)
+            parity = float(np.max(np.abs(traces - reference)))
+            row.update(parity=parity, status="ok" if parity < PARITY_TOL else "parity-fail")
+        else:
+            row.update(parity=0.0, status="ok")
+    except Exception as exc:
+        row.update(status="error", error=f"{type(exc).__name__}: {exc}")
+    Path(args.row_out).write_text(json.dumps(row, indent=2) + "\n")
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, text=True, stdout=subprocess.PIPE
+    ).stdout.strip()
+
+
+def _package_version(name: str) -> str | None:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _provenance(repo: Path, base_ref: str, args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "python": platform.python_version(),
+        "head_branch": _git(repo, "branch", "--show-current") or "detached",
+        "head_commit": _git(repo, "rev-parse", "HEAD"),
+        "head_dirty": bool(_git(repo, "status", "--porcelain", "--untracked-files=no")),
+        "base_ref": base_ref,
+        "base_commit": _git(repo, "rev-parse", base_ref),
+        "qutip": _package_version("qutip"),
+        "dynamiqs": _package_version("dynamiqs"),
+        "jax": _package_version("jax"),
+        "numpy": _package_version("numpy"),
+        "build_repeat": args.build_repeat,
+        "warmup": args.warmup,
+        "solve_repeat": args.solve_repeat,
+        "parity_tol": PARITY_TOL,
+        "constants": {
+            "levels": args.levels,
+            "coupling_g": COUPLING_G,
+            "drive_amp": DRIVE_AMP,
+            "atol": ATOL,
+            "rtol": RTOL,
+            "n_times": N_TIMES,
+        },
+    }
+
+
+def _extract_ref(repo: Path, ref: str, destination: Path) -> None:
+    archive = subprocess.run(
+        ["git", "archive", "--format=tar", ref], cwd=repo, check=True, stdout=subprocess.PIPE
+    ).stdout
+    with tarfile.open(fileobj=io.BytesIO(archive), mode="r:") as handle:
+        handle.extractall(destination)
+
+
+def _invoke_worker(
+    *,
+    path_name: str,
+    family: str,
+    n: int,
+    args: argparse.Namespace,
+    source_root: Path | None,
+    reference: Path | None,
+    temp_dir: Path,
+) -> tuple[dict[str, Any], Path]:
+    stem = f"{n}-{family}-{path_name}"
+    row_path = temp_dir / f"{stem}.json"
+    trace_path = temp_dir / f"{stem}.npy"
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "_worker",
+        "--path",
+        path_name,
+        "--family",
+        family,
+        "--n",
+        str(n),
+        "--levels",
+        str(args.levels),
+        "--build-repeat",
+        str(args.build_repeat),
+        "--warmup",
+        str(args.warmup),
+        "--solve-repeat",
+        str(args.solve_repeat),
+        "--row-out",
+        str(row_path),
+        "--trace-out",
+        str(trace_path),
+    ]
+    if source_root is not None:
+        command.extend(("--source-root", str(source_root)))
+    if reference is not None:
+        command.extend(("--reference", str(reference)))
+    environment = dict(os.environ)
+    if source_root is not None:
+        environment["PYTHONPATH"] = str(source_root)
+    subprocess.run(command, check=True, env=environment)
+    return json.loads(row_path.read_text()), trace_path
+
+
+def _parse_rungs(value: str) -> list[int]:
+    rungs = [int(token.strip()) for token in value.split(",") if token.strip()]
+    if not rungs or any(n < 1 for n in rungs) or len(rungs) != len(set(rungs)):
+        raise ValueError("--rungs must contain unique positive comma-separated integers")
+    return rungs
+
+
+def _run(args: argparse.Namespace) -> None:
+    repo = Path(_git(Path.cwd(), "rev-parse", "--show-toplevel"))
+    provenance = _provenance(repo, args.base_ref, args)
+    if provenance["head_dirty"] and not args.allow_dirty:
+        raise SystemExit("current checkout is dirty; commit it first or pass --allow-dirty")
+    output = Path(args.out).resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    rows: list[dict[str, Any]] = []
+
+    def persist(complete: bool) -> None:
+        output.write_text(
+            json.dumps(
+                {"schema_version": 1, "provenance": provenance, "complete": complete, "rows": rows},
+                indent=2,
+            )
+            + "\n"
+        )
+
+    with tempfile.TemporaryDirectory(prefix="quchip-base-") as base_temp, tempfile.TemporaryDirectory(
+        prefix="quchip-benchmark-"
+    ) as cell_temp:
+        base_root = Path(base_temp)
+        cell_root = Path(cell_temp)
+        _extract_ref(repo, args.base_ref, base_root)
+        for rung_index, n in enumerate(_parse_rungs(args.rungs)):
+            qutip_native, reference_trace = _invoke_worker(
+                path_name="native",
+                family="qutip",
+                n=n,
+                args=args,
+                source_root=None,
+                reference=None,
+                temp_dir=cell_root,
+            )
+            rows.append(qutip_native)
+            persist(False)
+            print(f"[dim={args.levels**n} qutip/native] {qutip_native['status']}", flush=True)
+            reference = reference_trace if reference_trace.exists() else None
+            revisions: tuple[tuple[str, Path], ...] = (("head", repo), ("base", base_root))
+            if rung_index % 2:
+                revisions = tuple(reversed(revisions))
+            for path_name, source_root in revisions:
+                row, _ = _invoke_worker(
+                    path_name=path_name,
+                    family="qutip",
+                    n=n,
+                    args=args,
+                    source_root=source_root,
+                    reference=reference,
+                    temp_dir=cell_root,
+                )
+                rows.append(row)
+                persist(False)
+                print(f"[dim={args.levels**n} qutip/{path_name}] {row['status']}", flush=True)
+
+            dynamiqs_native, _ = _invoke_worker(
+                path_name="native",
+                family="dynamiqs",
+                n=n,
+                args=args,
+                source_root=None,
+                reference=reference,
+                temp_dir=cell_root,
+            )
+            rows.append(dynamiqs_native)
+            persist(False)
+            print(f"[dim={args.levels**n} dynamiqs/native] {dynamiqs_native['status']}", flush=True)
+            for path_name, source_root in revisions:
+                row, _ = _invoke_worker(
+                    path_name=path_name,
+                    family="dynamiqs",
+                    n=n,
+                    args=args,
+                    source_root=source_root,
+                    reference=reference,
+                    temp_dir=cell_root,
+                )
+                rows.append(row)
+                persist(False)
+                print(f"[dim={args.levels**n} dynamiqs/{path_name}] {row['status']}", flush=True)
+    persist(True)
+    failures = [row for row in rows if row.get("status") != "ok"]
+    if failures:
+        cells = ", ".join(f"{row['family']}/{row['path']}/N={row['N']}" for row in failures)
+        raise SystemExit(f"benchmark failed after writing {output}: {cells}")
+    print(f"wrote {output}")
+
+
+def _report(args: argparse.Namespace) -> None:
+    from reporting import load_result, render_markdown, render_plots
+
+    document = load_result(Path(args.data))
+    summary = render_markdown(document)
+    summary_path = Path(args.summary)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(summary)
+    outputs = render_plots(document, Path(args.out_dir))
+    print(f"wrote {summary_path} and {len(outputs)} plots")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run = subparsers.add_parser("run", help="record closed-system benchmark rows")
+    run.add_argument("--base-ref", default="main")
+    run.add_argument("--levels", type=int, default=LEVELS)
+    run.add_argument("--rungs", default="1,3,5,7")
+    run.add_argument("--build-repeat", type=int, default=3)
+    run.add_argument("--warmup", type=int, default=1)
+    run.add_argument("--solve-repeat", type=int, default=3)
+    run.add_argument("--out", default="benchmark-output/closed-system.json")
+    run.add_argument("--allow-dirty", action="store_true")
+    run.set_defaults(handler=_run)
+
+    report = subparsers.add_parser("report", help="validate and render a recorded result")
+    report.add_argument("--data", default="benchmark-output/closed-system.json")
+    report.add_argument("--out-dir", default="benchmark-output")
+    report.add_argument("--summary", default="benchmark-output/summary.md")
+    report.set_defaults(handler=_report)
+
+    worker = subparsers.add_parser("_worker", help=argparse.SUPPRESS)
+    worker.add_argument("--path", choices=("head", "base", "native"), required=True)
+    worker.add_argument("--family", choices=("qutip", "dynamiqs"), required=True)
+    worker.add_argument("--n", type=int, required=True)
+    worker.add_argument("--levels", type=int, required=True)
+    worker.add_argument("--build-repeat", type=int, required=True)
+    worker.add_argument("--warmup", type=int, required=True)
+    worker.add_argument("--solve-repeat", type=int, required=True)
+    worker.add_argument("--source-root")
+    worker.add_argument("--reference")
+    worker.add_argument("--row-out", required=True)
+    worker.add_argument("--trace-out", required=True)
+    worker.set_defaults(handler=_worker)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run a benchmark command."""
+    args = _parser().parse_args(argv)
+    args.handler(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/closed_system.py
+++ b/benchmarks/closed_system.py
@@ -302,7 +302,7 @@ def _package_version(name: str) -> str | None:
         return None
 
 
-def _provenance(repo: Path, base_ref: str, args: argparse.Namespace) -> dict[str, Any]:
+def _provenance(repo: Path, main_ref: str, args: argparse.Namespace) -> dict[str, Any]:
     return {
         "platform": platform.platform(),
         "machine": platform.machine(),
@@ -310,8 +310,8 @@ def _provenance(repo: Path, base_ref: str, args: argparse.Namespace) -> dict[str
         "head_branch": _git(repo, "branch", "--show-current") or "detached",
         "head_commit": _git(repo, "rev-parse", "HEAD"),
         "head_dirty": bool(_git(repo, "status", "--porcelain", "--untracked-files=no")),
-        "base_ref": base_ref,
-        "base_commit": _git(repo, "rev-parse", base_ref),
+        "main_ref": main_ref,
+        "main_commit": _git(repo, "rev-parse", main_ref),
         "qutip": _package_version("qutip"),
         "dynamiqs": _package_version("dynamiqs"),
         "jax": _package_version("jax"),
@@ -395,7 +395,7 @@ def _parse_rungs(value: str) -> list[int]:
 
 def _run(args: argparse.Namespace) -> None:
     repo = Path(_git(Path.cwd(), "rev-parse", "--show-toplevel"))
-    provenance = _provenance(repo, args.base_ref, args)
+    provenance = _provenance(repo, args.main_ref, args)
     if provenance["head_dirty"] and not args.allow_dirty:
         raise SystemExit("current checkout is dirty; commit it first or pass --allow-dirty")
     output = Path(args.out).resolve()
@@ -405,18 +405,18 @@ def _run(args: argparse.Namespace) -> None:
     def persist(complete: bool) -> None:
         output.write_text(
             json.dumps(
-                {"schema_version": 1, "provenance": provenance, "complete": complete, "rows": rows},
+                {"schema_version": 2, "provenance": provenance, "complete": complete, "rows": rows},
                 indent=2,
             )
             + "\n"
         )
 
-    with tempfile.TemporaryDirectory(prefix="quchip-base-") as base_temp, tempfile.TemporaryDirectory(
+    with tempfile.TemporaryDirectory(prefix="quchip-main-") as main_temp, tempfile.TemporaryDirectory(
         prefix="quchip-benchmark-"
     ) as cell_temp:
-        base_root = Path(base_temp)
+        main_root = Path(main_temp)
         cell_root = Path(cell_temp)
-        _extract_ref(repo, args.base_ref, base_root)
+        _extract_ref(repo, args.main_ref, main_root)
         for rung_index, n in enumerate(_parse_rungs(args.rungs)):
             qutip_native, reference_trace = _invoke_worker(
                 path_name="native",
@@ -431,7 +431,7 @@ def _run(args: argparse.Namespace) -> None:
             persist(False)
             print(f"[dim={args.levels**n} qutip/native] {qutip_native['status']}", flush=True)
             reference = reference_trace if reference_trace.exists() else None
-            revisions: tuple[tuple[str, Path], ...] = (("head", repo), ("base", base_root))
+            revisions: tuple[tuple[str, Path], ...] = (("head", repo), ("main", main_root))
             if rung_index % 2:
                 revisions = tuple(reversed(revisions))
             for path_name, source_root in revisions:
@@ -498,7 +498,7 @@ def _parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     run = subparsers.add_parser("run", help="record closed-system benchmark rows")
-    run.add_argument("--base-ref", default="main")
+    run.add_argument("--main-ref", default="main")
     run.add_argument("--levels", type=int, default=LEVELS)
     run.add_argument("--rungs", default="1,3,5,7")
     run.add_argument("--build-repeat", type=int, default=3)
@@ -515,7 +515,7 @@ def _parser() -> argparse.ArgumentParser:
     report.set_defaults(handler=_report)
 
     worker = subparsers.add_parser("_worker", help=argparse.SUPPRESS)
-    worker.add_argument("--path", choices=("head", "base", "native"), required=True)
+    worker.add_argument("--path", choices=("head", "main", "native"), required=True)
     worker.add_argument("--family", choices=("qutip", "dynamiqs"), required=True)
     worker.add_argument("--n", type=int, required=True)
     worker.add_argument("--levels", type=int, required=True)

--- a/benchmarks/reporting.py
+++ b/benchmarks/reporting.py
@@ -1,0 +1,260 @@
+"""Validate and report closed-system benchmark results."""
+
+from __future__ import annotations
+
+import math
+import os
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+os.environ.setdefault("MPLCONFIGDIR", str(Path(tempfile.gettempdir()) / "quchip-matplotlib"))
+
+METRICS = {
+    "cold_build_s": "Cold build",
+    "build_s": "Repeated build",
+    "first_solve_s": "First solve",
+    "warm_solve_s": "Warm solve",
+}
+FAMILIES = ("qutip", "dynamiqs")
+PATHS = ("head", "base", "native")
+
+NAVY = "#1D3557"
+INK = "#3D405B"
+RED = "#E63946"
+SAGE = "#81B29A"
+TERRA = "#E07A5F"
+PAPER = "#FAFBFC"
+
+
+def load_result(path: Path) -> dict[str, Any]:
+    """Load a complete successful benchmark result."""
+    import json
+
+    document = json.loads(path.read_text())
+    if not isinstance(document, dict) or document.get("schema_version") != 1:
+        raise ValueError("unsupported benchmark schema")
+    if document.get("complete") is not True:
+        raise ValueError("benchmark result is incomplete")
+
+    provenance = document.get("provenance")
+    if not isinstance(provenance, dict):
+        raise ValueError("benchmark provenance is missing")
+    for key in ("head_commit", "base_commit"):
+        value = provenance.get(key)
+        if not isinstance(value, str) or len(value) != 40:
+            raise ValueError(f"benchmark provenance has invalid {key}")
+
+    rows = document.get("rows")
+    if not isinstance(rows, list) or not rows:
+        raise ValueError("benchmark rows are missing")
+    failures: list[str] = []
+    cells: set[tuple[str, str, int]] = set()
+    for row in rows:
+        if not isinstance(row, dict):
+            raise ValueError("benchmark row is not an object")
+        family = row.get("family")
+        path_name = row.get("path")
+        n = row.get("N")
+        status = row.get("status")
+        cell = f"{family}/{path_name}/N={n}"
+        if status != "ok":
+            failures.append(f"{cell}: {status}")
+            continue
+        if family not in FAMILIES or path_name not in PATHS or not isinstance(n, int):
+            raise ValueError(f"invalid benchmark cell {cell}")
+        if not isinstance(row.get("dim"), int) or row["dim"] < 1:
+            raise ValueError(f"{cell} has invalid dimension")
+        for metric in METRICS:
+            value = row.get(metric)
+            if not isinstance(value, (int, float)) or not math.isfinite(value) or value < 0:
+                raise ValueError(f"{cell} has invalid {metric}")
+        cells.add((family, path_name, n))
+    if failures:
+        raise ValueError("; ".join(failures))
+
+    rungs = {row["N"] for row in rows}
+    missing = [
+        f"{family}/{path_name}/N={n}"
+        for family in FAMILIES
+        for path_name in PATHS
+        for n in rungs
+        if (family, path_name, n) not in cells
+    ]
+    if missing:
+        raise ValueError(f"benchmark cells are missing: {', '.join(missing)}")
+    return document
+
+
+def _rows(document: Mapping[str, Any], family: str, path_name: str) -> list[dict[str, Any]]:
+    return sorted(
+        (
+            row
+            for row in document["rows"]
+            if row["family"] == family and row["path"] == path_name
+        ),
+        key=lambda row: row["dim"],
+    )
+
+
+def _paired(document: Mapping[str, Any], family: str, metric: str) -> tuple[list[int], list[float]]:
+    head = _rows(document, family, "head")
+    base = _rows(document, family, "base")
+    if [row["dim"] for row in head] != [row["dim"] for row in base]:
+        raise ValueError(f"head/base dimensions differ for {family}")
+    deltas = [(head_row[metric] / base_row[metric] - 1.0) * 100.0 for head_row, base_row in zip(head, base)]
+    return [row["dim"] for row in head], deltas
+
+
+def render_markdown(document: Mapping[str, Any]) -> str:
+    """Render a compact head-versus-base job summary."""
+    provenance = document["provenance"]
+    lines = [
+        "## Closed-system performance",
+        "",
+        f"Head `{provenance['head_commit'][:12]}` compared with base `{provenance['base_commit'][:12]}` in one job.",
+        "Timing changes are informational; execution and physics-parity failures are not.",
+        "",
+        "| Backend | Regime | Largest space | Worst observed |",
+        "| --- | --- | ---: | ---: |",
+    ]
+    for family in FAMILIES:
+        for metric, label in METRICS.items():
+            _, deltas = _paired(document, family, metric)
+            largest = deltas[-1]
+            worst = max(deltas, key=abs)
+            backend = "QuTiP" if family == "qutip" else "dynamiqs"
+            lines.append(f"| {backend} | {label} | {largest:+.1f}% | {worst:+.1f}% |")
+    lines.extend(
+        ("", "Lower is faster. Download the run bundle for absolute timings, samples, environment, and plots.", "")
+    )
+    return "\n".join(lines)
+
+
+def _time_label(value: float, _: float) -> str:
+    if value >= 1.0:
+        return f"{value:.3g} s"
+    if value >= 1e-3:
+        return f"{value * 1e3:.3g} ms"
+    return f"{value * 1e6:.3g} μs"
+
+
+def _style_axis(axis: Any, dims: list[int], n_by_dim: Mapping[int, int], *, xlabel: bool) -> None:
+    from matplotlib.ticker import NullLocator
+
+    axis.set_xscale("log")
+    axis.set_xticks(dims)
+    axis.set_xticklabels([f"{dim}\nN={n_by_dim[dim]}" for dim in dims])
+    axis.xaxis.set_minor_locator(NullLocator())
+    axis.set_xlim(dims[0] / 1.35, dims[-1] * 1.7)
+    axis.spines[["top", "right"]].set_visible(False)
+    if xlabel:
+        axis.set_xlabel("Hilbert dimension")
+
+
+def render_plots(document: Mapping[str, Any], output_dir: Path) -> list[Path]:
+    """Render the dashboard and regression plots from validated data."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.lines import Line2D
+    from matplotlib.ticker import FuncFormatter
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    dashboard_path = output_dir / "closed-system-dashboard.png"
+    regression_path = output_dir / "closed-system-regression.png"
+    n_by_dim = {row["dim"]: row["N"] for row in document["rows"]}
+    styles: dict[str, dict[str, Any]] = {
+        "head": dict(color=NAVY, marker="o", linestyle="-"),
+        "base": dict(color=TERRA, marker="s", linestyle="-."),
+        "native": dict(color=SAGE, marker="o", linestyle="--", markerfacecolor="white"),
+    }
+    labels = {"head": "PR head", "base": "stacked base", "native": "direct framework"}
+    rc: dict[str, Any] = {
+        "figure.facecolor": PAPER,
+        "axes.facecolor": PAPER,
+        "text.color": INK,
+        "axes.labelcolor": INK,
+        "axes.edgecolor": INK,
+        "axes.grid": True,
+        "grid.color": INK,
+        "grid.alpha": 0.13,
+        "axes.titlelocation": "left",
+        "axes.titlesize": 9.5,
+        "font.size": 8.5,
+        "legend.frameon": False,
+    }
+
+    with plt.rc_context(rc):  # type: ignore[arg-type]
+        figure, axes = plt.subplots(2, 3, figsize=(11.5, 6.2), squeeze=False)
+        for row_index, family in enumerate(FAMILIES):
+            dims = [row["dim"] for row in _rows(document, family, "head")]
+            absolute, delta, builds = axes[row_index]
+            for path_name in PATHS:
+                rows = _rows(document, family, path_name)
+                absolute.plot(dims, [row["warm_solve_s"] for row in rows], **styles[path_name])
+            absolute.set_yscale("log")
+            absolute.yaxis.set_major_formatter(FuncFormatter(_time_label))
+            absolute.set_title(f"{'QuTiP' if family == 'qutip' else 'dynamiqs'} · warm solve")
+            _style_axis(absolute, dims, n_by_dim, xlabel=row_index == 1)
+
+            _, warm_delta = _paired(document, family, "warm_solve_s")
+            delta.axhspan(-5, 5, color=SAGE, alpha=0.18, linewidth=0)
+            delta.axhline(0, color=INK, alpha=0.65, linestyle="--", linewidth=0.9)
+            delta.plot(dims, warm_delta, color=RED, marker="o", linewidth=1.6)
+            delta.yaxis.set_major_formatter(FuncFormatter(lambda value, _: f"{value:+.0f}%"))
+            delta.set_title(f"{'QuTiP' if family == 'qutip' else 'dynamiqs'} · warm delta")
+            _style_axis(delta, dims, n_by_dim, xlabel=row_index == 1)
+
+            for metric, marker, linestyle in (("cold_build_s", "s", "-"), ("build_s", "o", "--")):
+                for path_name in PATHS:
+                    rows = _rows(document, family, path_name)
+                    builds.plot(
+                        dims,
+                        [row[metric] for row in rows],
+                        color=styles[path_name]["color"],
+                        marker=marker,
+                        linestyle=linestyle,
+                        linewidth=1.4,
+                    )
+            builds.set_yscale("log")
+            builds.yaxis.set_major_formatter(FuncFormatter(_time_label))
+            builds.set_title(f"{'QuTiP' if family == 'qutip' else 'dynamiqs'} · build regimes")
+            _style_axis(builds, dims, n_by_dim, xlabel=row_index == 1)
+        axes[0, 0].set_ylabel("time")
+        axes[1, 0].set_ylabel("time")
+        axes[0, 1].set_ylabel("head vs base")
+        axes[1, 1].set_ylabel("head vs base")
+        handles = [Line2D([0], [0], label=labels[path], **styles[path]) for path in PATHS]
+        handles.extend(
+            (
+                Line2D([0], [0], label="cold build", color=INK, marker="s", linestyle="-"),
+                Line2D([0], [0], label="repeated build", color=INK, marker="o", linestyle="--"),
+            )
+        )
+        figure.legend(handles=handles, loc="upper center", ncol=3, bbox_to_anchor=(0.5, 0.93))
+        figure.suptitle("Closed-system benchmark · CI dashboard", fontsize=14, y=0.99)
+        figure.tight_layout(rect=(0, 0, 1, 0.88), h_pad=1.8, w_pad=1.6)
+        figure.savefig(dashboard_path, dpi=220, bbox_inches="tight", facecolor=PAPER)
+        plt.close(figure)
+
+        figure, axes = plt.subplots(4, 2, figsize=(9.2, 9.2), sharex="col", squeeze=False)
+        for row_index, (metric, label) in enumerate(METRICS.items()):
+            for column, family in enumerate(FAMILIES):
+                axis = axes[row_index, column]
+                dims, deltas = _paired(document, family, metric)
+                axis.axhspan(-5, 5, color=SAGE, alpha=0.18, linewidth=0)
+                axis.axhline(0, color=INK, alpha=0.65, linestyle="--", linewidth=0.9)
+                axis.plot(dims, deltas, color=RED, marker="o", linewidth=1.6)
+                axis.yaxis.set_major_formatter(FuncFormatter(lambda value, _: f"{value:+.0f}%"))
+                axis.set_title(f"{'QuTiP' if family == 'qutip' else 'dynamiqs'} · {label}")
+                _style_axis(axis, dims, n_by_dim, xlabel=row_index == len(METRICS) - 1)
+            axes[row_index, 0].set_ylabel("head vs base")
+        figure.suptitle("Performance regression view · lower is faster", fontsize=14, y=1.0)
+        figure.tight_layout(h_pad=1.5, w_pad=1.6)
+        figure.savefig(regression_path, dpi=220, bbox_inches="tight", facecolor=PAPER)
+        plt.close(figure)
+
+    return [dashboard_path, regression_path]

--- a/benchmarks/reporting.py
+++ b/benchmarks/reporting.py
@@ -18,11 +18,10 @@ METRICS = {
     "warm_solve_s": "Warm solve",
 }
 FAMILIES = ("qutip", "dynamiqs")
-PATHS = ("head", "base", "native")
+PATHS = ("head", "main", "native")
 
 NAVY = "#1D3557"
 INK = "#3D405B"
-RED = "#E63946"
 SAGE = "#81B29A"
 TERRA = "#E07A5F"
 PAPER = "#FAFBFC"
@@ -33,7 +32,7 @@ def load_result(path: Path) -> dict[str, Any]:
     import json
 
     document = json.loads(path.read_text())
-    if not isinstance(document, dict) or document.get("schema_version") != 1:
+    if not isinstance(document, dict) or document.get("schema_version") != 2:
         raise ValueError("unsupported benchmark schema")
     if document.get("complete") is not True:
         raise ValueError("benchmark result is incomplete")
@@ -41,7 +40,7 @@ def load_result(path: Path) -> dict[str, Any]:
     provenance = document.get("provenance")
     if not isinstance(provenance, dict):
         raise ValueError("benchmark provenance is missing")
-    for key in ("head_commit", "base_commit"):
+    for key in ("head_commit", "main_commit"):
         value = provenance.get(key)
         if not isinstance(value, str) or len(value) != 40:
             raise ValueError(f"benchmark provenance has invalid {key}")
@@ -100,10 +99,10 @@ def _rows(document: Mapping[str, Any], family: str, path_name: str) -> list[dict
 
 def _paired(document: Mapping[str, Any], family: str, metric: str) -> tuple[list[int], list[float]]:
     head = _rows(document, family, "head")
-    base = _rows(document, family, "base")
-    if [row["dim"] for row in head] != [row["dim"] for row in base]:
-        raise ValueError(f"head/base dimensions differ for {family}")
-    deltas = [(head_row[metric] / base_row[metric] - 1.0) * 100.0 for head_row, base_row in zip(head, base)]
+    main = _rows(document, family, "main")
+    if [row["dim"] for row in head] != [row["dim"] for row in main]:
+        raise ValueError(f"head/main dimensions differ for {family}")
+    deltas = [(head_row[metric] / main_row[metric] - 1.0) * 100.0 for head_row, main_row in zip(head, main)]
     return [row["dim"] for row in head], deltas
 
 
@@ -113,7 +112,7 @@ def render_markdown(document: Mapping[str, Any]) -> str:
     lines = [
         "## Closed-system performance",
         "",
-        f"Head `{provenance['head_commit'][:12]}` compared with base `{provenance['base_commit'][:12]}` in one job.",
+        f"Head `{provenance['head_commit'][:12]}` compared with main `{provenance['main_commit'][:12]}` in one job.",
         "Timing changes are informational; execution and physics-parity failures are not.",
         "",
         "| Backend | Regime | Largest space | Worst observed |",
@@ -154,7 +153,7 @@ def _style_axis(axis: Any, dims: list[int], n_by_dim: Mapping[int, int], *, xlab
 
 
 def render_plots(document: Mapping[str, Any], output_dir: Path) -> list[Path]:
-    """Render the dashboard and regression plots from validated data."""
+    """Render one simple PR-versus-main-versus-hand-built comparison."""
     import matplotlib
 
     matplotlib.use("Agg")
@@ -163,15 +162,14 @@ def render_plots(document: Mapping[str, Any], output_dir: Path) -> list[Path]:
     from matplotlib.ticker import FuncFormatter
 
     output_dir.mkdir(parents=True, exist_ok=True)
-    dashboard_path = output_dir / "closed-system-dashboard.png"
-    regression_path = output_dir / "closed-system-regression.png"
+    output_path = output_dir / "closed-system-comparison.png"
     n_by_dim = {row["dim"]: row["N"] for row in document["rows"]}
     styles: dict[str, dict[str, Any]] = {
         "head": dict(color=NAVY, marker="o", linestyle="-"),
-        "base": dict(color=TERRA, marker="s", linestyle="-."),
+        "main": dict(color=TERRA, marker="s", linestyle="-."),
         "native": dict(color=SAGE, marker="o", linestyle="--", markerfacecolor="white"),
     }
-    labels = {"head": "PR head", "base": "stacked base", "native": "direct framework"}
+    labels = {"head": "this PR", "main": "main", "native": "hand-built"}
     rc: dict[str, Any] = {
         "figure.facecolor": PAPER,
         "axes.facecolor": PAPER,
@@ -188,73 +186,30 @@ def render_plots(document: Mapping[str, Any], output_dir: Path) -> list[Path]:
     }
 
     with plt.rc_context(rc):  # type: ignore[arg-type]
-        figure, axes = plt.subplots(2, 3, figsize=(11.5, 6.2), squeeze=False)
+        figure, axes = plt.subplots(2, 2, figsize=(9.4, 6.4), sharex="col", squeeze=False)
         for row_index, family in enumerate(FAMILIES):
             dims = [row["dim"] for row in _rows(document, family, "head")]
-            absolute, delta, builds = axes[row_index]
-            for path_name in PATHS:
-                rows = _rows(document, family, path_name)
-                absolute.plot(dims, [row["warm_solve_s"] for row in rows], **styles[path_name])
-            absolute.set_yscale("log")
-            absolute.yaxis.set_major_formatter(FuncFormatter(_time_label))
-            absolute.set_title(f"{'QuTiP' if family == 'qutip' else 'dynamiqs'} · warm solve")
-            _style_axis(absolute, dims, n_by_dim, xlabel=row_index == 1)
-
-            _, warm_delta = _paired(document, family, "warm_solve_s")
-            delta.axhspan(-5, 5, color=SAGE, alpha=0.18, linewidth=0)
-            delta.axhline(0, color=INK, alpha=0.65, linestyle="--", linewidth=0.9)
-            delta.plot(dims, warm_delta, color=RED, marker="o", linewidth=1.6)
-            delta.yaxis.set_major_formatter(FuncFormatter(lambda value, _: f"{value:+.0f}%"))
-            delta.set_title(f"{'QuTiP' if family == 'qutip' else 'dynamiqs'} · warm delta")
-            _style_axis(delta, dims, n_by_dim, xlabel=row_index == 1)
-
-            for metric, marker, linestyle in (("cold_build_s", "s", "-"), ("build_s", "o", "--")):
+            backend = "QuTiP" if family == "qutip" else "dynamiqs"
+            for column, (metric, label) in enumerate((("build_s", "repeated build"), ("warm_solve_s", "warm solve"))):
+                axis = axes[row_index, column]
                 for path_name in PATHS:
                     rows = _rows(document, family, path_name)
-                    builds.plot(
+                    axis.plot(
                         dims,
                         [row[metric] for row in rows],
-                        color=styles[path_name]["color"],
-                        marker=marker,
-                        linestyle=linestyle,
-                        linewidth=1.4,
+                        label=labels[path_name],
+                        **styles[path_name],
                     )
-            builds.set_yscale("log")
-            builds.yaxis.set_major_formatter(FuncFormatter(_time_label))
-            builds.set_title(f"{'QuTiP' if family == 'qutip' else 'dynamiqs'} · build regimes")
-            _style_axis(builds, dims, n_by_dim, xlabel=row_index == 1)
+                axis.set_yscale("log")
+                axis.yaxis.set_major_formatter(FuncFormatter(_time_label))
+                axis.set_title(f"{backend} · {label}")
+                _style_axis(axis, dims, n_by_dim, xlabel=row_index == 1)
         axes[0, 0].set_ylabel("time")
         axes[1, 0].set_ylabel("time")
-        axes[0, 1].set_ylabel("head vs base")
-        axes[1, 1].set_ylabel("head vs base")
         handles = [Line2D([0], [0], label=labels[path], **styles[path]) for path in PATHS]
-        handles.extend(
-            (
-                Line2D([0], [0], label="cold build", color=INK, marker="s", linestyle="-"),
-                Line2D([0], [0], label="repeated build", color=INK, marker="o", linestyle="--"),
-            )
-        )
-        figure.legend(handles=handles, loc="upper center", ncol=3, bbox_to_anchor=(0.5, 0.93))
-        figure.suptitle("Closed-system benchmark · CI dashboard", fontsize=14, y=0.99)
-        figure.tight_layout(rect=(0, 0, 1, 0.88), h_pad=1.8, w_pad=1.6)
-        figure.savefig(dashboard_path, dpi=220, bbox_inches="tight", facecolor=PAPER)
+        figure.legend(handles=handles, loc="upper center", ncol=3, bbox_to_anchor=(0.5, 0.94))
+        figure.suptitle("Closed-system overhead", fontsize=14, y=0.995)
+        figure.tight_layout(rect=(0, 0, 1, 0.89), h_pad=1.8, w_pad=1.8)
+        figure.savefig(output_path, dpi=220, bbox_inches="tight", facecolor=PAPER)
         plt.close(figure)
-
-        figure, axes = plt.subplots(4, 2, figsize=(9.2, 9.2), sharex="col", squeeze=False)
-        for row_index, (metric, label) in enumerate(METRICS.items()):
-            for column, family in enumerate(FAMILIES):
-                axis = axes[row_index, column]
-                dims, deltas = _paired(document, family, metric)
-                axis.axhspan(-5, 5, color=SAGE, alpha=0.18, linewidth=0)
-                axis.axhline(0, color=INK, alpha=0.65, linestyle="--", linewidth=0.9)
-                axis.plot(dims, deltas, color=RED, marker="o", linewidth=1.6)
-                axis.yaxis.set_major_formatter(FuncFormatter(lambda value, _: f"{value:+.0f}%"))
-                axis.set_title(f"{'QuTiP' if family == 'qutip' else 'dynamiqs'} · {label}")
-                _style_axis(axis, dims, n_by_dim, xlabel=row_index == len(METRICS) - 1)
-            axes[row_index, 0].set_ylabel("head vs base")
-        figure.suptitle("Performance regression view · lower is faster", fontsize=14, y=1.0)
-        figure.tight_layout(h_pad=1.5, w_pad=1.6)
-        figure.savefig(regression_path, dpi=220, bbox_inches="tight", facecolor=PAPER)
-        plt.close(figure)
-
-    return [dashboard_path, regression_path]
+    return [output_path]

--- a/tests/test_benchmark_reporting.py
+++ b/tests/test_benchmark_reporting.py
@@ -22,7 +22,7 @@ def _document() -> dict[str, object]:
     rows = []
     for family in ("qutip", "dynamiqs"):
         for n in (1, 2):
-            for path, scale in (("head", 1.1), ("base", 1.0), ("native", 0.8)):
+            for path, scale in (("head", 1.1), ("main", 1.0), ("native", 0.8)):
                 row = {
                     "N": n,
                     "levels": 3,
@@ -35,11 +35,11 @@ def _document() -> dict[str, object]:
                 row.update({name: value * scale * n for name, value in METRICS.items()})
                 rows.append(row)
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "complete": True,
         "provenance": {
             "head_commit": "a" * 40,
-            "base_commit": "b" * 40,
+            "main_commit": "b" * 40,
             "parity_tol": 1e-5,
         },
         "rows": rows,
@@ -73,15 +73,12 @@ def test_render_markdown_reports_exact_revisions_and_all_regimes(tmp_path: Path)
     assert "+10.0%" in markdown
 
 
-def test_render_plots_writes_dashboard_and_regression(tmp_path: Path) -> None:
-    """Render both identity-colored plots from one validated result."""
+def test_render_plots_writes_one_simple_comparison(tmp_path: Path) -> None:
+    """Render one PR-versus-main-versus-hand-built comparison."""
     path = tmp_path / "result.json"
     path.write_text(json.dumps(_document()))
 
     outputs = render_plots(load_result(path), tmp_path)
 
-    assert {output.name for output in outputs} == {
-        "closed-system-dashboard.png",
-        "closed-system-regression.png",
-    }
+    assert [output.name for output in outputs] == ["closed-system-comparison.png"]
     assert all(output.stat().st_size > 1_000 for output in outputs)

--- a/tests/test_benchmark_reporting.py
+++ b/tests/test_benchmark_reporting.py
@@ -1,0 +1,87 @@
+"""Contracts for benchmark validation and reporting."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from benchmarks.reporting import load_result, render_markdown, render_plots
+
+
+METRICS = {
+    "cold_build_s": 0.4,
+    "build_s": 0.3,
+    "first_solve_s": 0.2,
+    "warm_solve_s": 0.1,
+}
+
+
+def _document() -> dict[str, object]:
+    rows = []
+    for family in ("qutip", "dynamiqs"):
+        for n in (1, 2):
+            for path, scale in (("head", 1.1), ("base", 1.0), ("native", 0.8)):
+                row = {
+                    "N": n,
+                    "levels": 3,
+                    "dim": 3**n,
+                    "family": family,
+                    "path": path,
+                    "status": "ok",
+                    "parity": 0.0,
+                }
+                row.update({name: value * scale * n for name, value in METRICS.items()})
+                rows.append(row)
+    return {
+        "schema_version": 1,
+        "complete": True,
+        "provenance": {
+            "head_commit": "a" * 40,
+            "base_commit": "b" * 40,
+            "parity_tol": 1e-5,
+        },
+        "rows": rows,
+    }
+
+
+def test_load_result_rejects_failed_measurements(tmp_path: Path) -> None:
+    """Reject incomplete or failed measurements before reporting them."""
+    document = _document()
+    document["rows"][0]["status"] = "parity-fail"  # type: ignore[index]
+    path = tmp_path / "result.json"
+    path.write_text(json.dumps(document))
+
+    with pytest.raises(ValueError, match="qutip/head/N=1: parity-fail"):
+        load_result(path)
+
+
+def test_render_markdown_reports_exact_revisions_and_all_regimes(tmp_path: Path) -> None:
+    """Show exact revisions and all timing regimes in the CI summary."""
+    path = tmp_path / "result.json"
+    path.write_text(json.dumps(_document()))
+
+    markdown = render_markdown(load_result(path))
+
+    assert "aaaaaaaaaaaa" in markdown
+    assert "bbbbbbbbbbbb" in markdown
+    assert "Cold build" in markdown
+    assert "Repeated build" in markdown
+    assert "First solve" in markdown
+    assert "Warm solve" in markdown
+    assert "+10.0%" in markdown
+
+
+def test_render_plots_writes_dashboard_and_regression(tmp_path: Path) -> None:
+    """Render both identity-colored plots from one validated result."""
+    path = tmp_path / "result.json"
+    path.write_text(json.dumps(_document()))
+
+    outputs = render_plots(load_result(path), tmp_path)
+
+    assert {output.name for output in outputs} == {
+        "closed-system-dashboard.png",
+        "closed-system-regression.png",
+    }
+    assert all(output.stat().st_size > 1_000 for output in outputs)


### PR DESCRIPTION
## Summary

- compare the exact pull-request head, `main`, and hand-built framework paths in one Ubuntu job for QuTiP and dynamiqs
- record cold and repeated construction plus first and warm solving while retaining physics-parity checks
- publish one simple four-panel repeated-build/warm-solve dashboard, a compact job summary, environment metadata, and raw samples as a 90-day artifact on each PR push and `main` push

## User-visible and physics impact

Timing deltas are informational; benchmark execution and physics-parity failures fail the workflow. The benchmark does not change quchip's API, Hamiltonians, approximations, or solver behavior.

## Documentation

The job summary labels each timing regime and links the exact-revision data, environment, samples, and dashboard. No user-facing API documentation changes.

## Verification

- `python -m pytest tests/test_benchmark_reporting.py -q` (3 passed)
- `ruff check .`
- `python -m mypy quchip benchmarks`
- `actionlint v1.7.12 .github/workflows/benchmark.yml`
- QuTiP and dynamiqs head/main/hand-built paths pass physics parity

## Stack

Current order: **#3 → #4 → #6 → #7 → #8**. This PR is based on #6; review only the diff from `feat/local-basis-materialization`.

## Checklist

- [x] This pull request is focused and contains no unrelated changes.
- [x] Changed behavior is covered by tests, or no behavior changed.
- [x] Relevant documentation and examples are updated.
- [x] Generated files and paired notebooks are synchronized, if applicable.
- [x] `PHYSICS.md` is not relevant: this PR measures performance and verifies parity without changing runtime physics contracts.

## AI assistance

AI assistance was used to implement and verify this change. The contributor reviewed the benchmark contract, measurements, workflow, plots, and claims.
