### PR TITLE
perf: reuse resolved chip contracts

### DIFF
--- a/benchmarks/reporting.py
+++ b/benchmarks/reporting.py
@@ -120,6 +120,14 @@ def render_markdown(document: Mapping[str, Any]) -> str:
         f"Head `{provenance['head_commit'][:12]}` compared with main `{provenance['main_commit'][:12]}` in one job.",
         "Timing changes are informational; execution and physics-parity failures are not.",
         "",
+        "- **Cold build:** first model construction in a fresh worker; includes one-time construction setup.",
+        "- **Repeated build:** median of later model constructions; represents steady model assembly.",
+        (
+            "- **First solve:** first evolution of that model; includes backend setup and JAX compilation where "
+            "applicable."
+        ),
+        "- **Warm solve:** median repeated execution after solver warm-up; represents steady solving.",
+        "",
         "| Backend | Regime | Largest space | Worst observed |",
         "| --- | --- | ---: | ---: |",
     ]

--- a/benchmarks/reporting.py
+++ b/benchmarks/reporting.py
@@ -19,6 +19,11 @@ METRICS = {
 }
 FAMILIES = ("qutip", "dynamiqs")
 PATHS = ("head", "main", "native")
+PLOT_METRICS = (
+    ("cold_build_s", "cold build"),
+    ("build_s", "repeated build"),
+    ("warm_solve_s", "warm solve"),
+)
 
 NAVY = "#1D3557"
 INK = "#3D405B"
@@ -159,7 +164,7 @@ def render_plots(document: Mapping[str, Any], output_dir: Path) -> list[Path]:
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
     from matplotlib.lines import Line2D
-    from matplotlib.ticker import FuncFormatter
+    from matplotlib.ticker import FuncFormatter, NullFormatter
 
     output_dir.mkdir(parents=True, exist_ok=True)
     output_path = output_dir / "closed-system-comparison.png"
@@ -186,11 +191,11 @@ def render_plots(document: Mapping[str, Any], output_dir: Path) -> list[Path]:
     }
 
     with plt.rc_context(rc):  # type: ignore[arg-type]
-        figure, axes = plt.subplots(2, 2, figsize=(9.4, 6.4), sharex="col", squeeze=False)
+        figure, axes = plt.subplots(2, 3, figsize=(13.2, 6.2), sharex="col", squeeze=False)
         for row_index, family in enumerate(FAMILIES):
             dims = [row["dim"] for row in _rows(document, family, "head")]
             backend = "QuTiP" if family == "qutip" else "dynamiqs"
-            for column, (metric, label) in enumerate((("build_s", "repeated build"), ("warm_solve_s", "warm solve"))):
+            for column, (metric, label) in enumerate(PLOT_METRICS):
                 axis = axes[row_index, column]
                 for path_name in PATHS:
                     rows = _rows(document, family, path_name)
@@ -202,6 +207,7 @@ def render_plots(document: Mapping[str, Any], output_dir: Path) -> list[Path]:
                     )
                 axis.set_yscale("log")
                 axis.yaxis.set_major_formatter(FuncFormatter(_time_label))
+                axis.yaxis.set_minor_formatter(NullFormatter())
                 axis.set_title(f"{backend} · {label}")
                 _style_axis(axis, dims, n_by_dim, xlabel=row_index == 1)
         axes[0, 0].set_ylabel("time")

--- a/quchip/chip/chip.py
+++ b/quchip/chip/chip.py
@@ -95,6 +95,20 @@ def _concrete_cache_value(value: Any) -> Any:
     return concrete
 
 
