### PR TITLE
docs: audit and align public prose with shipped physics

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- State the problem and the change. Include physical or user-visible effects. -->
+
+## Verification
+
+<!-- List the commands or checks you ran and their results. -->
+
+## Checklist
+
+- [ ] This pull request is focused and contains no unrelated changes.
+- [ ] Changed behavior is covered by tests, or no behavior changed.
+- [ ] Relevant documentation and examples are updated.
+- [ ] Generated files and paired notebooks are synchronized, if applicable.
+- [ ] `PHYSICS.md` is updated, or is not relevant: <!-- explain why -->
+
+## AI assistance
+
+<!-- State how AI assistance was used, or write "None". You remain accountable for every claim and change. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,84 @@
+# Changelog
+
+This file records notable user-visible changes to quchip.
+
+## [0.2.0] - Unreleased
+
+### Highlights
+
+- Inspect authored and solver-resolved physics as backend-neutral symbolic expressions without forcing numerical materialization.
+- Choose explicit Fock, charge, phase-grid, or custom local spaces, with native or energy-eigenstate solver bases.
+- Reuse sparse operators, compiled batches, and resolved chip contracts while tracking construction and solve performance in CI.
+
+### Physics and modelling
+
+- Added `PhysicsExpr` for symbolic parameters, matrices, time-dependent scalars, labels, and opaque JAX callables. Expressions support semantic display, immutable parameter rebinding, and explicit `.matrix()` materialization. [#4]
+- Added `LocalSpace`, `FockSpace`, `ChargeSpace`, `PhaseGridSpace`, and `CustomSpace`. A chip or individual device can use its authored native basis or project into a retained local energy basis with `projection_levels`. [#6]
+- Basis resolution now transforms Hamiltonians, couplings, drives, pumps, states, observables, collapse operators, frames, and RWA bands through one engine-owned boundary. Native solving remains the default. [#6]
+- Added distinct inspection paths: `unresolved_hamiltonian()` preserves authored static physics, while `hamiltonian()` reports the canonical result after basis, frame, and RWA resolution. Sequence Hamiltonians also include scheduled drives. [#6]
+
+### Engine and performance
+
+- Replaced the previous Hamiltonian containers with the frozen `EngineResult`, `SolveProblem`, and `SolveBatch` contracts shared by QuTiP and dynamiqs. [#4]
+- Preserved sparse canonical operators through assembly, compiled native batches once, avoided unnecessary result densification, and selected compact dynamiqs storage. [#6]
+- Reused resolved engine assembly and chip snapshots when their physics inputs are unchanged, including the common state-preparation and sequence-build path. [#8]
+- Added reproducible QuTiP and dynamiqs benchmark CI with separate cold-build, repeated-build, first-solve, and warm-solve measurements, physics-parity checks, environment receipts, and raw samples. Timing changes remain informational. [#7]
+
+### Developer tooling and CI
+
+- Added per-Python CI constraint files and a weekly unconstrained dependency canary. Published package metadata remains unpinned. [#3]
+- Added a format-aware prose audit for Python docstrings, Markdown, and rendered HTML. It reports recognizable patterns and coverage without guessing authorship. [#9]
+- Added a pull-request template covering verification, documentation, paired notebooks, `PHYSICS.md`, and AI-assistance disclosure. [#9]
+
+### Documentation
+
+- Updated the README, physics reference, cookbook, API docstrings, documentation home, and executed hello-chip example for symbolic inspection, local spaces, basis projection, and authored versus resolved Hamiltonians. [#9]
+- Kept the hello-chip plots unchanged after clean execution, receipt checks, strict Jupytext pairing, and image comparison. [#9]
+
+### Compatibility and migration
+
+- Replace `HamiltonianDescription` with `EngineResult`, `build_hamiltonian_description()` with `build_engine_result()`, and `SolveProblem.hamiltonian` with `SolveProblem.engine_result`.
+- Replace `ProblemBatch` and `BatchedHamiltonianDescription` with `SolveBatch` and the `QuantumSequence` batch APIs.
+- `CircuitDevice` is no longer public. Custom devices should declare an explicit `LocalSpace` through `BaseDevice` or `FockDevice`, as appropriate; built-in charge-basis and phase-grid devices use the same boundary.
+- Declarative device and coupling methods now receive the symbolic parameter namespace `p`: use `local_hamiltonian(op, p)`, `interaction(a, b, p)`, and `time_dependent(a, b, p)` in custom models.
+- `NoiseChannel.build` now accepts `(device, basis)` and returns `(operator, rate)` pairs. Operators are unscaled and rates use inverse nanoseconds.
+- Use `chip.unresolved_hamiltonian()` when authored lab-frame physics is required. `chip.hamiltonian()` now returns the resolved basis/frame/RWA view used by the engine.
+- Required CI currently constrains `qutip<5.3.1` because scqubits 4.3.1 and earlier cannot consume the SciPy sparse arrays returned by qutip 5.3.1. This is a CI compatibility constraint, not a package dependency pin. [#3]
+
+## [0.1.1] - 2026-07-21
+
+### Added
+
+- Added the executed [Hello, drive and readout] example, its reader-facing walkthrough, and a cookbook for executable quchip studies. [#1]
+- Added `CITATION.cff` with the accompanying paper as the preferred citation.
+- Published the API and physics documentation at [docs.quchip.org].
+
+### Fixed
+
+- Heterogeneous QuTiP problem lists now use the loky process pool while preserving input order. [#2]
+- Aligned the physics reference with the implementation and widened one physics-sentinel symmetry bound to a platform-independent solver-accuracy floor.
+
+### Packaging and infrastructure
+
+- Added PyPI trusted publishing for version tags, project links, Python 3.11/3.12 pull-request checks, and scheduled full-suite CI.
+- Served README figures from quchip.org so they render consistently on GitHub and PyPI.
+
+## [0.1.0] - 2026-07-19
+
+- Initial public release of the open-source Python toolkit for modelling superconducting quantum chips.
+- Included device, coupling, control, frame, RWA, dissipation, transformation, sweep, visualization, and inverse-design APIs; QuTiP and dynamiqs backends; and JAX-compatible differentiation paths.
+- Published the README, contribution guide, code of conduct, physics reference, and test suite.
+
+[0.2.0]: https://github.com/quchip/quchip/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/quchip/quchip/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/quchip/quchip/tree/v0.1.0
+[#1]: https://github.com/quchip/quchip/pull/1
+[#2]: https://github.com/quchip/quchip/pull/2
+[#3]: https://github.com/quchip/quchip/pull/3
+[#4]: https://github.com/quchip/quchip/pull/4
+[#6]: https://github.com/quchip/quchip/pull/6
+[#7]: https://github.com/quchip/quchip/pull/7
+[#8]: https://github.com/quchip/quchip/pull/8
+[#9]: https://github.com/quchip/quchip/pull/9
+[Hello, drive and readout]: https://docs.quchip.org/examples/hello-chip.html
+[docs.quchip.org]: https://docs.quchip.org

--- a/PHYSICS.md
+++ b/PHYSICS.md
@@ -1,6 +1,6 @@
 # quchip Physics Reference
 
-This document states the physics contracts implemented by quchip. It answers what the public `.hamiltonian()` methods mean, where frames are applied, where RWA is applied, and which assumptions the engine makes.
+This document states the physics contracts implemented by quchip. It distinguishes authored and resolved Hamiltonians, records where local bases, frames, and RWA are applied, and states the engine's assumptions.
 
 ## 1. Units and the 2π Convention
 
@@ -17,21 +17,23 @@ The domain layer stays in ordinary GHz. The only Hamiltonian-assembly `2π` conv
 
 ## 2. What `.hamiltonian()` Means
 
-### 2.1 Device `.hamiltonian()`
+### 2.1 Device Hamiltonians
 
-`BaseDevice.hamiltonian()` returns that device's static local Hamiltonian in its own Hilbert space, in the lab frame, in ordinary GHz.
+`BaseDevice.unresolved_hamiltonian()` returns that device's authored static Hamiltonian in its declared local space, in the lab frame, in ordinary GHz.
 
 Examples:
 
-- `DuffingTransmon.hamiltonian()` returns `omega * n + (alpha / 2) * n * (n - I)`.
-- `Resonator.hamiltonian()` returns `omega * n`.
+- `DuffingTransmon.unresolved_hamiltonian()` returns `omega * n + (alpha / 2) * n * (n - I)`.
+- `Resonator.unresolved_hamiltonian()` returns `omega * n`.
 
-It does not:
+The authored view does not:
 
 - include `2π`
 - include any rotating-frame subtraction
 - include any drive term
 - include any explicit time dependence
+
+`BaseDevice.hamiltonian()` resolves the same device through the engine path. For an owned device it inherits the chip's local-basis and frame policy; an explicit `frame=` passed to `resolve()` affects only that snapshot. The result is a one-device expression, so couplings to the rest of the chip remain outside its boundary.
 
 ### 2.2 Coupling `.interaction_hamiltonian()`
 
@@ -45,24 +47,28 @@ full: g * (a + a†)(b + b†)
 
 `interaction_hamiltonian()` always returns this full form. The RWA form `g * (a†b + ab†)` is never authored directly — it is what remains once the bands that change total excitation are masked out by the chip or filtered by the engine.
 
-### 2.3 `Chip.hamiltonian()`
+### 2.3 Chip and sequence Hamiltonians
 
-`Chip.hamiltonian()` returns the full static lab-frame Hamiltonian after embedding device and coupling operators into the total Hilbert space. For each coupling where `Chip.resolve_rwa(coupling)` is `True`, the full interaction is masked to the excitation-change bands its `rwa_keeps_band` predicate accepts (§6.1) before embedding. RWA is therefore already included in this Hamiltonian rather than deferred to the engine.
+`Chip.unresolved_hamiltonian()` embeds every authored device Hamiltonian and full coupling interaction into the total declared Hilbert space. It is the exact static lab-frame expression before local-basis materialization, retained-level truncation, frame transformation, or RWA.
 
-It is still not the solver-ready Hamiltonian. The engine later:
+`Chip.hamiltonian()` is reconstructed from `Chip.resolve()`, the frozen `EngineResult` used by backends. Resolution:
 
-1. multiplies by `2π`
-2. subtracts the chosen frame generator
-3. decomposes non-static pieces into excitation-change bands, filtering coupling bands with the same `rwa_keeps_band` predicate so the two views agree
-4. attaches explicit time-dependent phases where needed
-5. adds drive and crosstalk terms
+1. materializes each authored local space into the selected solver basis and retained dimension
+2. multiplies solver-facing operators by `2π`
+3. subtracts the chosen frame generator
+4. decomposes non-static pieces into excitation-change bands and filters coupling bands with each coupling's `rwa_keeps_band` predicate
+5. attaches explicit time-dependent phases where needed
+
+The returned expression is an inspectable, ordinary-GHz view of those same canonical terms; the solver-facing `EngineResult` retains the internal `2π` scaling. `QuantumSequence.hamiltonian()` follows the same path and adds the sequence's scheduled drive and crosstalk terms.
 
 The resulting contracts are:
 
-- device `.hamiltonian()` means local static lab-frame physics
+- device `.unresolved_hamiltonian()` means authored local static lab-frame physics
+- device `.hamiltonian()` means the resolved one-device engine view
 - coupling `.interaction_hamiltonian()` means local static lab-frame interaction physics
-- `Chip.hamiltonian()` means the embedded static lab-frame chip Hamiltonian
-- the engine builds the actual solver Hamiltonian from those pieces
+- `Chip.unresolved_hamiltonian()` means the embedded authored static lab-frame chip Hamiltonian
+- `Chip.hamiltonian()` means the resolved canonical chip Hamiltonian without scheduled drives
+- `QuantumSequence.hamiltonian()` means the resolved canonical Hamiltonian with scheduled drives
 
 ## 3. Device Models
 
@@ -99,6 +105,16 @@ The standard dissipators are:
 Those are assembled in the device layer. Backends only receive already-built operators.
 
 Noise parameters are ordinary tracked attributes: set (or clear with `None`) at construction **or any time after** — collapse operators are rebuilt from current values on every solve, and post-construction writes get the same validation as the constructor. Chip-level shared/collective dissipation lives in `Bath` ([`quchip/chip/baths.py`](quchip/chip/baths.py)), attached at construction or later via `chip.add_bath(...)`; bath rates are Lindblad-ready 1/ns with no assembly `2π` (that boundary is Hamiltonian-only — a component's *intrinsic* `2π`, e.g. a resonator's `κ = 2π·f/Q`, is its own physics).
+
+### 3.4 Authored local spaces and solver bases
+
+Source: [`quchip/devices/spaces.py`](quchip/devices/spaces.py), [`quchip/engine/basis.py`](quchip/engine/basis.py)
+
+Each device authors its Hamiltonian and named operators in a `LocalSpace`. The built-in realizations are `FockSpace`, `ChargeSpace`, `PhaseGridSpace`, and `CustomSpace`. This declared coordinate space is independent of the solver-basis policy.
+
+`Chip(..., basis="native")` preserves each authored local coordinate basis and dimension. `basis="eigen"` diagonalizes each device's exact authored local Hamiltonian and projects all Hamiltonians, coupling and drive operators, states, observables, and collapse operators into the retained local energy subspace. A device can override the chip-wide policy with its own `basis` and selects the retained energy dimension with `projection_levels` where required.
+
+Resolution records every fixed authored-to-solver transformation in `EngineResult.bases`. Local energy ordering is distinct from whole-chip dressing: `Chip.dress()` diagonalizes the coupled static chip for analysis, while local-basis resolution defines the tensor factors sent through the engine and backends.
 
 ## 4. Frames
 
@@ -187,9 +203,7 @@ This band decomposition is the frame-tracking mechanism.
 
 ## 6. RWA
 
-RWA in quchip means "drop fast, non-resonant pieces instead of carrying them explicitly."
-
-There are two places where that can happen.
+RWA in quchip means "drop fast, non-resonant pieces instead of carrying them explicitly." The authored and resolved views meet that policy as follows.
 
 ### 6.1 Coupling RWA
 
@@ -197,8 +211,8 @@ Source: [`quchip/chip/rwa.py`](quchip/chip/rwa.py)
 
 Coupling RWA is a chip-resolved policy, not a second operator defined by each coupling class. A coupling implements exactly one interaction, `interaction_hamiltonian()` (§2.2) — always the full, non-RWA form — and, optionally, `rwa_keeps_band(delta_a, delta_b)`, a predicate over the two-body excitation-change bands `(delta_a, delta_b)` the interaction decomposes into (default: total-excitation-conserving, `delta_a + delta_b == 0`, the beam-splitter selection). `Chip.resolve_rwa(coupling)` chooses the per-coupling override when present and otherwise uses the chip default. The resolved value is used in both paths:
 
-- `Chip.hamiltonian()` masks the full local operator down to the bands `rwa_keeps_band` accepts (`apply_rwa_mask`), before embedding it into the static lab-frame Hamiltonian (§2.3).
-- Stage 2 (`_collect_coupling_terms` in [`quchip/engine/stage2_assembly.py`](quchip/engine/stage2_assembly.py)) band-decomposes the same full operator and filters with the same predicate. Rejected bands become advisory `DroppedTerm` records with `reason="counter-rotating under RWA"`. Each record carries the band's `(delta_a, delta_b)` weights, its largest matrix-element magnitude, and its frame frequency. The amplitude equals `|g|` for a two-level `Capacitive` interaction, but ladder-operator factors can make it larger when either mode has more levels. Retained bands follow the general per-band static/dynamic fold of §5.2: a band whose carrier `delta_a*omega_a + delta_b*omega_b` is concretely zero stays folded into `H0`; every other retained band is subtracted back out and carried as an explicit time-dependent term.
+- `Chip.unresolved_hamiltonian()` preserves the full authored interaction without applying RWA (§2.3).
+- Stage 2 (`_collect_coupling_terms` in [`quchip/engine/stage2_assembly.py`](quchip/engine/stage2_assembly.py)) band-decomposes that interaction and filters with the resolved predicate. `Chip.hamiltonian()` is reconstructed from the retained canonical terms, so it reflects the same RWA decision as a solve. Rejected bands become advisory `DroppedTerm` records with `reason="counter-rotating under RWA"`. Each record carries the band's `(delta_a, delta_b)` weights, its largest matrix-element magnitude, and its frame frequency. The amplitude equals `|g|` for a two-level `Capacitive` interaction, but ladder-operator factors can make it larger when either mode has more levels. Retained bands follow the general per-band static/dynamic fold of §5.2: a band whose carrier `delta_a*omega_a + delta_b*omega_b` is concretely zero stays folded into `H0`; every other retained band is subtracted back out and carried as an explicit time-dependent term.
 
 For `Capacitive`:
 

--- a/PHYSICS.md
+++ b/PHYSICS.md
@@ -61,6 +61,8 @@ full: g * (a + a†)(b + b†)
 
 The returned expression is an inspectable, ordinary-GHz view of those same canonical terms; the solver-facing `EngineResult` retains the internal `2π` scaling. `QuantumSequence.hamiltonian()` follows the same path and adds the sequence's scheduled drive and crosstalk terms.
 
+These inspection methods return `PhysicsExpr`, the backend-neutral scalar and operator algebra used for authored and resolved physics. It retains declared parameters, matrices, time-dependent scalars, labels, and opaque JAX callables without forcing numerical values. Numerical materialization is explicit through `.matrix()` or backend lowering.
+
 The resulting contracts are:
 
 - device `.unresolved_hamiltonian()` means authored local static lab-frame physics

--- a/README.md
+++ b/README.md
@@ -61,19 +61,28 @@ python -m pip install .
 ```python
 from quchip import Capacitive, ChargeDrive, Chip, DuffingTransmon, Resonator
 
-qubit = DuffingTransmon(freq=5.0, anharmonicity=-0.30, levels=6, label="qubit")
-readout = Resonator(freq=6.8, levels=10, quality_factor=6800, label="readout")
-coupling = Capacitive(qubit, readout, g=0.060, rwa=True, label="qubit-readout")
+qubit = DuffingTransmon(freq=5.0, anharmonicity=-0.30, levels=6, label="q")
+readout = Resonator(freq=6.8, levels=10, quality_factor=6800, label="r")
+coupling = Capacitive(qubit, readout, g=0.060, rwa=True, label="qr")
 chip = Chip([qubit, readout], couplings=[coupling], frame="rotating", rwa=True)
 qubit_line = ChargeDrive(qubit, label="qubit-charge")
 readout_line = ChargeDrive(readout, label="readout-charge")
 chip.wire(qubit_line, readout_line)
+
+authored_hamiltonian = chip.unresolved_hamiltonian()
+resolved_hamiltonian = chip.hamiltonian()
 
 f01 = chip.freq(qubit)
 f12 = chip.freq(qubit, when={qubit: 1})
 fr0 = chip.freq(readout, when={qubit: 0})
 fr1 = chip.freq(readout, when={qubit: 1})
 ```
+
+The authored Hamiltonian preserves the device and coupling expressions in their
+declared local spaces. The resolved view applies the chip's basis, frame, and
+RWA policies through the same engine path used by simulation. Both remain
+inspectable symbolic expressions; call `.matrix()` when a numerical array is
+needed.
 
 The complete example derives short and selective nominal-pi Gaussian drives from $|f_{12}-f_{01}|$, then derives a Gaussian-edge readout duration from the conditional pull and resonator linewidth. Both parts run the real multilevel, lossy chip with compact reproducibility receipts.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@
   <a href="https://arxiv.org/abs/2607.17081">Paper</a>
 </p>
 
+<p align="center">
+  <a href="https://pypi.org/project/quchip/"><img src="https://img.shields.io/pypi/v/quchip" alt="PyPI version"></a>
+  <a href="https://pypi.org/project/quchip/"><img src="https://img.shields.io/badge/python-3.11%2B-blue" alt="Python 3.11 or newer"></a>
+  <a href="https://github.com/quchip/quchip/actions/workflows/ci.yml"><img src="https://github.com/quchip/quchip/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI status"></a>
+  <a href="https://docs.quchip.org"><img src="https://github.com/quchip/quchip/actions/workflows/docs.yml/badge.svg?branch=main" alt="Documentation build status"></a>
+</p>
+
 `quchip` is an open-source Python toolkit for modeling superconducting quantum chips.
 
 A predictive chip model needs more than a Hamiltonian: device physics, control-line transformations, frames and approximations, dissipation, and measured observables all belong to it. quchip represents each part explicitly. Line properties such as gain, delay, and crosstalk belong to the control chain, not to Hamiltonian terms written by hand.
@@ -28,7 +35,7 @@ Declare the chip once. The same declaration drives dressed-state analysis, model
 
 `Chip + QuantumSequence` → `ResolvedFrame` → `EngineResult` → `SolveProblem` → QuTiP or dynamiqs → `SimulationResult`
 
-QuTiP is the default backend. The dynamiqs backend is JAX-native and keeps declared device and control parameters differentiable through the solve.
+QuTiP is the default backend. The dynamiqs backend is JAX-native and keeps declared device and control parameters differentiable through the solve. The optional scqubits integration imports and exports selected device and composite models.
 
 `quchip` uses GHz for ordinary frequencies, ns for time, and mK for temperature. The implemented conventions and approximations are documented in the [physics guide](https://docs.quchip.org/physics).
 
@@ -56,7 +63,7 @@ cd quchip
 python -m pip install .
 ```
 
-## A minimal chip
+## Declare and inspect a chip
 
 ```python
 from quchip import Capacitive, ChargeDrive, Chip, DuffingTransmon, Resonator
@@ -90,34 +97,18 @@ The complete example derives short and selective nominal-pi Gaussian drives from
 
 ![Conditional resonator IQ paths with emphasized final points](https://raw.githubusercontent.com/quchip/quchip/main/docs/images/hello_dispersive_readout_iq.png)
 
-The complete walkthrough is available as [authored Markdown](https://github.com/quchip/quchip/blob/main/examples/00_hello_chip.md) and an [executed notebook](https://github.com/quchip/quchip/blob/main/examples/00_hello_chip.ipynb).
-
-## Tests
-
-Install the dependencies used by all shipped test lanes:
-
-```bash
-python -m pip install -e '.[test,dynamiqs]'
-```
-
-Run the full suite:
-
-```bash
-python -m pytest
-```
-
-Run one lane:
-
-```bash
-python -m pytest -m core
-python -m pytest -m physics_sentinel
-python -m pytest -m extended
-```
+The complete walkthrough is available in the [documentation](https://docs.quchip.org/examples/hello-chip).
 
 ## Examples
 
-- [Hello, drive and readout](https://github.com/quchip/quchip/blob/main/examples/00_hello_chip.md): compare qubit-drive leakage, then resolve pulse-level dispersive readout on the same chip.
+- [Hello, drive and readout](https://docs.quchip.org/examples/hello-chip): compare qubit-drive leakage, then resolve pulse-level dispersive readout on the same chip.
 - [Cookbook](https://docs.quchip.org/cookbook): practical conventions and task recipes.
+
+## Project status and contributing
+
+`quchip` is under active development. While it remains in 0.x, minor releases may refine public APIs; see the [changelog](https://github.com/quchip/quchip/blob/main/CHANGELOG.md).
+
+Report bugs and model requests through [GitHub Issues](https://github.com/quchip/quchip/issues). Use [Discussions](https://github.com/quchip/quchip/discussions) for questions and open-ended proposals. See the [contributing guide](https://github.com/quchip/quchip/blob/main/CONTRIBUTING.md) before making code or physics changes.
 
 ## Paper and citation
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -10,6 +10,10 @@ Put parameters at the top, then construct devices, couplings, the chip, control 
 
 quchip uses GHz for ordinary frequencies, ns for time, and mK for temperature. Set the frame and chip RWA policy explicitly, and state the model approximation and Hilbert-space truncation that matter for the result. A drive constructed with its default `rwa=None` inherits the chip policy when the Hamiltonian template is resolved.
 
+### Inspect authored and resolved physics
+
+Use `chip.unresolved_hamiltonian()` to inspect the exact static expressions supplied by devices and couplings. Use `chip.hamiltonian()` for the canonical result after local-basis materialization, retained-level truncation, frame resolution, and RWA. Use `sequence.hamiltonian()` when scheduled drives must be included. These methods return inspectable expressions; call `.matrix()` only at a numerical boundary.
+
 ### Prepare the intended state
 
 Use `chip.state()` by default. It returns the dressed eigenstate assigned to the requested bare labels and is safe inside `jax.jit`, `grad`, and `vmap`. Use `chip.bare_state()` only when the question intentionally concerns a bare product state, such as a swap or transfer experiment; explain that choice where it appears.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,8 @@
 
 A predictive chip model needs more than a Hamiltonian: device physics, control-line transformations, frames and approximations, dissipation, and measured observables all belong to it. quchip represents each part explicitly. Declare the chip once; the same declaration drives dressed-state analysis, model reduction, control sequencing, open-system simulation, parameter sweeps, and exact JAX gradients.
 
+The declared and resolved physics remain inspectable. `chip.unresolved_hamiltonian()` shows the authored static model, while `chip.hamiltonian()` applies the same basis, frame, and RWA policies used by simulation. A sequence's Hamiltonian also includes its scheduled drives.
+
 ## Install
 
 quchip requires Python 3.11 or newer.

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,8 +46,6 @@ Start with {doc}`Hello, drive and readout <examples/hello-chip>` to declare an e
 
 The accompanying paper is [quchip: A Differentiable Toolkit for Modeling Quantum Devices](https://arxiv.org/abs/2607.17081) (arXiv:2607.17081); citation metadata is in the repository's [CITATION.cff](https://github.com/quchip/quchip/blob/main/CITATION.cff).
 
-Worked examples and guides are being added incrementally.
-
 ```{toctree}
 :maxdepth: 1
 :hidden:

--- a/docs/prose-audit-workflow.md
+++ b/docs/prose-audit-workflow.md
@@ -1,0 +1,126 @@
+# Prose audit workflow
+
+This workflow scans repository prose for named writing patterns without guessing
+whether AI wrote it. It covers Python docstrings, Markdown prose, and visible or
+accessibility text in rendered HTML.
+
+## Sources and rule contract
+
+The primary contract comes from
+[`petergyang/no-ai-slop`](https://github.com/petergyang/no-ai-slop) at commit
+`d30eddb9e04562234f2070b5ee63ca4649d9a05e`: preserve the writer's voice, make
+the minimum effective edit, name each detected pattern, quote its evidence, and
+do not assign an authorship score.
+
+The contextual signals come from
+[`hardikpandya/stop-slop`](https://github.com/hardikpandya/stop-slop) at commit
+`8da1f030185bdfe8471220585162991eaeb970e9`. Its exact filler, puffery,
+attribution, and rhetorical patterns are useful candidates. Its blanket rules
+against passive voice, adverbs, em dashes, Wh-word openings, and three-item lists
+are review signals only. Applying those bans mechanically would damage physics
+definitions, API reference material, and intentional project voice.
+
+## Run the inventory
+
+From the repository root:
+
+```bash
+.venv/bin/python -m tools.prose_audit.cli \
+  --root . \
+  --rendered-html docs/_build/html \
+  --extra-path TRUTH.md \
+  --extra-path EXAMPLES_PLAN.md \
+  --output docs/_build/prose-audit/candidates.json
+```
+
+The command discovers tracked and untracked, non-ignored Python, Markdown, and
+HTML files. Repeat `--extra-path` for each deliberately ignored authored source
+that belongs in the audit, such as `TRUTH.md` or `EXAMPLES_PLAN.md`;
+`--rendered-html` adds ignored Sphinx output as a derived verification set. The
+output remains under ignored `docs/_build/`.
+
+The command exits nonzero for an extraction failure or an unaccounted target. A
+style candidate does not fail the command.
+
+## What extraction includes
+
+- Python: module, class, function, and async-function docstrings, with owning
+  symbols and physical source lines.
+- Markdown: headings, paragraphs, lists, tables, block quotations, link labels,
+  and image alt text.
+- HTML: visible text plus `alt` and `aria-label` text.
+
+The extractors exclude Python comments and ordinary string literals; Markdown
+code fences, inline syntax, link destinations, and display math; and HTML
+scripts, styles, navigation, code listings, and generated source views.
+
+## Adjudicate candidates
+
+The deterministic candidate list is only the discovery pass. Split a large
+repository into non-overlapping semantic lanes—authored Markdown, production
+docstrings, test/tooling docstrings, and rendered-only text—and read every
+passage in each lane, including passages with no lexical match. A scout must
+return exact `file:line` evidence, the named pattern, confidence, contextual
+reasoning, and a preserve/repair recommendation. A separate triage pass then
+re-reads each proposal in its owning section or symbol.
+
+Give each proposed issue one disposition:
+
+- **confirmed**: the named pattern weakens this passage in context;
+- **dismissed**: the match is legitimate technical or intentional prose; or
+- **duplicate-generated**: rendered HTML repeats an authored source passage.
+
+High-confidence lexical matches are still candidates, not verdicts. Protect
+equations, API identifiers, domain terms, qualified claims, uncertainty,
+necessary passives, citations, accessibility text, and deliberate examples.
+Check technical claims against `TRUTH.md`, `PHYSICS.md`, implementation, or tests
+before treating them as writing problems.
+
+Review contextual signals in clusters, then inspect every member of a suspicious
+cluster in its source. Typical legitimate clusters include:
+
+- passive voice where a physical object or transformation matters more than an
+  actor;
+- three-item or longer lists that enumerate parameters, states, solver paths,
+  or invariants;
+- Wh-word openings in headings and NumPy-style parameter clauses;
+- em dashes separating equations, qualifications, or deliberate contrasts; and
+- adverbs that distinguish actual from nominal behavior or carry mathematical
+  precision.
+
+Rendered Sphinx candidates must be mapped back to their Markdown or docstring.
+Only prose introduced by the rendering layer stays attached to an HTML path.
+
+Review the authored entries in the JSON `passages` array in file order. Apply
+the portability test to short standalone claims; check module introductions for
+catalogues that duplicate the API; compare repeated explanations across module,
+class, and helper docstrings; inspect test prose for generic rigor claims; and
+inspect section endings for generic recaps. These semantic patterns often have
+no banned word. Preserve specific technical details and deliberate cadence.
+
+## Report and verify
+
+Record each confirmed finding with `file:line`, the smallest useful quotation,
+rule provenance, confidence, contextual rationale, and a short repair direction.
+Also record representative dismissals and the complete inventory totals.
+
+Keep the working findings ledger at
+`docs/_build/prose-audit/prose-audit-findings.md`. It contains audit-process
+notes and quotations of known-bad prose, so it should enter the published
+documentation only through an explicit publication decision.
+
+Run:
+
+```bash
+MPLCONFIGDIR=/tmp/quchip-matplotlib \
+  .venv/bin/python -m pytest tests/test_prose_audit.py -q
+.venv/bin/ruff check tools/prose_audit tests/test_prose_audit.py
+git diff --check
+```
+
+Finally regenerate `candidates.json`. Its `failures` list must be empty,
+`inventory.unaccounted_targets` must be zero, and every quoted finding must
+still match its source line.
+
+The audit does not rewrite prose or establish a CI gate. Remediation is a
+separate reviewable change.

--- a/examples/00_hello_chip.ipynb
+++ b/examples/00_hello_chip.ipynb
@@ -9,12 +9,9 @@
         "\n",
         "# Hello, drive and readout\n",
         "\n",
-        "This example couples a Duffing transmon to a lossy resonator. First we compare\n",
-        "leakage from two qubit pulses; then we drive the resonator and follow its\n",
-        "response for qubit $|0\\rangle$ and $|1\\rangle$.\n",
+        "This example couples a Duffing transmon to a lossy resonator. First we compare leakage from two qubit pulses; then we drive the resonator and follow its response for qubit $|0\\rangle$ and $|1\\rangle$.\n",
         "\n",
-        "quchip uses GHz for frequencies and ns for time. The chip and coupling use the\n",
-        "RWA in a per-device rotating frame; both drives inherit `chip.rwa=True`."
+        "quchip uses GHz for frequencies and ns for time. The chip and coupling use the RWA in a per-device rotating frame; both drives inherit `chip.rwa=True`."
       ]
     },
     {
@@ -76,9 +73,9 @@
       "source": [
         "## Inspect the authored Hamiltonian\n",
         "\n",
-        "Before scheduling a pulse, inspect the static Hamiltonian exactly as the devices\n",
-        "and coupling define it. The labels `q`, `r`, and `qr` become compact operator\n",
-        "subscripts; call `.matrix()` only when a numerical array is needed.\n",
+        "Before scheduling a pulse, inspect the static Hamiltonian exactly as the\n",
+        "devices and coupling define it. The labels `q`, `r`, and `qr` become compact\n",
+        "operator subscripts; call `.matrix()` only when a numerical array is needed.\n",
         "`chip.hamiltonian()` is the complementary resolved view after the chip's basis,\n",
         "frame, and RWA policies."
       ]
@@ -104,7 +101,7 @@
         }
       ],
       "source": [
-        "chip.unresolved_hamiltonian();"
+        "chip.unresolved_hamiltonian()"
       ]
     },
     {
@@ -114,8 +111,7 @@
       "source": [
         "## Part 1: Qubit drive and leakage\n",
         "\n",
-        "The coupled chip's dressed transitions set the carrier and the neighboring line\n",
-        "to avoid. Ask quchip for $f_{01}$ and the dressed $1\\rightarrow2$ transition:"
+        "The coupled chip's dressed transitions set the carrier and the neighboring line to avoid. Ask quchip for $f_{01}$ and the dressed $1\\rightarrow2$ transition:"
       ]
     },
     {
@@ -125,8 +121,8 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "f01 = float(chip.freq(qubit));\n",
-        "f12 = float(chip.freq(qubit, when = { qubit: 1 }));"
+        "f01 = float(chip.freq(qubit))\n",
+        "f12 = float(chip.freq(qubit, when={qubit: 1}))"
       ]
     },
     {
@@ -134,9 +130,7 @@
       "id": "8b476860",
       "metadata": {},
       "source": [
-        "Both pulses are three-sigma Gaussians with the same nominal-$\\pi$ area. The\n",
-        "short pulse has bandwidth $|f_{12}-f_{01}|$; the four-times-longer pulse is more\n",
-        "selective. `pi_gaussian` rescales each waveform so $2\\pi\\int E(t)\\,dt=\\pi$."
+        "Both pulses are three-sigma Gaussians with the same nominal-$\\pi$ area. The short pulse has bandwidth $|f_{12}-f_{01}|$; the four-times-longer pulse is more selective. `pi_gaussian` rescales each waveform so $2\\pi\\int E(t)\\,dt=\\pi$."
       ]
     },
     {
@@ -172,9 +166,7 @@
       "id": "55f7fc35",
       "metadata": {},
       "source": [
-        "Both pulses start at $t=0$ from dressed $|0,0\\rangle$. The batch varies duration\n",
-        "and amplitude on one shared grid; after the short pulse ends, that trajectory\n",
-        "evolves freely."
+        "Both pulses start at $t=0$ from dressed $|0,0\\rangle$. The batch varies duration and amplitude on one shared grid; after the short pulse ends, that trajectory evolves freely."
       ]
     },
     {
@@ -209,9 +201,7 @@
       "source": [
         "## Inspect the batch with Quchip\n",
         "\n",
-        "Each batch element is a `SimulationResult`. With `trace_out=readout`,\n",
-        "`plot_populations` shows the qubit populations directly. The first result\n",
-        "contains the short pulse followed by idle evolution."
+        "Each batch element is a `SimulationResult`. With `trace_out=readout`, `plot_populations` shows the qubit populations directly. The first result contains the short pulse followed by idle evolution."
       ]
     },
     {
@@ -232,8 +222,8 @@
         }
       ],
       "source": [
-        "drive_batch[0].plot_populations(trace_out = readout);\n",
-        "plt.show();"
+        "drive_batch[0].plot_populations(trace_out=readout)\n",
+        "plt.show()"
       ]
     },
     {
@@ -262,8 +252,8 @@
         }
       ],
       "source": [
-        "drive_batch[1].plot_populations(trace_out = readout);\n",
-        "plt.show();"
+        "drive_batch[1].plot_populations(trace_out=readout)\n",
+        "plt.show()"
       ]
     },
     {
@@ -273,8 +263,7 @@
       "source": [
         "## Customize the comparison\n",
         "\n",
-        "For the shared-grid comparison, read $P_0$, $P_1$, and $P_2$ from the batch.\n",
-        "Each call returns an array indexed by `(pulse, time)`."
+        "For the shared-grid comparison, read $P_0$, $P_1$, and $P_2$ from the batch. Each call returns an array indexed by `(pulse, time)`."
       ]
     },
     {
@@ -314,9 +303,7 @@
       "id": "1a342cb9",
       "metadata": {},
       "source": [
-        "The panels show the actual scheduled envelopes and $P(|0\\rangle)$,\n",
-        "$P(|1\\rangle)$, and $P(|2\\rangle)$. The short pulse reaches the adjacent\n",
-        "transition; the long pulse suppresses that leakage."
+        "The panels show the actual scheduled envelopes and $P(|0\\rangle)$, $P(|1\\rangle)$, and $P(|2\\rangle)$. The short pulse reaches the adjacent transition; the long pulse suppresses that leakage."
       ]
     },
     {
@@ -400,8 +387,7 @@
       "source": [
         "## Part 2: Dispersive readout\n",
         "\n",
-        "The resonator frequency depends on whether the qubit is in $|0\\rangle$ or\n",
-        "$|1\\rangle$. Ask quchip for both conditional frequencies:"
+        "The resonator frequency depends on whether the qubit is in $|0\\rangle$ or $|1\\rangle$. Ask quchip for both conditional frequencies:"
       ]
     },
     {
@@ -411,9 +397,10 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "readout_frequencies =\n",
-        "  (float(chip.freq(readout, when = { qubit: 0 })),\n",
-        "    float(chip.freq(readout, when = { qubit: 1 })));"
+        "readout_frequencies = (\n",
+        "    float(chip.freq(readout, when={qubit: 0})),\n",
+        "    float(chip.freq(readout, when={qubit: 1})),\n",
+        ")"
       ]
     },
     {
@@ -421,9 +408,7 @@
       "id": "3c519c31",
       "metadata": {},
       "source": [
-        "The readout lasts for the larger of five resonator lifetimes and half the\n",
-        "inverse conditional pull, rounded up to the 5 ns grid. Its amplitude is set\n",
-        "directly."
+        "The readout lasts for the larger of five resonator lifetimes and half the inverse conditional pull, rounded up to the 5 ns grid. Its amplitude is set directly."
       ]
     },
     {
@@ -433,19 +418,19 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "readout_time_step = 5.0;\n",
+        "readout_time_step = 5.0\n",
         "readout_duration = readout_time_step * np.ceil(\n",
-        "  max(\n",
-        "    5.0 / (2.0 * np.pi * resonator_linewidth),\n",
-        "    1.0 / (2.0 * abs(readout_frequencies[1] - readout_frequencies[0])),\n",
-        "  ) /\n",
-        "    readout_time_step,\n",
-        ");\n",
+        "    max(\n",
+        "        5.0 / (2.0 * np.pi * resonator_linewidth),\n",
+        "        1.0 / (2.0 * abs(readout_frequencies[1] - readout_frequencies[0])),\n",
+        "    )\n",
+        "    / readout_time_step\n",
+        ")\n",
         "readout_times = np.linspace(\n",
-        "  0.0,\n",
-        "  readout_duration,\n",
-        "  int(round(readout_duration / readout_time_step)) + 1,\n",
-        ");"
+        "    0.0,\n",
+        "    readout_duration,\n",
+        "    int(round(readout_duration / readout_time_step)) + 1,\n",
+        ")"
       ]
     },
     {
@@ -463,31 +448,31 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "readout_sequence = QuantumSequence(chip);\n",
+        "readout_sequence = QuantumSequence(chip)\n",
         "readout_sequence.schedule(\n",
-        "  readout_line,\n",
-        "  envelope = GaussianEdge(\n",
-        "    duration = readout_duration,\n",
-        "    edge_duration = 40.0,\n",
-        "    sigmas = 3,\n",
-        "    amplitude = 0.0012,\n",
-        "  ),\n",
-        "  freq = sum(readout_frequencies) / 2.0,\n",
-        ");\n",
+        "    readout_line,\n",
+        "    envelope=GaussianEdge(\n",
+        "        duration=readout_duration,\n",
+        "        edge_duration=40.0,\n",
+        "        sigmas=3,\n",
+        "        amplitude=0.0012,\n",
+        "    ),\n",
+        "    freq=sum(readout_frequencies) / 2.0,\n",
+        ")\n",
         "readout_batch = readout_sequence.simulate_batch(\n",
-        "  readout_sequence.vary(\n",
-        "    \"initial_state\",\n",
-        "    [\n",
-        "      chip.state({ qubit: 0, readout: 0 }),\n",
-        "      chip.state({ qubit: 1, readout: 0 }),\n",
-        "    ],\n",
-        "    name = \"prepared_qubit\",\n",
-        "  ),\n",
-        "  tlist = readout_times,\n",
-        "  e_ops = chip.e_ops(r = \"a\"),\n",
-        "  progress = False,\n",
-        "  truncation_threshold = truncation_threshold,\n",
-        ");"
+        "    readout_sequence.vary(\n",
+        "        \"initial_state\",\n",
+        "        [\n",
+        "            chip.state({qubit: 0, readout: 0}),\n",
+        "            chip.state({qubit: 1, readout: 0}),\n",
+        "        ],\n",
+        "        name=\"prepared_qubit\",\n",
+        "    ),\n",
+        "    tlist=readout_times,\n",
+        "    e_ops=chip.e_ops(r=\"a\"),\n",
+        "    progress=False,\n",
+        "    truncation_threshold=truncation_threshold,\n",
+        ")"
       ]
     },
     {
@@ -495,8 +480,7 @@
       "id": "6c091e39",
       "metadata": {},
       "source": [
-        "The solver returns $\\alpha(t)=\\langle a\\rangle$; its real and imaginary parts\n",
-        "trace the IQ response for each prepared state."
+        "The solver returns $\\alpha(t)=\\langle a\\rangle$; its real and imaginary parts trace the IQ response for each prepared state."
       ]
     },
     {
@@ -506,15 +490,15 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "alpha = np.asarray(readout_batch.expect(\"r\"), dtype = complex);\n",
+        "alpha = np.asarray(readout_batch.expect(\"r\"), dtype=complex)\n",
         "readout_receipt = {\n",
-        "  \"conditional_resonator_frequencies_ghz\": readout_frequencies,\n",
-        "  \"final_iq_separation\": float(abs(alpha[0, -1] - alpha[1, -1])),\n",
-        "  \"iq_plot\": \"../docs/images/hello_dispersive_readout_iq.png\",\n",
-        "  \"readout_carrier_ghz\": sum(readout_frequencies) / 2.0,\n",
-        "  \"readout_duration_ns\": readout_duration,\n",
-        "  \"solver\": readout_batch[0].solver,\n",
-        "};"
+        "    \"conditional_resonator_frequencies_ghz\": readout_frequencies,\n",
+        "    \"final_iq_separation\": float(abs(alpha[0, -1] - alpha[1, -1])),\n",
+        "    \"iq_plot\": \"../docs/images/hello_dispersive_readout_iq.png\",\n",
+        "    \"readout_carrier_ghz\": sum(readout_frequencies) / 2.0,\n",
+        "    \"readout_duration_ns\": readout_duration,\n",
+        "    \"solver\": readout_batch[0].solver,\n",
+        "}"
       ]
     },
     {
@@ -589,8 +573,7 @@
       "id": "e4096c3d",
       "metadata": {},
       "source": [
-        "One chip now shows both effects: pulse bandwidth controls leakage, and the qubit\n",
-        "state shifts the resonator response."
+        "One chip now shows both effects: pulse bandwidth controls leakage, and the qubit state shifts the resonator response."
       ]
     }
   ],

--- a/examples/00_hello_chip.ipynb
+++ b/examples/00_hello_chip.ipynb
@@ -9,9 +9,12 @@
         "\n",
         "# Hello, drive and readout\n",
         "\n",
-        "This example couples a Duffing transmon to a lossy resonator. First we compare leakage from two qubit pulses; then we drive the resonator and follow its response for qubit $|0\\rangle$ and $|1\\rangle$.\n",
+        "This example couples a Duffing transmon to a lossy resonator. First we compare\n",
+        "leakage from two qubit pulses; then we drive the resonator and follow its\n",
+        "response for qubit $|0\\rangle$ and $|1\\rangle$.\n",
         "\n",
-        "quchip uses GHz for frequencies and ns for time. The chip and coupling use the RWA in a per-device rotating frame; both drives inherit `chip.rwa=True`."
+        "quchip uses GHz for frequencies and ns for time. The chip and coupling use the\n",
+        "RWA in a per-device rotating frame; both drives inherit `chip.rwa=True`."
       ]
     },
     {
@@ -71,11 +74,13 @@
       "id": "5a972a3f",
       "metadata": {},
       "source": [
-        "## Inspect the symbolic Hamiltonian\n",
+        "## Inspect the authored Hamiltonian\n",
         "\n",
-        "Before scheduling a pulse, inspect the chip's symbolic static Hamiltonian. The\n",
-        "labels `q`, `r`, and `qr` become compact operator subscripts; call `.matrix()`\n",
-        "only when a numerical array is needed."
+        "Before scheduling a pulse, inspect the static Hamiltonian exactly as the devices\n",
+        "and coupling define it. The labels `q`, `r`, and `qr` become compact operator\n",
+        "subscripts; call `.matrix()` only when a numerical array is needed.\n",
+        "`chip.hamiltonian()` is the complementary resolved view after the chip's basis,\n",
+        "frame, and RWA policies."
       ]
     },
     {
@@ -87,42 +92,10 @@
         {
           "data": {
             "text/latex": [
-              "$1\\,\\hat H_0 + f_{coupling,0}\\!\\left(t\\right)\\,\\hat H_{coupling,0} + f_{coupling,1}\\!\\left(t\\right)\\,\\hat H_{coupling,1}$"
+              "$\\omega_{q}\\,\\hat n_{q} + 0.5\\,\\alpha_{q}\\,\\hat n_{q}\\,(\\hat n_{q} - \\hat I_{q}) + \\omega_{r}\\,\\hat n_{r} + g_{qr}\\,(\\hat a_{q} + \\hat a^\\dagger_{q})\\,(\\hat a_{r} + \\hat a^\\dagger_{r})$"
             ],
             "text/plain": [
-              "PhysicsExpr(kind='add', args=(PhysicsExpr(kind='add', args=(PhysicsExpr(kind='scale', args=(PhysicsExpr(kind='literal', args=(1.0,), labels=(), dynamic_sources=()), PhysicsExpr(kind='matrix', args=(array([[ 0.00000000e+00+0.j,  0.00000000e+00+0.j,  0.00000000e+00+0.j,\n",
-              "        ...,  0.00000000e+00+0.j,  0.00000000e+00+0.j,\n",
-              "         0.00000000e+00+0.j],\n",
-              "       [ 0.00000000e+00+0.j, -1.99778270e-03+0.j,  0.00000000e+00+0.j,\n",
-              "        ...,  0.00000000e+00+0.j,  0.00000000e+00+0.j,\n",
-              "         0.00000000e+00+0.j],\n",
-              "       [ 0.00000000e+00+0.j,  0.00000000e+00+0.j, -3.99556540e-03+0.j,\n",
-              "        ...,  0.00000000e+00+0.j,  0.00000000e+00+0.j,\n",
-              "         0.00000000e+00+0.j],\n",
-              "       ...,\n",
-              "       [ 0.00000000e+00+0.j,  0.00000000e+00+0.j,  0.00000000e+00+0.j,\n",
-              "        ..., -3.00399557e+00+0.j,  0.00000000e+00+0.j,\n",
-              "         0.00000000e+00+0.j],\n",
-              "       [ 0.00000000e+00+0.j,  0.00000000e+00+0.j,  0.00000000e+00+0.j,\n",
-              "        ...,  0.00000000e+00+0.j, -3.00599335e+00+0.j,\n",
-              "         0.00000000e+00+0.j],\n",
-              "       [ 0.00000000e+00+0.j,  0.00000000e+00+0.j,  0.00000000e+00+0.j,\n",
-              "        ...,  0.00000000e+00+0.j,  0.00000000e+00+0.j,\n",
-              "        -3.00799113e+00+0.j]], shape=(60, 60)), (6, 10), '\\\\hat H_0'), labels=('q', 'r'), dynamic_sources=())), labels=('q', 'r'), dynamic_sources=()), PhysicsExpr(kind='scale', args=(PhysicsExpr(kind='signal', args=(Carrier(freq=np.float64(11.334838430768222), sign=-1), 'f_{coupling,0}'), labels=(), dynamic_sources=()), PhysicsExpr(kind='matrix', args=(array([[0.+0.j, 0.+0.j, 0.+0.j, ..., 0.+0.j, 0.+0.j, 0.+0.j],\n",
-              "       [0.+0.j, 0.+0.j, 0.+0.j, ..., 0.+0.j, 0.+0.j, 0.+0.j],\n",
-              "       [0.+0.j, 0.+0.j, 0.+0.j, ..., 0.+0.j, 0.+0.j, 0.+0.j],\n",
-              "       ...,\n",
-              "       [0.+0.j, 0.+0.j, 0.+0.j, ..., 0.+0.j, 0.+0.j, 0.+0.j],\n",
-              "       [0.+0.j, 0.+0.j, 0.+0.j, ..., 0.+0.j, 0.+0.j, 0.+0.j],\n",
-              "       [0.+0.j, 0.+0.j, 0.+0.j, ..., 0.+0.j, 0.+0.j, 0.+0.j]],\n",
-              "      shape=(60, 60)), (6, 10), '\\\\hat H_{coupling,0}'), labels=('q', 'r'), dynamic_sources=())), labels=('q', 'r'), dynamic_sources=())), labels=('q', 'r'), dynamic_sources=()), PhysicsExpr(kind='scale', args=(PhysicsExpr(kind='signal', args=(Carrier(freq=np.float64(-11.334838430768222), sign=-1), 'f_{coupling,1}'), labels=(), dynamic_sources=()), PhysicsExpr(kind='matrix', args=(array([[0.+0.j, 0.+0.j, 0.+0.j, ..., 0.+0.j, 0.+0.j, 0.+0.j],\n",
-              "       [0.+0.j, 0.+0.j, 0.+0.j, ..., 0.+0.j, 0.+0.j, 0.+0.j],\n",
-              "       [0.+0.j, 0.+0.j, 0.+0.j, ..., 0.+0.j, 0.+0.j, 0.+0.j],\n",
-              "       ...,\n",
-              "       [0.+0.j, 0.+0.j, 0.+0.j, ..., 0.+0.j, 0.+0.j, 0.+0.j],\n",
-              "       [0.+0.j, 0.+0.j, 0.+0.j, ..., 0.+0.j, 0.+0.j, 0.+0.j],\n",
-              "       [0.+0.j, 0.+0.j, 0.+0.j, ..., 0.+0.j, 0.+0.j, 0.+0.j]],\n",
-              "      shape=(60, 60)), (6, 10), '\\\\hat H_{coupling,1}'), labels=('q', 'r'), dynamic_sources=())), labels=('q', 'r'), dynamic_sources=())), labels=('q', 'r'), dynamic_sources=())"
+              "PhysicsExpr(kind='add', args=(PhysicsExpr(kind='add', args=(PhysicsExpr(kind='embed', args=(PhysicsExpr(kind='add', args=(PhysicsExpr(kind='scale', args=(PhysicsExpr(kind='parameter', args=('q.freq', '\\\\omega', 'GHz'), labels=(), dynamic_sources=()), PhysicsExpr(kind='op', args=('n', FockSpace(levels=6)), labels=('q',), dynamic_sources=())), labels=('q',), dynamic_sources=()), PhysicsExpr(kind='scale', args=(PhysicsExpr(kind='mul', args=(PhysicsExpr(kind='literal', args=(0.5,), labels=(), dynamic_sources=()), PhysicsExpr(kind='parameter', args=('q.anharmonicity', '\\\\alpha', 'GHz'), labels=(), dynamic_sources=())), labels=(), dynamic_sources=()), PhysicsExpr(kind='matmul', args=(PhysicsExpr(kind='op', args=('n', FockSpace(levels=6)), labels=('q',), dynamic_sources=()), PhysicsExpr(kind='sub', args=(PhysicsExpr(kind='op', args=('n', FockSpace(levels=6)), labels=('q',), dynamic_sources=()), PhysicsExpr(kind='op', args=('I', FockSpace(levels=6)), labels=('q',), dynamic_sources=())), labels=('q',), dynamic_sources=())), labels=('q',), dynamic_sources=())), labels=('q',), dynamic_sources=())), labels=('q',), dynamic_sources=()), ('q', 'r'), (6, 10)), labels=('q', 'r'), dynamic_sources=()), PhysicsExpr(kind='embed', args=(PhysicsExpr(kind='scale', args=(PhysicsExpr(kind='parameter', args=('r.freq', '\\\\omega', 'GHz'), labels=(), dynamic_sources=()), PhysicsExpr(kind='op', args=('n', FockSpace(levels=10)), labels=('r',), dynamic_sources=())), labels=('r',), dynamic_sources=()), ('q', 'r'), (6, 10)), labels=('q', 'r'), dynamic_sources=())), labels=('q', 'r'), dynamic_sources=()), PhysicsExpr(kind='embed', args=(PhysicsExpr(kind='tensor', args=(PhysicsExpr(kind='scale', args=(PhysicsExpr(kind='parameter', args=('qr.g', 'g', 'GHz'), labels=(), dynamic_sources=()), PhysicsExpr(kind='add', args=(PhysicsExpr(kind='op', args=('a', FockSpace(levels=6)), labels=('q',), dynamic_sources=()), PhysicsExpr(kind='op', args=('adag', FockSpace(levels=6)), labels=('q',), dynamic_sources=())), labels=('q',), dynamic_sources=())), labels=('q',), dynamic_sources=()), PhysicsExpr(kind='add', args=(PhysicsExpr(kind='op', args=('a', FockSpace(levels=10)), labels=('r',), dynamic_sources=()), PhysicsExpr(kind='op', args=('adag', FockSpace(levels=10)), labels=('r',), dynamic_sources=())), labels=('r',), dynamic_sources=())), labels=('q', 'r'), dynamic_sources=()), ('q', 'r'), (6, 10)), labels=('q', 'r'), dynamic_sources=())), labels=('q', 'r'), dynamic_sources=())"
             ]
           },
           "execution_count": 2,
@@ -131,7 +104,7 @@
         }
       ],
       "source": [
-        "chip.hamiltonian()"
+        "chip.unresolved_hamiltonian();"
       ]
     },
     {
@@ -141,7 +114,8 @@
       "source": [
         "## Part 1: Qubit drive and leakage\n",
         "\n",
-        "The coupled chip's dressed transitions set the carrier and the neighboring line to avoid. Ask quchip for $f_{01}$ and the dressed $1\\rightarrow2$ transition:"
+        "The coupled chip's dressed transitions set the carrier and the neighboring line\n",
+        "to avoid. Ask quchip for $f_{01}$ and the dressed $1\\rightarrow2$ transition:"
       ]
     },
     {
@@ -151,8 +125,8 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "f01 = float(chip.freq(qubit))\n",
-        "f12 = float(chip.freq(qubit, when={qubit: 1}))"
+        "f01 = float(chip.freq(qubit));\n",
+        "f12 = float(chip.freq(qubit, when = { qubit: 1 }));"
       ]
     },
     {
@@ -160,7 +134,9 @@
       "id": "8b476860",
       "metadata": {},
       "source": [
-        "Both pulses are three-sigma Gaussians with the same nominal-$\\pi$ area. The short pulse has bandwidth $|f_{12}-f_{01}|$; the four-times-longer pulse is more selective. `pi_gaussian` rescales each waveform so $2\\pi\\int E(t)\\,dt=\\pi$."
+        "Both pulses are three-sigma Gaussians with the same nominal-$\\pi$ area. The\n",
+        "short pulse has bandwidth $|f_{12}-f_{01}|$; the four-times-longer pulse is more\n",
+        "selective. `pi_gaussian` rescales each waveform so $2\\pi\\int E(t)\\,dt=\\pi$."
       ]
     },
     {
@@ -196,7 +172,9 @@
       "id": "55f7fc35",
       "metadata": {},
       "source": [
-        "Both pulses start at $t=0$ from dressed $|0,0\\rangle$. The batch varies duration and amplitude on one shared grid; after the short pulse ends, that trajectory evolves freely."
+        "Both pulses start at $t=0$ from dressed $|0,0\\rangle$. The batch varies duration\n",
+        "and amplitude on one shared grid; after the short pulse ends, that trajectory\n",
+        "evolves freely."
       ]
     },
     {
@@ -231,7 +209,9 @@
       "source": [
         "## Inspect the batch with Quchip\n",
         "\n",
-        "Each batch element is a `SimulationResult`. With `trace_out=readout`, `plot_populations` shows the qubit populations directly. The first result contains the short pulse followed by idle evolution."
+        "Each batch element is a `SimulationResult`. With `trace_out=readout`,\n",
+        "`plot_populations` shows the qubit populations directly. The first result\n",
+        "contains the short pulse followed by idle evolution."
       ]
     },
     {
@@ -252,8 +232,8 @@
         }
       ],
       "source": [
-        "drive_batch[0].plot_populations(trace_out=readout)\n",
-        "plt.show()"
+        "drive_batch[0].plot_populations(trace_out = readout);\n",
+        "plt.show();"
       ]
     },
     {
@@ -282,8 +262,8 @@
         }
       ],
       "source": [
-        "drive_batch[1].plot_populations(trace_out=readout)\n",
-        "plt.show()"
+        "drive_batch[1].plot_populations(trace_out = readout);\n",
+        "plt.show();"
       ]
     },
     {
@@ -293,7 +273,8 @@
       "source": [
         "## Customize the comparison\n",
         "\n",
-        "For the shared-grid comparison, read $P_0$, $P_1$, and $P_2$ from the batch. Each call returns an array indexed by `(pulse, time)`."
+        "For the shared-grid comparison, read $P_0$, $P_1$, and $P_2$ from the batch.\n",
+        "Each call returns an array indexed by `(pulse, time)`."
       ]
     },
     {
@@ -333,7 +314,9 @@
       "id": "1a342cb9",
       "metadata": {},
       "source": [
-        "The panels show the actual scheduled envelopes and $P(|0\\rangle)$, $P(|1\\rangle)$, and $P(|2\\rangle)$. The short pulse reaches the adjacent transition; the long pulse suppresses that leakage."
+        "The panels show the actual scheduled envelopes and $P(|0\\rangle)$,\n",
+        "$P(|1\\rangle)$, and $P(|2\\rangle)$. The short pulse reaches the adjacent\n",
+        "transition; the long pulse suppresses that leakage."
       ]
     },
     {
@@ -417,7 +400,8 @@
       "source": [
         "## Part 2: Dispersive readout\n",
         "\n",
-        "The resonator frequency depends on whether the qubit is in $|0\\rangle$ or $|1\\rangle$. Ask quchip for both conditional frequencies:"
+        "The resonator frequency depends on whether the qubit is in $|0\\rangle$ or\n",
+        "$|1\\rangle$. Ask quchip for both conditional frequencies:"
       ]
     },
     {
@@ -427,10 +411,9 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "readout_frequencies = (\n",
-        "    float(chip.freq(readout, when={qubit: 0})),\n",
-        "    float(chip.freq(readout, when={qubit: 1})),\n",
-        ")"
+        "readout_frequencies =\n",
+        "  (float(chip.freq(readout, when = { qubit: 0 })),\n",
+        "    float(chip.freq(readout, when = { qubit: 1 })));"
       ]
     },
     {
@@ -438,7 +421,9 @@
       "id": "3c519c31",
       "metadata": {},
       "source": [
-        "The readout lasts for the larger of five resonator lifetimes and half the inverse conditional pull, rounded up to the 5 ns grid. Its amplitude is set directly."
+        "The readout lasts for the larger of five resonator lifetimes and half the\n",
+        "inverse conditional pull, rounded up to the 5 ns grid. Its amplitude is set\n",
+        "directly."
       ]
     },
     {
@@ -448,19 +433,19 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "readout_time_step = 5.0\n",
+        "readout_time_step = 5.0;\n",
         "readout_duration = readout_time_step * np.ceil(\n",
-        "    max(\n",
-        "        5.0 / (2.0 * np.pi * resonator_linewidth),\n",
-        "        1.0 / (2.0 * abs(readout_frequencies[1] - readout_frequencies[0])),\n",
-        "    )\n",
-        "    / readout_time_step\n",
-        ")\n",
+        "  max(\n",
+        "    5.0 / (2.0 * np.pi * resonator_linewidth),\n",
+        "    1.0 / (2.0 * abs(readout_frequencies[1] - readout_frequencies[0])),\n",
+        "  ) /\n",
+        "    readout_time_step,\n",
+        ");\n",
         "readout_times = np.linspace(\n",
-        "    0.0,\n",
-        "    readout_duration,\n",
-        "    int(round(readout_duration / readout_time_step)) + 1,\n",
-        ")"
+        "  0.0,\n",
+        "  readout_duration,\n",
+        "  int(round(readout_duration / readout_time_step)) + 1,\n",
+        ");"
       ]
     },
     {
@@ -478,31 +463,31 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "readout_sequence = QuantumSequence(chip)\n",
+        "readout_sequence = QuantumSequence(chip);\n",
         "readout_sequence.schedule(\n",
-        "    readout_line,\n",
-        "    envelope=GaussianEdge(\n",
-        "        duration=readout_duration,\n",
-        "        edge_duration=40.0,\n",
-        "        sigmas=3,\n",
-        "        amplitude=0.0012,\n",
-        "    ),\n",
-        "    freq=sum(readout_frequencies) / 2.0,\n",
-        ")\n",
+        "  readout_line,\n",
+        "  envelope = GaussianEdge(\n",
+        "    duration = readout_duration,\n",
+        "    edge_duration = 40.0,\n",
+        "    sigmas = 3,\n",
+        "    amplitude = 0.0012,\n",
+        "  ),\n",
+        "  freq = sum(readout_frequencies) / 2.0,\n",
+        ");\n",
         "readout_batch = readout_sequence.simulate_batch(\n",
-        "    readout_sequence.vary(\n",
-        "        \"initial_state\",\n",
-        "        [\n",
-        "            chip.state({qubit: 0, readout: 0}),\n",
-        "            chip.state({qubit: 1, readout: 0}),\n",
-        "        ],\n",
-        "        name=\"prepared_qubit\",\n",
-        "    ),\n",
-        "    tlist=readout_times,\n",
-        "    e_ops=chip.e_ops(r=\"a\"),\n",
-        "    progress=False,\n",
-        "    truncation_threshold=truncation_threshold,\n",
-        ")"
+        "  readout_sequence.vary(\n",
+        "    \"initial_state\",\n",
+        "    [\n",
+        "      chip.state({ qubit: 0, readout: 0 }),\n",
+        "      chip.state({ qubit: 1, readout: 0 }),\n",
+        "    ],\n",
+        "    name = \"prepared_qubit\",\n",
+        "  ),\n",
+        "  tlist = readout_times,\n",
+        "  e_ops = chip.e_ops(r = \"a\"),\n",
+        "  progress = False,\n",
+        "  truncation_threshold = truncation_threshold,\n",
+        ");"
       ]
     },
     {
@@ -510,7 +495,8 @@
       "id": "6c091e39",
       "metadata": {},
       "source": [
-        "The solver returns $\\alpha(t)=\\langle a\\rangle$; its real and imaginary parts trace the IQ response for each prepared state."
+        "The solver returns $\\alpha(t)=\\langle a\\rangle$; its real and imaginary parts\n",
+        "trace the IQ response for each prepared state."
       ]
     },
     {
@@ -520,15 +506,15 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "alpha = np.asarray(readout_batch.expect(\"r\"), dtype=complex)\n",
+        "alpha = np.asarray(readout_batch.expect(\"r\"), dtype = complex);\n",
         "readout_receipt = {\n",
-        "    \"conditional_resonator_frequencies_ghz\": readout_frequencies,\n",
-        "    \"final_iq_separation\": float(abs(alpha[0, -1] - alpha[1, -1])),\n",
-        "    \"iq_plot\": \"../docs/images/hello_dispersive_readout_iq.png\",\n",
-        "    \"readout_carrier_ghz\": sum(readout_frequencies) / 2.0,\n",
-        "    \"readout_duration_ns\": readout_duration,\n",
-        "    \"solver\": readout_batch[0].solver,\n",
-        "}"
+        "  \"conditional_resonator_frequencies_ghz\": readout_frequencies,\n",
+        "  \"final_iq_separation\": float(abs(alpha[0, -1] - alpha[1, -1])),\n",
+        "  \"iq_plot\": \"../docs/images/hello_dispersive_readout_iq.png\",\n",
+        "  \"readout_carrier_ghz\": sum(readout_frequencies) / 2.0,\n",
+        "  \"readout_duration_ns\": readout_duration,\n",
+        "  \"solver\": readout_batch[0].solver,\n",
+        "};"
       ]
     },
     {
@@ -603,7 +589,8 @@
       "id": "e4096c3d",
       "metadata": {},
       "source": [
-        "One chip now shows both effects: pulse bandwidth controls leakage, and the qubit state shifts the resonator response."
+        "One chip now shows both effects: pulse bandwidth controls leakage, and the qubit\n",
+        "state shifts the resonator response."
       ]
     }
   ],
@@ -617,16 +604,7 @@
       "name": "python3"
     },
     "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.11.14"
+      "name": "python"
     }
   },
   "nbformat": 4,

--- a/examples/00_hello_chip.ipynb
+++ b/examples/00_hello_chip.ipynb
@@ -199,7 +199,7 @@
       "id": "8c8ef473",
       "metadata": {},
       "source": [
-        "## Inspect the batch with Quchip\n",
+        "## Inspect the batch with quchip\n",
         "\n",
         "Each batch element is a `SimulationResult`. With `trace_out=readout`, `plot_populations` shows the qubit populations directly. The first result contains the short pulse followed by idle evolution."
       ]

--- a/examples/00_hello_chip.md
+++ b/examples/00_hello_chip.md
@@ -133,7 +133,7 @@ drive_batch = drive_sequence.simulate_batch(
 )
 ```
 
-## Inspect the batch with Quchip
+## Inspect the batch with quchip
 
 Each batch element is a `SimulationResult`. With `trace_out=readout`, `plot_populations` shows the qubit populations directly. The first result contains the short pulse followed by idle evolution.
 

--- a/examples/00_hello_chip.md
+++ b/examples/00_hello_chip.md
@@ -67,14 +67,16 @@ readout_line = ChargeDrive(readout, label="readout-charge")
 _ = chip.wire(qubit_line, readout_line)
 ```
 
-## Inspect the symbolic Hamiltonian
+## Inspect the authored Hamiltonian
 
-Before scheduling a pulse, inspect the chip's symbolic static Hamiltonian. The
-labels `q`, `r`, and `qr` become compact operator subscripts; call `.matrix()`
-only when a numerical array is needed.
+Before scheduling a pulse, inspect the static Hamiltonian exactly as the
+devices and coupling define it. The labels `q`, `r`, and `qr` become compact
+operator subscripts; call `.matrix()` only when a numerical array is needed.
+`chip.hamiltonian()` is the complementary resolved view after the chip's basis,
+frame, and RWA policies.
 
 ```python
-chip.hamiltonian()
+chip.unresolved_hamiltonian()
 ```
 
 ## Part 1: Qubit drive and leakage

--- a/quchip/__init__.py
+++ b/quchip/__init__.py
@@ -1,19 +1,7 @@
 """Public package surface for quchip.
 
-This module re-exports the primary user-facing objects that make up a
-quchip study: device models (:class:`DuffingTransmon`,
-:class:`Resonator`, ...), chip topology and analysis
-(:class:`Chip`, :class:`Capacitive`, :class:`DressedResult`, ...),
-classical control (drives, envelopes, sequences, crosstalk), the
-engine entry points (:func:`simulate`, :func:`build_problem`,
-:func:`solve_problem`, :func:`solve_many`), backend selection helpers,
-backend-agnostic result containers, sweep helpers
-(:class:`Sweep`, :class:`SpectrumSweep`), post-hoc analysis
-(:func:`effective_hamiltonian`, :func:`analyze_cross_resonance`, ...),
-the immutable physical constants, and :func:`enable_compilation_cache`.
-
-Visualization helpers and optional third-party interop (pyvis, scqubits,
-matplotlib-based plots, ...) are loaded lazily through the module-level
+Visualization helpers and optional third-party interop are loaded lazily
+through the module-level
 :func:`__getattr__` so that ``import quchip`` stays fast and does not
 force any optional dependency on the core install.
 """

--- a/quchip/chip/baths.py
+++ b/quchip/chip/baths.py
@@ -227,22 +227,14 @@ class Bath:
         return tuple(self.parameter_values())
 
     def _bose(self, freq: Any, xp: Any) -> Any:
-        """Thermal occupation n̄(freq, T); JAX-safe (no branch on traced T), T=0-safe.
+        """Thermal occupation n̄(freq, T), including the ``T=0`` limit.
 
         ``k_B`` is ``k_B/h`` in GHz/mK, so ``freq/(k_B*T)`` is dimensionless.
-        The physical ``T -> 0`` limit is ``n̄ -> 0`` (a zero-temperature bath
-        carries no thermal photons), but ``T`` exactly ``0`` cannot reach that
-        limit through a live division: ``k_B*T`` would be the divisor, and
-        for a concrete zero-valued (plain Python or NumPy) temperature that
-        raises ``ZeroDivisionError``/emits ``inf`` before ``expm1`` ever
-        combines it back down to a finite value. The denominator is
-        therefore replaced with a nonzero placeholder *before* the division
-        runs — guarding the division's input, not just selecting between two
-        already-computed branch outputs, since ``xp.where`` evaluates both
-        branches and a zero divisor in the unselected branch would still
-        raise or poison gradients with ``NaN`` — and the exact ``T=0``
-        result (``0.0``) is selected explicitly afterward. No Python branch
-        on the traced temperature either way.
+        At ``T=0``, a nonzero placeholder is substituted before division and
+        the physical result ``n̄=0`` is selected afterward. Substitution must
+        happen first because ``xp.where`` evaluates both branches; a zero
+        divisor in the unselected branch could still raise or produce ``NaN``
+        gradients. Both selections avoid a Python branch on traced ``T``.
 
         Returns
         -------

--- a/quchip/chip/chip.py
+++ b/quchip/chip/chip.py
@@ -153,6 +153,11 @@ class Chip:
     rwa : bool
         Default RWA policy for couplings and drives. Per-component
         ``rwa`` overrides inherit this (``None`` means inherit).
+    basis : {"native", "eigen"}
+        Chip-wide local solver-basis policy. ``"native"`` preserves each
+        device's authored coordinate basis; ``"eigen"`` transforms into its
+        retained local energy subspace. A device-level ``basis`` overrides
+        this policy.
     backend : str or Backend, optional
         Chip-specific backend. ``None`` uses the process default.
 

--- a/quchip/chip/sw.py
+++ b/quchip/chip/sw.py
@@ -40,10 +40,9 @@ _WORKING_PRECISION = 1e-12
 def bare_hamiltonian(chip: "Chip") -> tuple[Any, list[str], tuple[int, ...]]:
     """Full bare Hamiltonian as a dense ``jnp`` array in GHz, with labels and dims.
 
-    Assembles the engine-consumed lab-frame Hamiltonian so the chip's resolved
-    RWA policy is included without changing the authored Hamiltonian view.
-    This is an analysis kernel, not a solver path; dense conversion is the
-    point, not a cost to avoid.
+    This analysis-only path applies the chip's resolved RWA policy while
+    leaving the authored Hamiltonian unchanged. It intentionally materializes
+    a dense matrix.
     """
     from quchip.engine.basis import semantic_to_solver_transform
     from quchip.engine.stage2_assembly import _analysis_matrix_ghz

--- a/quchip/control/batch.py
+++ b/quchip/control/batch.py
@@ -1,11 +1,7 @@
 """Batch / sweep-axis machinery for :class:`~quchip.control.sequence.QuantumSequence`.
 
-This module owns everything about turning a scheduled sequence into a
-*batched* solve request: the sweepable :class:`BatchAxis` /
-:class:`ZippedBatchAxis` descriptors, the per-entry handles
-(:class:`PulseHandle`, :class:`DelayHandle`) that create them, the axis
-expansion into per-point overrides consumed by
-:class:`~quchip.engine.ir.SolveBatch`.
+Batch axes and per-entry handles expand a scheduled sequence into
+per-point overrides consumed by :class:`~quchip.engine.ir.SolveBatch`.
 
 :class:`QuantumSequence` (in ``sequence.py``) is the scheduler; it delegates
 its ``vary`` / ``zip`` / ``build_batch`` surface here. The split keeps the

--- a/quchip/devices/resonator.py
+++ b/quchip/devices/resonator.py
@@ -74,9 +74,8 @@ from quchip.devices.fock import FockDevice
 def _photon_loss_channel(device: Any, basis: Any = None) -> list[tuple[Any, Any]]:
     """Cavity photon-loss channel ``sqrt(κ)·a`` with ``κ = 2π·freq/Q``.
 
-    The ``2π`` is intrinsic to the physical definition of Q (cycles of the
-    ordinary oscillation per e-folding of energy), not a units conversion —
-    see the module docstring. Empty when ``quality_factor`` is unset.
+    Empty when ``quality_factor`` is unset. See the module docstring for the
+    quality-factor convention.
     """
     if device.quality_factor is None:
         return []
@@ -95,15 +94,12 @@ class Resonator(FockDevice):
         Bare cavity frequency ω in GHz. Must be positive. May be a JAX
         tracer for sweeps / gradients.
     quality_factor : float | None, optional
-        Loaded Q, defined against the *ordinary* frequency ``freq``
-        (GHz). When set, adds a photon-loss Lindblad channel
-        ``sqrt(2*pi*freq/Q) a`` — i.e. decay rate
-        ``kappa = 2*pi*freq/Q`` (angular, rad/ns). The ``2*pi`` here is
-        part of the physical definition of Q (energy e-folds per
-        ordinary cycle divided by Q), not a units-boundary conversion.
-        Must be positive. Like every noise parameter it may be set — or
-        cleared with ``None`` — after construction; the next simulate
-        reflects the current value.
+        Loaded Q referenced to the ordinary frequency ``freq`` in GHz.
+        When set, adds a photon-loss Lindblad channel
+        ``sqrt(2*pi*freq/Q) a`` with angular decay rate
+        ``kappa = 2*pi*freq/Q`` in rad/ns. Must be positive. Like every
+        noise parameter, it may be set after construction or cleared with
+        ``None``; the next simulation reflects the current value.
     levels : int, default 10
         Fock-space truncation. Choose comfortably above the maximum
         expected photon occupation.

--- a/quchip/results/results.py
+++ b/quchip/results/results.py
@@ -1,20 +1,7 @@
 """Backend-agnostic wrapper around solver output.
 
-This module is the contract between backends and users. The engine emits
-backend-agnostic physics descriptions, and each backend converts them into
-its own optimal solver-ready form; the *result* of solving is then
-re-wrapped here so that user code never has to know whether QuTiP or
-dynamiqs/JAX produced the numbers.
-
-Key classes:
-
-- :class:`SimulationResult` — one solve's states, times, expectations,
-  and partial-trace / population accessors.
-- :class:`SimulationBatchResult` — ordered, immutable batch of results
-  with helpers that stack across the batch for e.g. sweeps.
-- :class:`ObservableTrace` — one named expectation-value trace, keeping
-  the pre-processing and post-processing values side by side (band
-  reconstruction, demodulation, etc.).
+The engine wraps each backend's solver output here so callers use the same
+state, expectation, partial-trace, population, and batch interfaces.
 
 All helpers that return arrays stay inside the backend's array module
 (JAX / NumPy) to preserve differentiability. The convenience wrappers

--- a/quchip/sweep.py
+++ b/quchip/sweep.py
@@ -1,18 +1,8 @@
 """Declarative parameter sweeps for chip studies.
 
-This module provides the user-facing sweep abstractions and a
-dressed-spectrum sweep driver:
-
-- :class:`Sweep` declares a 1-D axis of values for a single named
-  parameter. Multiple :class:`Sweep` axes compose as a Cartesian
-  product.
-- :class:`ZippedSweep` (built with :meth:`Sweep.zip`) pairs axes
-  element-wise rather than expanding the product, which is the right
-  shape for correlated scans (e.g. frequency and drive amplitude moved
-  together along a calibration trace).
-- :class:`SpectrumSweep` walks a sweep grid, dresses the chip at each
-  point via :meth:`Chip.dress`, and records eigenvalues and bare→dressed
-  label assignments into a :class:`SpectrumSweepResult`.
+Sweep axes compose as Cartesian products or zipped correlated scans.
+Spectrum sweeps dress the chip at each point and retain eigenvalues and
+bare→dressed label assignments.
 
 Sweep values are stored in their native physical units (GHz for
 frequencies, ns for times, mK for temperatures). :class:`Sweep`

--- a/tests/examples/test_example_00.py
+++ b/tests/examples/test_example_00.py
@@ -208,7 +208,7 @@ def test_hello_chip_source_encodes_the_locked_two_part_experiment() -> None:
     assert "chip.state({qubit: 0, readout: 0})" in code
     assert "for level in range(3)" in code
     assert "drive_batch.population(qubit, level)" in code
-    assert "## Inspect the batch with Quchip" in markdown
+    assert "## Inspect the batch with quchip" in markdown
     assert "## Customize the comparison" in markdown
     population_plot_cells = [
         cell.strip() for cell in _markdown_code_cells(markdown) if ".plot_populations(" in cell

--- a/tests/examples/test_example_00.py
+++ b/tests/examples/test_example_00.py
@@ -156,8 +156,8 @@ def test_hello_chip_source_encodes_the_locked_two_part_experiment() -> None:
     assert 'label="qubit"' not in declaration
     assert 'label="readout"' not in declaration
     assert 'label="qubit-readout"' not in declaration
-    assert "## Inspect the symbolic Hamiltonian" in markdown
-    assert cells[declaration_index + 1] == "chip.hamiltonian()"
+    assert "## Inspect the authored Hamiltonian" in markdown
+    assert cells[declaration_index + 1] == "chip.unresolved_hamiltonian()"
 
     assert "# Hello, drive and readout" in markdown
     assert len(markdown.splitlines()) < 350
@@ -386,7 +386,7 @@ def test_hello_chip_pair_executes_and_records_physical_receipts(tmp_path: Path) 
                 assert set(image_outputs[0]["data"]) <= {"image/png", "text/plain"}
                 continue
 
-            assert "".join(cell["source"]).strip() == "chip.hamiltonian()"
+            assert "".join(cell["source"]).strip() == "chip.unresolved_hamiltonian()"
             assert len(cell["outputs"]) == 1
             symbolic_output = cell["outputs"][0]
             assert symbolic_output["output_type"] == "execute_result"

--- a/tests/extended/test_counter_rotating.py
+++ b/tests/extended/test_counter_rotating.py
@@ -1,7 +1,6 @@
 """Unit tests for (Δa, Δb) band decomposition of two-body operators.
 
-Every expected value is derived from analytical formulas — no reference
-to the function-under-test is used to *generate* ground truth.
+Band-decomposition formulas provide the reference values.
 """
 
 from __future__ import annotations

--- a/tests/extended/test_regression_snapshots.py
+++ b/tests/extended/test_regression_snapshots.py
@@ -10,9 +10,6 @@ The three paths tested:
   3. Crosstalk dynamics -- verifies victim device excitation from leaked
      signal through the crosstalk pipeline
 
-Purpose: safety net for the callable-IR and crosstalk paths. These tests detect any
-behavioral change.
-
 Unit convention: frequencies in GHz (ordinary), times in ns, h-bar = 1.
 """
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,8 +1,4 @@
-"""Tests for Backend protocol and QuTiPBackend implementation.
-
-Every assertion checks against a known analytical value, never against the implementation's
-own output, so tests catch real bugs rather than encoding implementation tautologies.
-"""
+"""Tests for Backend protocol and QuTiPBackend implementation."""
 
 from __future__ import annotations
 

--- a/tests/test_backend_switching.py
+++ b/tests/test_backend_switching.py
@@ -1,9 +1,9 @@
 """Per-call backend switching, state coercion, and solver-option defaults.
 
-The ``backend=`` argument of ``simulate``/``simulate_batch`` scopes one call:
-it outranks the chip-constructed backend and the process default, and foreign
--native initial states are coerced at the solve boundary. The nsteps default
-is a generous abort ceiling so user code never carries ``{"nsteps": ...}``.
+The ``backend=`` argument of ``simulate``/``simulate_batch`` scopes one call
+and takes precedence over the chip backend and process default. Initial states
+native to another backend are coerced at the solve boundary. When the caller
+omits ``nsteps``, QuTiP can infer an abort ceiling from spectral metadata.
 """
 
 from __future__ import annotations
@@ -46,8 +46,8 @@ def test_named_backend_coercion_returns_shared_instance() -> None:
     assert _coerce_backend("qutip") is _coerce_backend("qutip")
 
 
-def test_nsteps_default_is_a_generous_ceiling(backend: QuTiPBackend) -> None:
-    """The default nsteps ceiling never aborts a solve, and an explicit user value always overrides it."""
+def test_nsteps_default_is_at_least_200k(backend: QuTiPBackend) -> None:
+    """The inferred nsteps ceiling is at least 200,000; an explicit value takes precedence."""
     tlist = np.linspace(0.0, 100.0, 11)
     resolved = backend.resolve_solver_options({}, metadata={"spectral_bound_ghz": 5.0}, tlist=tlist)
     assert resolved["nsteps"] >= 200_000

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1,8 +1,6 @@
 """Domain model tests with analytical verification.
 
-Every expected value is derived from physics formulas rather than running the
-implementation first. Coverage includes device, coupling, and import-cleanliness
-behavior.
+The formulas below define the reference energies and coupling matrix element.
 
 Eigenvalue formulas:
     DuffingTransmon: E_n = ω·n + (α/2)·n·(n−1)

--- a/tests/test_dressed.py
+++ b/tests/test_dressed.py
@@ -1,7 +1,6 @@
 """Physics-verifying dressed-state tests for Chip.dress/energy/transition_freq.
 
-All expected values are derived analytically from the dispersive model,
-not from running implementation code first.
+The dispersive model below supplies the reference values.
 
 System under test (matches TestDispersiveShift in tests/test_physics.py):
     - Transmon:  w_q = 5.0 GHz, alpha = -0.25 GHz, levels = 4

--- a/tests/test_envelopes.py
+++ b/tests/test_envelopes.py
@@ -1,8 +1,7 @@
 """Unit tests for pulse envelope waveform generation.
 
-Pure-numpy tests — no backend or chip needed.  Every expected value
-is derived from the analytical envelope definitions, not from running
-the code.
+Analytical envelope definitions determine the reference waveforms; no backend
+or chip is required.
 """
 
 from __future__ import annotations

--- a/tests/test_prose_audit.py
+++ b/tests/test_prose_audit.py
@@ -1,0 +1,258 @@
+"""Format-aware coverage for the repository prose-audit workflow."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+from tools.prose_audit import Passage
+from tools.prose_audit.cli import build_report, main
+from tools.prose_audit.extract import extract_html, extract_markdown, extract_python
+from tools.prose_audit.rules import find_candidates
+
+
+def test_extract_python_returns_only_docstrings_with_source_owners(tmp_path) -> None:
+    """Comments and ordinary string literals do not enter the prose inventory."""
+    path = tmp_path / "sample.py"
+    source = '''"""Module summary."""
+
+# A prose comment is outside the requested audit scope.
+class Device:
+    """Device summary."""
+
+    note = "ordinary string"
+
+    def solve(self):
+        """Solve the model."""
+        return "result text"
+
+
+async def prepare():
+    """Prepare the model."""
+'''
+
+    passages = extract_python(path, source)
+
+    assert [(item.line, item.owner, item.text) for item in passages] == [
+        (1, "<module>", "Module summary."),
+        (5, "Device", "Device summary."),
+        (10, "Device.solve", "Solve the model."),
+        (15, "prepare", "Prepare the model."),
+    ]
+    assert {item.kind for item in passages} == {"docstring"}
+
+
+def test_extract_markdown_keeps_authored_prose_and_excludes_literal_syntax(tmp_path) -> None:
+    """Markdown structure remains reviewable without treating code or math as prose."""
+    path = tmp_path / "guide.md"
+    source = """# Device guide
+
+Model the `Chip` with the [physics guide](https://example.test/physics).
+Keep the declared approximation explicit.
+
+- First authored item.
+- Second authored item.
+
+![Pulse response for the readout resonator](pulse.png)
+
+```python
+print("Here's the thing: code is not prose")
+```
+
+$$
+H = 2\\pi f a^\\dagger a
+$$
+"""
+
+    passages = extract_markdown(path, source)
+    combined = "\n".join(item.text for item in passages)
+
+    assert [(item.line, item.kind) for item in passages] == [
+        (1, "markdown-heading"),
+        (3, "markdown-prose"),
+        (6, "markdown-list"),
+        (7, "markdown-list"),
+        (9, "markdown-alt"),
+    ]
+    assert "Device guide" in combined
+    assert "Model the Chip with the physics guide." in combined
+    assert "Keep the declared approximation explicit." in combined
+    assert "Pulse response for the readout resonator" in combined
+    assert "example.test" not in combined
+    assert "print" not in combined
+    assert "2\\pi" not in combined
+
+
+def test_extract_markdown_handles_front_matter_and_myst_figure_prose(tmp_path) -> None:
+    """Jupytext metadata stays out while MyST accessibility text and captions stay in."""
+    path = tmp_path / "figure.md"
+    source = """---
+jupyter:
+  kernelspec:
+    name: python3
+---
+
+```{figure} response.png
+:width: 560px
+:alt: Conditional resonator response
+
+The two paths separate over the declared readout pulse.
+```
+"""
+
+    passages = extract_markdown(path, source)
+
+    assert [(item.line, item.kind, item.text) for item in passages] == [
+        (9, "markdown-alt", "Conditional resonator response"),
+        (11, "markdown-prose", "The two paths separate over the declared readout pulse."),
+    ]
+
+
+def test_extract_html_keeps_visible_content_and_accessibility_text(tmp_path) -> None:
+    """Generated navigation, source listings, scripts, and styles stay out of the audit."""
+    path = tmp_path / "page.html"
+    source = """<!doctype html>
+<html><body>
+  <nav>Previous Next Search</nav>
+  <main>
+    <h1>Device model</h1>
+    <p>The solver receives an explicit physics description.</p>
+    <img src="response.png" alt="Conditional readout response">
+    <button aria-label="Copy example">icon</button>
+    <div class="highlight"><pre>print("not prose")</pre></div>
+  </main>
+  <script>const phrase = "not prose";</script>
+  <style>.hidden { display: none; }</style>
+</body></html>
+"""
+
+    passages = extract_html(path, source)
+    combined = "\n".join(item.text for item in passages)
+
+    assert "Device model" in combined
+    assert "The solver receives an explicit physics description." in combined
+    assert "Conditional readout response" in combined
+    assert "Copy example" in combined
+    assert "Previous Next Search" not in combined
+    assert "print" not in combined
+    assert "const phrase" not in combined
+    assert "display: none" not in combined
+
+
+def _candidate_ids(text: str) -> set[str]:
+    passage = Passage("guide.md", 10, "markdown-prose", "<document>", text)
+    return {candidate.rule_id for candidate in find_candidates(passage)}
+
+
+def test_named_rules_detect_high_confidence_patterns() -> None:
+    """The audit reports recognizable patterns by name instead of guessing authorship."""
+    cases = {
+        "Here's the thing: the engine is robust.": {"throat-clearing", "business-jargon"},
+        "The question isn't speed. It's trust.": {"binary-contrast"},
+        "What most people get wrong is the frame.": {"faux-insight"},
+        "This marks a pivotal moment for the toolkit.": {"importance-puffery"},
+        "Experts agree that this approach works.": {"weasel-attribution"},
+        "This distinction matters more than it sounds.": {"interpretive-metadiscourse"},
+        "The implications are significant.": {"vague-declaration"},
+        "Speed. Quality. Cost. That's it.": {"dramatic-fragmentation"},
+        "The best part: it learns.": {"colon-reveal"},
+        "In conclusion, the model is complete.": {"recap-ending"},
+    }
+
+    for text, expected in cases.items():
+        assert _candidate_ids(text) >= expected
+
+
+def test_broad_stop_slop_checks_are_contextual_review_signals() -> None:
+    """Categorical house-style bans cannot become confirmed findings on their own."""
+    ids = _candidate_ids(
+        "How is the state represented? The model is carefully tested — in simulation, hardware, and analysis."
+    )
+
+    assert ids >= {"wh-opener", "passive-voice", "adverb", "em-dash", "three-item-list"}
+
+
+def test_scientific_and_api_prose_has_no_confirmed_pattern_by_default() -> None:
+    """Technical vocabulary, uncertainty, and necessary passives remain protected content."""
+    passage = Passage(
+        "docs/physics.md",
+        20,
+        "markdown-prose",
+        "<document>",
+        "The state is represented in the dressed basis. chip.freq returns the 0→1 transition; "
+        "the time-dependent Hamiltonian may include 2π factors at the engine boundary.",
+    )
+
+    candidates = find_candidates(passage)
+
+    assert not [candidate for candidate in candidates if candidate.confidence == "high"]
+
+
+def test_citations_and_compact_parameter_notes_are_not_dramatic_fragments() -> None:
+    """Periods in citations and terse API constraints are not manufactured drama."""
+    examples = (
+        "Blais et al., Rev. Mod. Phys. 93, 025005 (2021), §II.B.",
+        "Charging energy in GHz. Positive. JAX-traceable.",
+        '"Git gud" grants none. Explain. Cite. Suggest.',
+    )
+
+    for text in examples:
+        assert "dramatic-fragmentation" not in _candidate_ids(text)
+
+
+def test_repository_report_reconciles_tracked_and_rendered_targets(tmp_path) -> None:
+    """Every discovered target receives a disposition and stable machine-readable counts."""
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    (tmp_path / ".gitignore").write_text("generated/\nlocal.md\n", encoding="utf-8")
+    (tmp_path / "sample.py").write_text('"""Here\'s the thing: module prose."""\n', encoding="utf-8")
+    (tmp_path / "untracked.py").write_text('"""Untracked working-tree prose."""\n', encoding="utf-8")
+    (tmp_path / "guide.md").write_text("# Guide\n\nDirect authored prose.\n", encoding="utf-8")
+    (tmp_path / "local.md").write_text("Local ignored prose.\n", encoding="utf-8")
+    (tmp_path / "notes.txt").write_text("Not in the requested formats.\n", encoding="utf-8")
+    rendered = tmp_path / "generated"
+    rendered.mkdir()
+    (rendered / "page.html").write_text("<main><p>Rendered prose.</p></main>\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "add", ".gitignore", "sample.py", "guide.md", "notes.txt"],
+        check=True,
+    )
+
+    report = build_report(tmp_path, rendered, [tmp_path / "local.md"])
+
+    assert report["inventory"] == {
+        "python_files": 2,
+        "markdown_files": 2,
+        "html_files": 1,
+        "docstrings": 2,
+        "markdown_passages": 3,
+        "html_passages": 1,
+        "total_passages": 6,
+        "high_confidence_candidates": 1,
+        "contextual_candidates": 0,
+        "failures": 0,
+        "unaccounted_targets": 0,
+    }
+    assert [(target["path"], target["status"]) for target in report["targets"]] == [
+        ("generated/page.html", "clean"),
+        ("guide.md", "clean"),
+        ("local.md", "clean"),
+        ("sample.py", "candidate"),
+        ("untracked.py", "clean"),
+    ]
+
+
+def test_cli_writes_stable_json_and_fails_on_extraction_errors(tmp_path) -> None:
+    """Malformed targets are visible failures rather than silent omissions."""
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    (tmp_path / "broken.py").write_text("def broken(:\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "broken.py"], check=True)
+    output = tmp_path / "audit.json"
+
+    exit_code = main(["--root", str(tmp_path), "--output", str(output)])
+    report = json.loads(output.read_text(encoding="utf-8"))
+
+    assert exit_code == 1
+    assert report["inventory"]["failures"] == 1
+    assert report["inventory"]["unaccounted_targets"] == 0
+    assert report["failures"][0]["path"] == "broken.py"
+    assert report["targets"][0]["status"] == "failed"

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -60,9 +60,8 @@ def correlator_result() -> SimulationResult:
 
     The initial state is an uncorrelated product state with q0 fixed in
     |0> (``<Z_q0> = +1``) and q1 in an equal superposition
-    (``<Z_q1> = 0``), so ``<Z_q0> != <Z_q0 Z_q1>`` already at ``t=0`` —
-    independent of any subsequent dynamics — giving a robust
-    ground-truth pair for distinguishing the two traces.
+    (``<Z_q1> = 0``), so ``<Z_q0> != <Z_q0 Z_q1>`` already at ``t=0``,
+    independent of subsequent dynamics.
     """
     q0 = qc.DuffingTransmon(freq=5.0, anharmonicity=-0.25, levels=2, label="q0")
     q1 = qc.DuffingTransmon(freq=5.3, anharmonicity=-0.25, levels=2, label="q1")

--- a/tools/prose_audit/__init__.py
+++ b/tools/prose_audit/__init__.py
@@ -1,0 +1,31 @@
+"""Format-aware prose audit records."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class Passage:
+    """One authored prose passage with a stable source location."""
+
+    path: str
+    line: int
+    kind: str
+    owner: str
+    text: str
+
+
+@dataclass(frozen=True, slots=True)
+class Candidate:
+    """One named pattern candidate requiring contextual adjudication."""
+
+    passage: Passage
+    rule_id: str
+    rule_name: str
+    source: str
+    confidence: str
+    evidence: str
+
+
+__all__ = ["Candidate", "Passage"]

--- a/tools/prose_audit/cli.py
+++ b/tools/prose_audit/cli.py
@@ -1,0 +1,182 @@
+"""Command-line inventory and candidate report for the prose audit."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+import json
+from pathlib import Path
+import subprocess
+from typing import Sequence
+
+from . import Candidate, Passage
+from .extract import extract_html, extract_markdown, extract_python
+from .rules import find_candidates
+
+
+def _tracked_paths(root: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+        check=True,
+        capture_output=True,
+    )
+    return [Path(item.decode()) for item in result.stdout.split(b"\0") if item]
+
+
+def _targets(
+    root: Path,
+    rendered_html: Path | None,
+    extra_paths: Sequence[Path],
+) -> list[tuple[Path, str, bool]]:
+    targets: dict[Path, tuple[str, bool]] = {}
+    for path in _tracked_paths(root):
+        suffix = path.suffix.casefold()
+        if suffix in {".py", ".pyi"}:
+            targets[path] = ("python", False)
+        elif suffix == ".md":
+            targets[path] = ("markdown", False)
+        elif suffix in {".html", ".htm"}:
+            targets[path] = ("html", False)
+
+    if rendered_html is not None and rendered_html.exists():
+        resolved_root = root.resolve()
+        for absolute in sorted(rendered_html.rglob("*")):
+            if not absolute.is_file() or absolute.suffix.casefold() not in {".html", ".htm"}:
+                continue
+            try:
+                path = absolute.resolve().relative_to(resolved_root)
+            except ValueError:
+                path = absolute.resolve()
+            previous = targets.get(path)
+            targets[path] = ("html", previous[1] if previous else True)
+
+    resolved_root = root.resolve()
+    for extra in extra_paths:
+        absolute = extra if extra.is_absolute() else root / extra
+        try:
+            path = absolute.resolve().relative_to(resolved_root)
+        except ValueError:
+            path = absolute.resolve()
+        suffix = path.suffix.casefold()
+        if suffix in {".py", ".pyi"}:
+            targets[path] = ("python", False)
+        elif suffix == ".md":
+            targets[path] = ("markdown", False)
+        elif suffix in {".html", ".htm"}:
+            targets[path] = ("html", False)
+
+    return [(path, *targets[path]) for path in sorted(targets, key=lambda item: str(item))]
+
+
+def _extract(root: Path, path: Path, target_format: str) -> list[Passage]:
+    absolute = path if path.is_absolute() else root / path
+    source = absolute.read_text(encoding="utf-8")
+    display = path if not path.is_absolute() else absolute
+    if target_format == "python":
+        return extract_python(display, source)
+    if target_format == "markdown":
+        return extract_markdown(display, source)
+    return extract_html(display, source)
+
+
+def _candidate_dict(candidate: Candidate) -> dict[str, object]:
+    data = asdict(candidate)
+    passage = data.pop("passage")
+    return {**passage, **data}
+
+
+def build_report(
+    root: Path,
+    rendered_html: Path | None = None,
+    extra_paths: Sequence[Path] = (),
+) -> dict[str, object]:
+    """Build a stable JSON-compatible repository coverage and candidate report."""
+    root = root.resolve()
+    passages: list[Passage] = []
+    candidates: list[Candidate] = []
+    failures: list[dict[str, str]] = []
+    target_rows: list[dict[str, object]] = []
+
+    for path, target_format, generated in _targets(root, rendered_html, extra_paths):
+        display = str(path)
+        try:
+            extracted = _extract(root, path, target_format)
+        except (OSError, SyntaxError, UnicodeError, ValueError) as error:
+            failures.append({"path": display, "error": f"{type(error).__name__}: {error}"})
+            target_rows.append(
+                {
+                    "path": display,
+                    "format": target_format,
+                    "generated": generated,
+                    "passages": 0,
+                    "candidates": 0,
+                    "status": "failed",
+                }
+            )
+            continue
+
+        target_candidates = [candidate for passage in extracted for candidate in find_candidates(passage)]
+        passages.extend(extracted)
+        candidates.extend(target_candidates)
+        target_rows.append(
+            {
+                "path": display,
+                "format": target_format,
+                "generated": generated,
+                "passages": len(extracted),
+                "candidates": len(target_candidates),
+                "status": "candidate" if target_candidates else "clean",
+            }
+        )
+
+    target_formats = [row["format"] for row in target_rows]
+    inventory = {
+        "python_files": target_formats.count("python"),
+        "markdown_files": target_formats.count("markdown"),
+        "html_files": target_formats.count("html"),
+        "docstrings": sum(item.kind == "docstring" for item in passages),
+        "markdown_passages": sum(item.kind.startswith("markdown-") for item in passages),
+        "html_passages": sum(item.kind.startswith("html-") for item in passages),
+        "total_passages": len(passages),
+        "high_confidence_candidates": sum(item.confidence == "high" for item in candidates),
+        "contextual_candidates": sum(item.confidence == "contextual" for item in candidates),
+        "failures": len(failures),
+        "unaccounted_targets": sum(row["status"] not in {"candidate", "clean", "failed"} for row in target_rows),
+    }
+    return {
+        "inventory": inventory,
+        "targets": target_rows,
+        "passages": [asdict(item) for item in sorted(passages, key=lambda item: (item.path, item.line, item.kind))],
+        "candidates": [
+            _candidate_dict(item)
+            for item in sorted(candidates, key=lambda item: (item.passage.path, item.passage.line, item.rule_id))
+        ],
+        "failures": failures,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--rendered-html", type=Path)
+    parser.add_argument("--extra-path", type=Path, action="append", default=[])
+    parser.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Write the report and return nonzero only for incomplete extraction."""
+    args = _parser().parse_args(argv)
+    rendered = args.rendered_html
+    if rendered is not None and not rendered.is_absolute():
+        rendered = args.root / rendered
+    report = build_report(args.root, rendered, args.extra_path)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    inventory = report["inventory"]
+    assert isinstance(inventory, dict)
+    return int(bool(inventory["failures"] or inventory["unaccounted_targets"]))
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised through the command
+    raise SystemExit(main())

--- a/tools/prose_audit/extract.py
+++ b/tools/prose_audit/extract.py
@@ -1,0 +1,221 @@
+"""Extract prose from repository formats without rewriting source files."""
+
+from __future__ import annotations
+
+import ast
+from html.parser import HTMLParser
+from pathlib import Path
+import re
+
+from . import Passage
+
+_DocstringNode = ast.Module | ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef
+
+
+def _docstring_line(node: _DocstringNode) -> int:
+    first = node.body[0]
+    assert isinstance(first, ast.Expr)
+    return first.lineno
+
+
+def extract_python(path: Path, source: str) -> list[Passage]:
+    """Return module, class, and callable docstrings in source order."""
+    tree = ast.parse(source, filename=str(path))
+    passages: list[Passage] = []
+
+    def visit(node: _DocstringNode, parents: tuple[str, ...]) -> None:
+        text = ast.get_docstring(node, clean=True)
+        if text is not None:
+            owner = ".".join(parents) if parents else "<module>"
+            passages.append(
+                Passage(
+                    path=str(path),
+                    line=_docstring_line(node),
+                    kind="docstring",
+                    owner=owner,
+                    text=text,
+                )
+            )
+        for child in node.body:
+            if isinstance(child, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                visit(child, (*parents, child.name))
+
+    visit(tree, ())
+    return sorted(passages, key=lambda item: item.line)
+
+
+_IMAGE_RE = re.compile(r"!\[([^]]*)\]\([^)]*\)")
+_LINK_RE = re.compile(r"(?<!!)\[([^]]+)\]\([^)]*\)")
+_INLINE_CODE_RE = re.compile(r"`([^`]+)`")
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_LIST_RE = re.compile(r"^\s*(?:[-+*]|\d+[.)])\s+(.*)$")
+
+
+def _clean_markdown_inline(text: str) -> str:
+    text = _IMAGE_RE.sub("", text)
+    text = _LINK_RE.sub(r"\1", text)
+    text = _INLINE_CODE_RE.sub(r"\1", text)
+    text = _HTML_TAG_RE.sub(" ", text)
+    text = re.sub(r"[*_~]", "", text)
+    return " ".join(text.split())
+
+
+def extract_markdown(path: Path, source: str) -> list[Passage]:
+    """Return authored Markdown blocks while excluding literal code and math."""
+    passages: list[Passage] = []
+    paragraph: list[str] = []
+    paragraph_line = 0
+    fenced = False
+    math = False
+    front_matter = False
+    directive: str | None = None
+
+    def flush() -> None:
+        nonlocal paragraph, paragraph_line
+        if paragraph:
+            text = _clean_markdown_inline(" ".join(paragraph))
+            if text:
+                passages.append(Passage(str(path), paragraph_line, "markdown-prose", "<document>", text))
+        paragraph = []
+        paragraph_line = 0
+
+    for line_number, raw in enumerate(source.splitlines(), start=1):
+        stripped = raw.strip()
+        if line_number == 1 and stripped == "---":
+            front_matter = True
+            continue
+        if front_matter:
+            if stripped == "---":
+                front_matter = False
+            continue
+        myst = re.match(r"^```\{([^}]+)\}", stripped)
+        if myst and not fenced:
+            flush()
+            directive = myst.group(1).casefold() if myst.group(1).casefold() in {"figure", "image"} else None
+            fenced = directive is None
+            continue
+        if directive is not None and stripped == "```":
+            flush()
+            directive = None
+            continue
+        if stripped.startswith(("```", "~~~")):
+            flush()
+            fenced = not fenced
+            continue
+        if fenced:
+            continue
+        if directive is not None and stripped.startswith(":"):
+            option = re.match(r"^:([^:]+):\s*(.*)$", stripped)
+            if option and option.group(1).casefold() == "alt" and option.group(2):
+                passages.append(
+                    Passage(str(path), line_number, "markdown-alt", "<document>", option.group(2).strip())
+                )
+            continue
+        if stripped == "$$":
+            flush()
+            math = not math
+            continue
+        if math:
+            continue
+        if not stripped:
+            flush()
+            continue
+
+        for alt in _IMAGE_RE.findall(raw):
+            cleaned_alt = _clean_markdown_inline(alt)
+            if cleaned_alt:
+                passages.append(Passage(str(path), line_number, "markdown-alt", "<document>", cleaned_alt))
+        without_images = _IMAGE_RE.sub("", raw).strip()
+        if not without_images:
+            flush()
+            continue
+
+        heading = re.match(r"^#{1,6}\s+(.*)$", without_images)
+        if heading:
+            flush()
+            text = _clean_markdown_inline(heading.group(1))
+            passages.append(Passage(str(path), line_number, "markdown-heading", "<document>", text))
+            continue
+
+        listed = _LIST_RE.match(without_images)
+        if listed:
+            flush()
+            text = _clean_markdown_inline(listed.group(1))
+            if text:
+                passages.append(Passage(str(path), line_number, "markdown-list", "<document>", text))
+            continue
+
+        if without_images.startswith("|") and without_images.endswith("|"):
+            flush()
+            cells = [cell.strip() for cell in without_images.strip("|").split("|")]
+            if cells and not all(re.fullmatch(r":?-+:?", cell) for cell in cells):
+                text = "; ".join(_clean_markdown_inline(cell) for cell in cells if cell)
+                if text:
+                    passages.append(Passage(str(path), line_number, "markdown-table", "<document>", text))
+            continue
+
+        if without_images.startswith(">"):
+            flush()
+            text = _clean_markdown_inline(without_images.lstrip("> "))
+            if text:
+                passages.append(Passage(str(path), line_number, "markdown-quote", "<document>", text))
+            continue
+
+        if not paragraph:
+            paragraph_line = line_number
+        paragraph.append(without_images)
+
+    flush()
+    return sorted(passages, key=lambda item: (item.line, item.kind))
+
+
+class _VisibleHTMLParser(HTMLParser):
+    _SUPPRESSED_TAGS = {"script", "style", "nav", "pre", "code", "svg"}
+    _SUPPRESSED_CLASSES = {
+        "admonition-title",
+        "headerlink",
+        "highlight",
+        "related-pages",
+        "sidebar",
+        "sphinxsidebar",
+        "toc",
+    }
+
+    def __init__(self, path: Path) -> None:
+        super().__init__(convert_charrefs=True)
+        self.path = path
+        self.passages: list[Passage] = []
+        self._suppressed: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attributes = dict(attrs)
+        classes = set((attributes.get("class") or "").split())
+        suppress = tag in self._SUPPRESSED_TAGS or bool(classes & self._SUPPRESSED_CLASSES)
+        if self._suppressed or suppress:
+            self._suppressed.append(tag)
+            return
+        line, _ = self.getpos()
+        for attr, kind in (("alt", "html-alt"), ("aria-label", "html-aria")):
+            text = " ".join((attributes.get(attr) or "").split())
+            if text:
+                self.passages.append(Passage(str(self.path), line, kind, "<rendered>", text))
+
+    def handle_endtag(self, tag: str) -> None:
+        if self._suppressed:
+            self._suppressed.pop()
+
+    def handle_data(self, data: str) -> None:
+        if self._suppressed:
+            return
+        text = " ".join(data.split())
+        if text:
+            line, _ = self.getpos()
+            self.passages.append(Passage(str(self.path), line, "html-visible", "<rendered>", text))
+
+
+def extract_html(path: Path, source: str) -> list[Passage]:
+    """Return visible and accessibility prose from an HTML document."""
+    parser = _VisibleHTMLParser(path)
+    parser.feed(source)
+    parser.close()
+    return sorted(parser.passages, key=lambda item: (item.line, item.kind, item.text))

--- a/tools/prose_audit/rules.py
+++ b/tools/prose_audit/rules.py
@@ -1,0 +1,191 @@
+"""Named prose-pattern candidates derived from the two reviewed style guides."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+
+from . import Candidate, Passage
+
+
+@dataclass(frozen=True, slots=True)
+class _Rule:
+    rule_id: str
+    name: str
+    source: str
+    confidence: str
+    pattern: re.Pattern[str]
+
+
+def _rule(
+    rule_id: str,
+    name: str,
+    source: str,
+    confidence: str,
+    pattern: str,
+) -> _Rule:
+    return _Rule(rule_id, name, source, confidence, re.compile(pattern, re.IGNORECASE | re.MULTILINE))
+
+
+_HIGH_CONFIDENCE_RULES = (
+    _rule(
+        "throat-clearing",
+        "Throat-clearing opener",
+        "no-ai-slop + stop-slop",
+        "high",
+        r"(?:^|[.!?]\s+)(?:here(?:'|’)s (?:the thing|what|why)|let me be clear|the uncomfortable truth is|"
+        r"i(?:'|’)ll be honest|it turns out(?: that)?)\b",
+    ),
+    _rule(
+        "binary-contrast",
+        "Binary contrast",
+        "no-ai-slop + stop-slop",
+        "high",
+        r"\b(?:the (?:question|answer|problem) is(?:n(?:'|’)t| not)|it is(?:n(?:'|’)t| not)|"
+        r"not because)\b[^.!?]{0,140}[.!?,]\s*(?:it is|it(?:'|’)s|because)\b|"
+        r"\bnot just\b[^.!?]{0,100}\bbut(?: also)?\b",
+    ),
+    _rule(
+        "faux-insight",
+        "Faux-insight setup",
+        "no-ai-slop",
+        "high",
+        r"\b(?:what (?:most people|nobody) (?:get wrong|tell you)|the part (?:everyone|most people) (?:misses|skip))\b",
+    ),
+    _rule(
+        "importance-puffery",
+        "Importance puffery",
+        "no-ai-slop",
+        "high",
+        r"\b(?:marks? a pivotal moment|stands? as a testament|plays? a vital role|"
+        r"solidif(?:y|ies) its position|underscores? its significance|paramount|transformative)\b",
+    ),
+    _rule(
+        "weasel-attribution",
+        "Weasel attribution",
+        "no-ai-slop",
+        "high",
+        r"\b(?:experts agree|studies show|industry reports suggest|many argue|widely regarded as)\b",
+    ),
+    _rule(
+        "interpretive-metadiscourse",
+        "Interpretive metadiscourse",
+        "no-ai-slop",
+        "high",
+        r"\b(?:this distinction matters|that last part matters|the key point is|as you can see|"
+        r"this matters because|here(?:'|’)s why that matters)\b",
+    ),
+    _rule(
+        "vague-declaration",
+        "Vague declaration",
+        "stop-slop",
+        "high",
+        r"\b(?:the reasons are structural|the implications are significant|this is the deepest problem|"
+        r"the stakes are high|the consequences are real)\b",
+    ),
+    _rule(
+        "business-jargon",
+        "Generic business jargon",
+        "no-ai-slop + stop-slop",
+        "high",
+        r"\b(?:delve|foster|leverage|utilize|facilitate|empower|streamline|robust|cutting-edge|"
+        r"paradigm shift|game[ -]changer|tapestry|realm|beacon|multifaceted|meticulous|intricate|"
+        r"elevate|embark|supercharge|harness|ever-evolving|lean into|double down|deep dive)\b",
+    ),
+    _rule(
+        "dramatic-fragmentation",
+        "Dramatic fragmentation",
+        "no-ai-slop + stop-slop",
+        "high",
+        r"(?:\b[A-Z][A-Za-z-]+\.\s+){2,}[A-Z][A-Za-z-]+\.\s+that(?:'|’)s it\b|"
+        r"\bthat(?:'|’)s it\.\s+that(?:'|’)s the\b|"
+        r"(?:^|[.!?]\s+)and\s+[^.!?]{1,50}[.!?]\s+and\s+[^.!?]{1,50}[.!?]",
+    ),
+    _rule(
+        "colon-reveal",
+        "Colon reveal",
+        "no-ai-slop",
+        "high",
+        r"\b(?:the best part|the key point|the detail that makes it work|the answer|the result):\s+[a-z]",
+    ),
+    _rule(
+        "recap-ending",
+        "Summary-recap ending",
+        "no-ai-slop",
+        "high",
+        r"(?:^|\n\s*|[.!?]\s+)(?:in conclusion|ultimately|overall),",
+    ),
+)
+
+_REVIEW_SIGNAL_RULES = (
+    _rule(
+        "passive-voice",
+        "Possible passive voice",
+        "stop-slop",
+        "contextual",
+        r"\b(?:is|are|was|were|be|been|being)\s+(?:\w+ly\s+)?\w+(?:ed|en)\b",
+    ),
+    _rule(
+        "adverb",
+        "Possible empty adverb",
+        "stop-slop",
+        "contextual",
+        r"\b(?:really|just|literally|genuinely|honestly|simply|actually|deeply|truly|fundamentally|"
+        r"inherently|inevitably|interestingly|importantly|crucially|carefully)\b",
+    ),
+    _rule("em-dash", "Em-dash usage", "stop-slop", "contextual", r"—"),
+    _rule(
+        "wh-opener",
+        "Wh-word sentence opener",
+        "stop-slop",
+        "contextual",
+        r"(?:^|[.!?]\s+)(?:what|when|where|which|who|why|how)\b",
+    ),
+    _rule(
+        "three-item-list",
+        "Three-item list",
+        "stop-slop",
+        "contextual",
+        r"\b[^,.;\n]{1,50},\s+[^,.;\n]{1,50},\s+(?:and|or)\s+[^,.;\n]{1,50}[.!?]?",
+    ),
+    _rule(
+        "inanimate-agency",
+        "Possible inanimate agency",
+        "stop-slop",
+        "contextual",
+        r"\b(?:the (?:decision|data|market|conversation|culture)|a (?:complaint|bet))\s+"
+        r"(?:emerges?|tells?|rewards?|moves?|shifts?|becomes?|lives?|dies?)\b",
+    ),
+)
+
+
+def _evidence_for(text: str, match: re.Match[str]) -> str:
+    start = max(text.rfind("\n", 0, match.start()), text.rfind(". ", 0, match.start()))
+    start = 0 if start < 0 else start + (2 if text[start : start + 2] == ". " else 1)
+    endings = [index for token in (". ", "? ", "! ", "\n") if (index := text.find(token, match.end())) >= 0]
+    end = min(endings) + 1 if endings else len(text)
+    return " ".join(text[start:end].split())
+
+
+def find_candidates(passage: Passage) -> list[Candidate]:
+    """Return named candidates without adjudicating or rewriting the passage."""
+    candidates: list[Candidate] = []
+    seen: set[tuple[str, str]] = set()
+    for rule in (*_HIGH_CONFIDENCE_RULES, *_REVIEW_SIGNAL_RULES):
+        for match in rule.pattern.finditer(passage.text):
+            evidence = _evidence_for(passage.text, match)
+            key = (rule.rule_id, evidence.casefold())
+            if key in seen:
+                continue
+            seen.add(key)
+            candidates.append(
+                Candidate(
+                    passage=passage,
+                    rule_id=rule.rule_id,
+                    rule_name=rule.name,
+                    source=rule.source,
+                    confidence=rule.confidence,
+                    evidence=evidence,
+                )
+            )
+    return sorted(candidates, key=lambda item: (item.passage.line, item.rule_id, item.evidence.casefold()))


### PR DESCRIPTION
## Summary

- audit package docstrings, test contracts, Markdown guides, and rendered documentation for concrete prose problems without making authorship claims
- align the README, physics reference, cookbook, documentation home, and executed hello-chip example with `PhysicsExpr`, `EngineResult`, authored versus resolved Hamiltonians, local spaces, and native/eigen projection
- add a format-aware prose-audit command with inventory tests and a concise pull request template
- add a root changelog covering the upcoming 0.2.0 release and the 0.1.0/0.1.1 release history, with migration notes linked to the stacked pull requests

## Verification

- `.venv/bin/python -m pytest -q tests/examples/test_example_00.py` (7 passed), including clean notebook execution, strict Jupytext parity, result receipts, and image regression
- the Sphinx HTML build completed successfully; autodoc duplicate, offline intersphinx, and unlinked-document warnings remain
- `git diff --check` passed
- the example plots remained pixel-identical, so no plot assets changed
- changelog dates, links, API migrations, and extension signatures were checked against repository tags, live pull requests, and current source
- PR CI covers the full suite and the prose-audit tests

## Checklist

- [x] This pull request is focused and contains no unrelated changes.
- [x] Changed behavior is covered by tests, or no behavior changed.
- [x] Relevant documentation and examples are updated.
- [x] Generated files and paired notebooks are synchronized, if applicable.
- [x] `PHYSICS.md` is updated: it now documents `PhysicsExpr`, `EngineResult`, authored and resolved Hamiltonians, local spaces, basis resolution, and `projection_levels`.

## Stack

Current order: **#3 → #4 → #6 → #7 → #8 → #9**. This is the top PR, based on #8; review only the diff from `perf/reduce-engine-build-overhead`.

## AI assistance

AI assistance was used for the audit, implementation, verification, and editorial review. The contributor reviewed the changes and remains accountable for every claim and change.
