### PR TITLE
fix: preserve traced crosstalk matrices

### DIFF
--- a/quchip/control/equipment.py
+++ b/quchip/control/equipment.py
@@ -296,6 +296,11 @@ class ControlEquipment:
         """
         order = tuple(line.label for line in self._lines) if labels is None else tuple(labels)
         n = len(order)
+        # Plain nested lists/tuples are accepted; traced arrays already carry a shape.
+        beta, theta, delay = (
+            np.asarray(matrix, dtype=float) if matrix is not None and not hasattr(matrix, "shape") else matrix
+            for matrix in (beta, theta, delay)
+        )
         # beta is required, so it is always shape-checked; theta and delay are
         # optional and validated only when provided.
         for name, matrix in (("beta", beta), ("theta", theta), ("delay", delay)):

--- a/quchip/control/equipment.py
+++ b/quchip/control/equipment.py
@@ -145,6 +145,22 @@ class CrosstalkMatrix(SignalTransform):
         )
 
 
+
+def _leaves(value: Any):
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _leaves(item)
+    else:
+        yield value
+
+
+def _as_matrix(matrix: Any) -> Any:
+    """Return *matrix* as an array; nested sequences are stacked, tracers preserved."""
+    if matrix is None or hasattr(matrix, "shape"):
+        return matrix
+    traced = any(_is_traced(leaf) for leaf in _leaves(matrix) if hasattr(leaf, "shape"))
+    return _select_array_module(traced).asarray(matrix, dtype=float)
+
 class ControlEquipment:
     """Ordered drive lines plus a sequence of signal-chain transforms.
 
@@ -296,11 +312,10 @@ class ControlEquipment:
         """
         order = tuple(line.label for line in self._lines) if labels is None else tuple(labels)
         n = len(order)
-        # Plain nested lists/tuples are accepted; traced arrays already carry a shape.
-        beta, theta, delay = (
-            np.asarray(matrix, dtype=float) if matrix is not None and not hasattr(matrix, "shape") else matrix
-            for matrix in (beta, theta, delay)
-        )
+        # Plain nested lists/tuples are accepted; arrays and tracers already carry
+        # a shape and pass through untouched. A list holding traced leaves is
+        # stacked with jax.numpy so no tracer is ever concretised.
+        beta, theta, delay = (_as_matrix(matrix) for matrix in (beta, theta, delay))
         # beta is required, so it is always shape-checked; theta and delay are
         # optional and validated only when provided.
         for name, matrix in (("beta", beta), ("theta", theta), ("delay", delay)):

--- a/tests/test_crosstalk_matrix.py
+++ b/tests/test_crosstalk_matrix.py
@@ -219,8 +219,32 @@ def test_set_crosstalk_matrix_accepts_nested_lists():
     xy1, xy2 = ChargeDrive(target=q1), ChargeDrive(target=q2)
     eq = ControlEquipment([xy1, xy2])
     eq.set_crosstalk_matrix([[1, 0.14], [0.16, 1]], [[0, 1.885], [3.31, 0]])
-    chip = Chip([q1, q2], couplings=[Capacitive(q1, q2, g=0.01)], control_equipment=eq, frame="rotating", approximation=RWA())
+    chip = Chip(
+        [q1, q2],
+        couplings=[Capacitive(q1, q2, g=0.01)],
+        control_equipment=eq,
+        frame="rotating",
+        approximation=RWA(),
+    )
     (matrix,) = chip.control_equipment.signal_chain
     assert matrix.beta.shape == (2, 2)
     assert float(matrix.beta[0, 1]) == 0.14
     assert float(matrix.theta[1, 0]) == 3.31
+
+
+def test_set_crosstalk_matrix_list_with_traced_entry_is_differentiable():
+    import jax
+    import jax.numpy as jnp
+    from quchip import ChargeDrive, DuffingTransmon
+    from quchip.control.equipment import ControlEquipment
+
+    q1 = DuffingTransmon(freq=5.3, anharmonicity=-0.26, levels=3)
+    q2 = DuffingTransmon(freq=5.2, anharmonicity=-0.26, levels=3)
+
+    def leak(b):
+        eq = ControlEquipment([ChargeDrive(target=q1), ChargeDrive(target=q2)])
+        eq.set_crosstalk_matrix([[1.0, b], [0.16, 1.0]])
+        (matrix,) = eq.signal_chain
+        return jnp.sum(matrix.beta)
+
+    assert float(jax.grad(leak)(jnp.asarray(0.14))) == 1.0

--- a/tests/test_crosstalk_matrix.py
+++ b/tests/test_crosstalk_matrix.py
@@ -208,3 +208,19 @@ def test_crosstalk_matrix_rejects_wrong_shape() -> None:
     _, equip, *_ = _build_two_drive_chip()
     with pytest.raises(ValueError):
         equip.set_crosstalk_matrix(np.zeros((3, 3)))
+
+
+def test_set_crosstalk_matrix_accepts_nested_lists():
+    from quchip import Capacitive, Chip, ChargeDrive, DuffingTransmon, RWA
+    from quchip.control.equipment import ControlEquipment
+
+    q1 = DuffingTransmon(freq=5.3, anharmonicity=-0.26, levels=3)
+    q2 = DuffingTransmon(freq=5.2, anharmonicity=-0.26, levels=3)
+    xy1, xy2 = ChargeDrive(target=q1), ChargeDrive(target=q2)
+    eq = ControlEquipment([xy1, xy2])
+    eq.set_crosstalk_matrix([[1, 0.14], [0.16, 1]], [[0, 1.885], [3.31, 0]])
+    chip = Chip([q1, q2], couplings=[Capacitive(q1, q2, g=0.01)], control_equipment=eq, frame="rotating", approximation=RWA())
+    (matrix,) = chip.control_equipment.signal_chain
+    assert matrix.beta.shape == (2, 2)
+    assert float(matrix.beta[0, 1]) == 0.14
+    assert float(matrix.theta[1, 0]) == 3.31


### PR DESCRIPTION
## Summary

- Accept nested Python lists in `ControlEquipment.set_crosstalk_matrix()`.
- Stack list rows with the active array namespace so JAX tracers are not converted to NumPy.
- Cover ordinary nested lists and traced list-valued matrices with regression tests.

## Verification

- `.venv/bin/pytest -q tests/test_crosstalk_matrix.py` — 11 passed.
- `.venv/bin/ruff check quchip/control/equipment.py tests/test_crosstalk_matrix.py` — passed.
- Included in the final stack verification: 69 focused tests passed.

## Checklist

- [x] This pull request is focused and contains no unrelated changes.
- [x] Changed behavior is covered by tests.
- [x] Documentation and examples are not affected by this input-normalization fix.
- [x] No generated files or paired notebooks change in this layer.
- [x] `PHYSICS.md` is not relevant; the physical crosstalk model is unchanged.

## AI assistance

AI assistance was used to inspect, format, and verify this change. The author remains accountable for the implementation and claims.