+def _frame_cache_value(frame: Any) -> Any:
+    """Return a stable cache key for one concrete frame specification."""
+    if isinstance(frame, str):
+        return frame
+    if isinstance(frame, Mapping):
+        return tuple(
+            sorted(
+                (resolve_label(label), _concrete_cache_value(value))
+                for label, value in frame.items()
+            )
+        )
+    return _concrete_cache_value(frame)
+
+
 class Chip:
     """Composite quantum system: devices + couplings + (optional) control.
 
@@ -323,26 +337,45 @@ class Chip:
             build_engine_result,
         )
 
-        local_resolution, resolved_frame = _prepare_engine_assembly(
-            self,
-            self.frame if frame is None else frame,
-        )
+        frame_spec = self.frame if frame is None else frame
+        equipment = self.control_equipment
+        control_lines = () if equipment is None else equipment.lines
         try:
             signature = (
                 id(self.backend),
                 self.rwa,
                 self.basis,
-                resolved_frame.mode,
-                tuple(
-                    (label, _concrete_cache_value(value))
-                    for label, value in resolved_frame.frequencies.items()
-                ),
-                tuple(
-                    (label, _concrete_cache_value(value))
-                    for label, value in resolved_frame.demod_freqs.items()
-                ),
+                _frame_cache_value(frame_spec),
                 tuple((device.label, device.state_version) for device in self.devices),
+                tuple(
+                    (device.label, _concrete_cache_value(device._reference_freq_override))
+                    for device in self.devices
+                ),
+                tuple(
+                    (
+                        device.label,
+                        tuple(
+                            (channel.name, channel.params, id(channel.build))
+                            for channel in type(device)._noise_channels
+                        ),
+                    )
+                    for device in self.devices
+                ),
                 tuple((coupling.label, coupling.state_version) for coupling in self.couplings),
+                tuple(
+                    (
+                        line.label,
+                        type(line),
+                        line.target_label,
+                        line.rwa,
+                        tuple(
+                            (name, _concrete_cache_value(getattr(line, name)))
+                            for name in line.collapse_parameter_names()
+                        ),
+                        id(type(line).collapse_contributions),
+                    )
+                    for line in control_lines
+                ),
                 tuple(
                     (
                         bath.label,
@@ -361,6 +394,7 @@ class Chip:
         if signature is not None and cache is not None and cache[0] == signature:
             return cache[1]
 
+        local_resolution, resolved_frame = _prepare_engine_assembly(self, frame_spec)
         result = build_engine_result(
             self,
             [],

--- a/quchip/control/sequence.py
+++ b/quchip/control/sequence.py
@@ -56,7 +56,6 @@ from quchip.control.envelopes import BaseEnvelope
 from quchip.devices.base import BaseDevice
 from quchip.engine.ir import DriveOp, EngineResult, HamiltonianTemplate
 from quchip.engine.stage2_assembly import (
-    _prepare_engine_assembly,
     build_engine_result,
     compile_hamiltonian_template,
     instantiate_engine_result,
@@ -817,15 +816,12 @@ class QuantumSequence:
     def resolve(self, *, frame: FrameSpec | None = None) -> EngineResult:
         """Resolve the backend-neutral Hamiltonian and noise description."""
         drive_ops = self._materialize_drive_ops()
-        local_resolution, resolved_frame = _prepare_engine_assembly(
-            self._chip,
-            self._chip.frame if frame is None else frame,
-        )
+        base_result = self._chip.resolve(frame=frame)
         return build_engine_result(
             self._chip,
             drive_ops,
-            resolved_frame=resolved_frame,
-            _local_resolution=local_resolution,
+            resolved_frame=base_result.resolved_frame,
+            _base_result=base_result,
         )
 
     def hamiltonian(self) -> PhysicsExpr:
@@ -1045,7 +1041,7 @@ class QuantumSequence:
             self._chip,
             reference_drive_ops,
             resolved_frame=context.resolved_frame,
-            _local_resolution=context._local_resolution,
+            _base_result=context._base_result,
         )
         reference_result = instantiate_engine_result(template, reference_drive_ops, self._chip)
 

--- a/quchip/engine/ir.py
+++ b/quchip/engine/ir.py
@@ -1058,6 +1058,7 @@ class EngineResult:
     collapse_terms: tuple[CollapseTerm, ...] = ()
     bases: Mapping[str, Any] = field(default_factory=dict)
     authored: Any = None
+    resolved_frame: Any = None
 
     def _contains_tracer(self) -> bool:
         """Return whether any value-bearing field belongs to a JAX trace.
