### PR TITLE
docs: unify modelling spelling and release prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This file records notable user-visible changes to quchip.
 
 - Inspect authored and solver-resolved physics as backend-neutral symbolic expressions without first evaluating a numerical matrix.
 - Choose explicit Fock, charge, phase-grid, or custom local spaces, with native or energy-eigenstate solver bases.
-- Extend devices, couplings, drives, envelopes, dissipation, local spaces, and classical signal transforms through tested public contracts.
+- Extend every part of the model, from custom devices to classical signal transforms, through tested public contracts.
 
 ### Physics and modelling
 
@@ -16,7 +16,7 @@ This file records notable user-visible changes to quchip.
 - Added `LocalSpace`, `FockSpace`, `ChargeSpace`, `PhaseGridSpace`, and `CustomSpace`. A chip or individual device can use its authored native basis or project into a retained local energy basis with `projection_levels`. [#6]
 - Basis resolution now transforms Hamiltonians, couplings, drives, pumps, states, observables, collapse operators, frames, and RWA bands through one engine-owned boundary. Native solving remains the default. [#6]
 - Added distinct inspection paths: `unresolved_hamiltonian()` preserves authored static physics, while `hamiltonian()` reports the canonical result after basis, frame, and RWA resolution. Sequence Hamiltonians also include scheduled drives. [#6]
-- Added declarative surfaces for custom devices, couplings, component-owned time dependence, drives, envelopes, scalar time coefficients, dissipation, local spaces, classical signal transforms, and interop mappings. Installed references exercise each supported path. [#10]
+- Added declarative surfaces for custom devices, couplings, component-owned time dependence, drives, envelopes, scalar time coefficients, dissipation, local spaces, classical signal transforms, and scqubits mappings. Installed references exercise each supported path. [#10]
 - Drives now map complete delivered analytic signals to quantum Hamiltonians through `hamiltonian(target, signal)`. Envelopes define local pulse shapes, while scheduling and `ControlEquipment` own carrier, phase, gain, delay, filtering, and crosstalk. [#10]
 - Added isolated and dressed transition queries through `device.transition_frequency(...)` and `chip.transition_frequency(...)`; `chip.freq(target)` remains the concise dressed `0 -> 1` query. [#10]
 
@@ -47,7 +47,7 @@ This file records notable user-visible changes to quchip.
 - Replace `ProblemBatch` and `BatchedHamiltonianDescription` with `SolveBatch` and the `QuantumSequence` batch APIs.
 - `CircuitDevice` is no longer public. Custom devices should declare an explicit `LocalSpace` through `BaseDevice` or `FockDevice`, as appropriate; built-in charge-basis and phase-grid devices use the same boundary.
 - Declarative methods receive the symbolic parameter namespace `p`. Custom models use `local_hamiltonian(op, p)`, `interaction(a, b, p)`, and `time_terms(...)` returning `TimeDependentTerm` values.
-- Replace Boolean `rwa=` arguments with the chip-level `approximation=RWA()` or `approximation=Exact()` strategy. `RWA(keep_bands=...)` supports an explicit structural band selection.
+- Replace Boolean and per-component `rwa=` arguments with the chip-level `approximation=RWA()` or `approximation=Exact()` strategy. `RWA(keep_bands=...)` supports an explicit structural band selection.
 - Replace `DriveChannel`, `DriveModulation`, and `DriveSignalSpec` with drive methods: implement `hamiltonian(target, signal)` and override `signal(pulse, target)` only when needed. The delivered signal exposes physical `signal.i` and `signal.q` quadratures after the classical signal chain.
 - Replace `EnvelopeShape` with `Envelope`. Custom envelopes implement `value(local_time)`; pulse timing, global phase, and carrier frequency belong to scheduling. In particular, move `Square.phase` to `QuantumSequence.schedule(..., phase=...)`.
 - Replace `Modulation` with component `time_terms(...)` returning `TimeDependentTerm` values and a `TimeCoefficient`, such as `CosineCoefficient`.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   <a href="https://docs.quchip.org"><img src="https://github.com/quchip/quchip/actions/workflows/docs.yml/badge.svg?branch=main" alt="Documentation build status"></a>
 </p>
 
-`quchip` is an open-source Python toolkit for modeling superconducting quantum chips.
+`quchip` is an open-source Python toolkit for modelling superconducting quantum chips.
 
 A predictive chip model needs more than a Hamiltonian: device physics, control-line transformations, frames and approximations, dissipation, and measured observables all belong to it. quchip represents each part explicitly. Line properties such as gain, delay, and crosstalk belong to the control chain, not to Hamiltonian terms written by hand.
 

--- a/RELEASE_NOTES_0.2.0.md
+++ b/RELEASE_NOTES_0.2.0.md
@@ -6,7 +6,7 @@ quchip 0.2.0 makes the physics assembled by the engine inspectable and gives cus
 
 - Inspect the model before and after engine resolution. `unresolved_hamiltonian()` preserves authored lab-frame physics, while `hamiltonian()` reports the basis-, frame-, and approximation-resolved expression used for simulation.
 - Author devices in Fock, charge, phase-grid, or custom local spaces. Use the native basis or project each device into a retained local energy basis without changing the attached couplings, drives, states, observables, or dissipation channels by hand.
-- Extend devices, couplings, component-owned time dependence, drives, envelopes, dissipation, local spaces, classical signal transforms, and scqubits mappings through documented contracts backed by installed reference implementations.
+- Extend devices, couplings, component-owned time dependence, drives, envelopes, scalar time coefficients, dissipation, local spaces, classical signal transforms, and scqubits mappings through documented contracts backed by installed reference implementations.
 - Query isolated or dressed transitions with `device.transition_frequency(...)` and `chip.transition_frequency(...)`, including conditional dressed transitions. `chip.freq(target)` remains the short form for the dressed `0 -> 1` transition.
 
 ## Control and approximation model

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@
 
 # Documentation
 
-`quchip` is an open-source Python toolkit for modeling superconducting quantum chips.
+`quchip` is an open-source Python toolkit for modelling superconducting quantum chips.
 
 A predictive chip model needs more than a Hamiltonian: device physics, control-line transformations, frames and approximations, dissipation, and measured observables all belong to it. quchip represents each part explicitly. Declare the chip once; the same declaration drives dressed-state analysis, model reduction, control sequencing, open-system simulation, parameter sweeps, and exact JAX gradients.
 

--- a/quchip/chip/couplings.py
+++ b/quchip/chip/couplings.py
@@ -235,7 +235,7 @@ class CrossKerr(CouplingModel):
     The effective diagonal interaction left when an exchange coupling is
     reduced in the dispersive regime — the natural coupling for effective
     readout chips (qubit + resonator + ``CrossKerr`` probed by an ordinary
-    charge line) and static-ZZ modeling. Diagonal in both endpoints, so the
+    charge line) and static-ZZ modelling. Diagonal in both endpoints, so the
     RWA and full forms coincide and the term is frame-trivial.
 
     Declared approximation: this is a *uniform-pull* model —

--- a/quchip/control/drive.py
+++ b/quchip/control/drive.py
@@ -403,7 +403,7 @@ class PhaseDrive(DeviceDrive):
     r"""Microwave phase drive coupling to :math:`\hat a + \hat a^\dagger`.
 
     Same carrier machinery as :class:`ChargeDrive` but with an
-    in-phase (rather than quadrature) coupling. Useful when modeling
+    in-phase (rather than quadrature) coupling. Useful when modelling
     phase-noise channels or drives whose physical coupling is already
     referenced to the field quadrature. See Krantz et al. 2019, Sec.
     IV.A for the two conventions.

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -264,7 +264,7 @@ def test_eliminate_purcell_survivor_without_thermal_population_folds_normally():
 
 
 def test_eliminate_purcell_survivor_with_thermal_population_raises():
-    """A Purcell fold onto a survivor that also carries thermal_population fails fast rather than mis-modeling."""
+    """A Purcell fold onto a survivor that also carries thermal_population fails fast rather than mis-modelling."""
     from quchip.chip.transformations import eliminate
 
     q = DuffingTransmon(


### PR DESCRIPTION
## Summary

Prose consistency pass over the 0.2.0 release documents. No behavior changes; two API docstrings and one test docstring change spelling only.

- Standardise on the double-l spelling of modelling across the README, the documentation home, the changelog, two docstrings, and one test docstring. The Didier et al. citation title in `quchip/devices/transmon/duffing.py` keeps its original spelling because it quotes a published title.
- Compress the duplicated extension-surface enumeration in the changelog highlights. The full list now appears once, in the Physics and modelling section, and matches the release notes item for item: both name scqubits mappings and include scalar time coefficients.
- Align the `rwa=` migration entry between the changelog and the release notes; both now say Boolean and per-component arguments.

## Verification

- `ruff check .`: all checks passed.
- `python -m mypy quchip tests/typing/external_declarative_models.py`: success, no issues in 109 source files.
- `python -m pytest tests/test_transformations.py`: 26 passed (the only test module touched; its change is one docstring).
- `python -m tools.prose_audit.cli` over the repository: no exact-pattern candidates in the changed files; the contextual candidates on touched lines are parameter enumerations and were reviewed and kept.
- `grep -rn modeling` over tracked sources: the only remaining single-l occurrence is the quoted citation title.

## Checklist

- [x] This pull request is focused and contains no unrelated changes.
- [x] Changed behavior is covered by tests, or no behavior changed.
- [x] Relevant documentation and examples are updated.
- [x] Generated files and paired notebooks are synchronized, if applicable.
- [x] `PHYSICS.md` is updated, or is not relevant: not relevant; the changes are spelling and release-notes prose, with no physics content.

## AI assistance

Prepared with AI assistance (Claude Code): the spelling sweep, changelog edits, prose audit, and verification runs. The maintainer reviewed every change.