@@ -1100,6 +1101,7 @@ class EngineResult:
                 ),
                 basis_payloads,
                 authored_values,
+                self.resolved_frame,
                 self.metadata,
             )
         )

--- a/quchip/engine/stage2_assembly.py
+++ b/quchip/engine/stage2_assembly.py
@@ -1425,12 +1425,50 @@ def _validate_variant_drive_ops(
 
 # -- Public API ----------------------------------------------------------
 
+
+def _template_from_engine_result(
+    chip: "Chip",
+    drive_ops: list["DriveOp"],
+    base_result: EngineResult,
+    resolved_frame: "ResolvedFrame",
+) -> HamiltonianTemplate:
+    """Attach scheduled-drive structure to an already resolved chip contract."""
+    if base_result.resolved_frame is not resolved_frame:
+        raise ValueError("The base EngineResult and scheduled drives must use the same resolved frame.")
+
+    dims = base_result.dims
+    subsystem_labels = tuple(device.label for device in chip.devices)
+    drive_terms, weight_zero_drops = _compile_drive_terms(
+        chip,
+        _resolve_drives(chip, drive_ops),
+        resolved_frame,
+        chip.backend,
+        bases=base_result.bases,
+        dims=dims,
+        subsystem_labels=subsystem_labels,
+    )
+    return HamiltonianTemplate(
+        resolved_frame=resolved_frame,
+        dims=dims,
+        static_terms=base_result.static_terms,
+        invariant_dynamic_terms=base_result.dynamic_terms,
+        drive_terms=drive_terms,
+        reference_drive_ops=tuple(drive_ops),
+        dropped_terms=base_result.dropped_terms,
+        weight_zero_drops=weight_zero_drops,
+        static_spectral_bound_ghz=base_result.metadata.get("static_spectral_bound_ghz"),
+        collapse_terms=base_result.collapse_terms,
+        bases=base_result.bases,
+        authored=base_result.authored,
+    )
+
 def compile_hamiltonian_template(
     chip: "Chip",
     drive_ops: list["DriveOp"],
     *,
     resolved_frame: "ResolvedFrame",
     _local_resolution: _LocalResolution | None = None,
+    _base_result: EngineResult | None = None,
 ) -> HamiltonianTemplate:
     """Compile the invariant Hamiltonian skeleton (H₀, couplings, pre-embedded drive bands).
 
@@ -1443,6 +1481,14 @@ def compile_hamiltonian_template(
     parameters, drive frequencies, phases, and frame scalars can sweep
     through JAX without retracing operator tensors.
     """
+    if _base_result is not None:
+        return _template_from_engine_result(
+            chip,
+            drive_ops,
+            _base_result,
+            resolved_frame,
+        )
+
     backend = chip.backend
     resolution = (
         _resolve_local_system(chip, backend)
@@ -1628,6 +1674,8 @@ def instantiate_engine_result(
     )
 
     metadata: dict[str, Any] = {"frame": str(template.resolved_frame)}
+    if template.static_spectral_bound_ghz is not None:
+        metadata["static_spectral_bound_ghz"] = template.static_spectral_bound_ghz
     metadata.update(_solver_hint_metadata(template.static_spectral_bound_ghz, dynamic_terms))
 
     return EngineResult(
@@ -1639,6 +1687,7 @@ def instantiate_engine_result(
         collapse_terms=template.collapse_terms,
         bases=template.bases,
         authored=template.authored,
+        resolved_frame=template.resolved_frame,
     )
 
 
@@ -1648,6 +1697,7 @@ def build_engine_result(
     *,
     resolved_frame: "ResolvedFrame",
     _local_resolution: _LocalResolution | None = None,
+    _base_result: EngineResult | None = None,
 ) -> EngineResult:
     """One-shot stage 2: compile the template then instantiate a single variant.
 
@@ -1679,6 +1729,7 @@ def build_engine_result(
         drive_ops,
         resolved_frame=resolved_frame,
         _local_resolution=_local_resolution,
+        _base_result=_base_result,
     )
     return instantiate_engine_result(template, drive_ops, chip)
 

--- a/quchip/engine/stage4_problem.py
+++ b/quchip/engine/stage4_problem.py
@@ -29,7 +29,7 @@ from quchip.engine.ir import (
     SolveProblem,
     _aggregate_batch_metadata,
 )
-from quchip.engine.stage2_assembly import _prepare_engine_assembly, build_engine_result
+from quchip.engine.stage2_assembly import build_engine_result
 from quchip.engine.stage3_observables import decompose_eops
 from quchip.utils.jax_utils import contains_tracer, maybe_concrete_scalar
 
@@ -50,7 +50,7 @@ class SolveProblemContext:
     e_ops: Any
     e_ops_meta: Any
     resolved_frame: Any
-    _local_resolution: Any
+    _base_result: EngineResult | None
     solver: str | None
     options: dict[str, Any]
     default_initial_state: Any
@@ -71,7 +71,7 @@ class SolveProblemContext:
             e_ops=ref.e_ops,
             e_ops_meta=ref.e_ops_meta,
             resolved_frame=ref.resolved_frame,
-            _local_resolution=None,
+            _base_result=None,
             solver=ref.solver,
             options=dict(ref.options),
             default_initial_state=ref.initial_state,
@@ -164,14 +164,14 @@ def prepare_solve_problem_context(
 
     if e_ops is not None and not isinstance(e_ops, dict):
         raise TypeError("e_ops must be dict or None")
-    local_resolution, resolved_frame = _prepare_engine_assembly(chip, chip.frame)
+    base_result = chip.resolve()
     return SolveProblemContext(
         chip=chip,
         tlist=tlist_arr,
         e_ops=e_ops,
         e_ops_meta=None,
-        resolved_frame=resolved_frame,
-        _local_resolution=local_resolution,
+        resolved_frame=base_result.resolved_frame,
+        _base_result=base_result,
         solver=solver,
         options=merged_options,
         default_initial_state=None,
@@ -337,7 +337,7 @@ def build_solve_problem(
         chip,
         drive_ops,
         resolved_frame=context.resolved_frame,
-        _local_resolution=context._local_resolution,
+        _base_result=context._base_result,
     )
     e_ops_solver, e_ops_meta = _prepare_context_eops(context, engine_result)
     return SolveProblem(

--- a/tests/test_benchmark_reporting.py
+++ b/tests/test_benchmark_reporting.py
@@ -70,6 +70,10 @@ def test_render_markdown_reports_exact_revisions_and_all_regimes(tmp_path: Path)
     assert "Repeated build" in markdown
     assert "First solve" in markdown
     assert "Warm solve" in markdown
+    assert "first model construction in a fresh worker" in markdown
+    assert "median of later model constructions" in markdown
+    assert "includes backend setup and JAX compilation where applicable" in markdown
+    assert "repeated execution after solver warm-up" in markdown
     assert "+10.0%" in markdown
 
 

--- a/tests/test_local_basis_materialization.py
+++ b/tests/test_local_basis_materialization.py
@@ -85,6 +85,44 @@ def test_charge_basis_device_exposes_unresolved_and_projected_hamiltonians() -> 
     )
 
 
+def test_eager_bare_state_and_problem_share_one_resolved_chip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reuse the resolved chip contract when an eager state precedes a solve."""
+    import quchip.engine.stage2_assembly as assembly
+
+    device = ChargeBasisTransmon(
+        E_C=0.25,
+        E_J=12.0,
+        num_basis=9,
+        basis="eigen",
+        levels=3,
+        label="q",
+    )
+    device.reference_freq = 5.0
+    chip = Chip([device])
+    build_static_h0 = assembly._build_static_h0
+    calls = 0
+
+    def counted_build_static_h0(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        return build_static_h0(*args, **kwargs)
+
+    monkeypatch.setattr(assembly, "_build_static_h0", counted_build_static_h0)
+
+    state = chip.bare_state(q=0)
+    problem = build_problem(
+        chip,
+        [],
+        np.asarray([0.0, 1.0]),
+        initial_state=state,
+    )
+
+    assert problem.engine_result.bases is chip.resolve().bases
+    assert calls == 1
+
+
 def test_native_is_default_and_device_policy_overrides_the_chip() -> None:
     inherited = ChargeBasisTransmon(
         E_C=0.25,

--- a/tests/test_parameter_surfaces.py
+++ b/tests/test_parameter_surfaces.py
@@ -219,6 +219,14 @@ def test_chip_parameter_inventory_includes_drive_control_and_bath_owners() -> No
     paths = {path for term in engine_result.collapse_terms for path in term.parameter_paths}
     assert {"drive.source.loss_rate", "bath.cold.temperature", "bath.cold.rate"} <= paths
 
+    first = build_problem(chip, [], np.asarray([0.0, 1.0])).engine_result
+    source.loss_rate = 0.03
+    second = build_problem(chip, [], np.asarray([0.0, 1.0])).engine_result
+    first_rate = next(term.rate for term in first.collapse_terms if term.source == "source")
+    second_rate = next(term.rate for term in second.collapse_terms if term.source == "source")
+    assert float(first_rate) == pytest.approx(0.01)
+    assert float(second_rate) == pytest.approx(0.03)
+
 
 def test_active_noise_is_rebindable_and_retained_in_engine_result() -> None:
     pytest.importorskip("dynamiqs")


### PR DESCRIPTION
## Summary

- reuse the chip's frozen `EngineResult` when a sequence adds scheduled drives
- return concrete cache hits before repeating local-basis and static-Hamiltonian assembly
- cover frame intent, device noise structure, baths, couplings, and mutable wired-drive noise in cache invalidation
- carry the static spectral hint forward without rematerializing cached JAX operators inside a later trace
- expand the benchmark dashboard to separate cold build, repeated build, and warm solve, with a concise timing key in the CI summary

## User-visible and physics impact

The common `chip.bare_state()` followed by `sequence.build_problem()` path no longer assembles the static chip twice. On the latest consistent CI run at the largest rung (seven three-level devices), repeated construction versus main is +31.9% for QuTiP and -27.4% for dynamiqs; warm solves are +0.1% and +0.2%, respectively. All branch, main, and hand-built traces passed physics parity.

## Documentation

No user-facing API documentation changes. The benchmark summary now defines cold build, repeated build, first solve, and warm solve, and the dashboard reports the construction and solve effects against exact revisions.

## Verification

- 1,461 tests passed in the one-time full local run; after fixing and rechecking its real traced-path finding, the two remaining failures were the known managed-sandbox loky semaphore `PermissionError`s
- the exact JIT/gradient regression and resolved-contract cache regressions pass
- focused engine, local-basis, frame, cache, noise, parameter, JAX, autodiff, QuTiP, and dynamiqs checks pass
- `ruff check .`, mypy, byte compilation, and diff hygiene pass
- the reporting contract passes all 3 focused tests and Ruff
- the final 24-cell QuTiP/dynamiqs CI benchmark completed at `2f17342a735b` with physics parity

## Stack

Current order: **#3 → #4 → #6 → #7 → #8**. This is the top PR, based on #7; review only the diff from `ci/performance-benchmarks`.

## Checklist

- [x] This pull request is focused and contains no unrelated changes.
- [x] Changed behavior is covered by tests, or no behavior changed.
- [x] Relevant documentation and examples are updated.
- [x] Generated files and paired notebooks are synchronized, if applicable.
- [x] `PHYSICS.md` is not relevant: cache reuse preserves the resolved physics contract and is covered by parity checks.

## AI assistance

AI assistance was used for profiling, implementation, tests, and review. The contributor reviewed the changes and remains accountable for every claim and change.
