### PR TITLE
Accelerate static QuTiP evolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Declare the chip once, then use the same model for dressed-state analysis, model
   <img src="https://raw.githubusercontent.com/quchip/quchip/main/docs/images/quchip_pipeline_light.png" alt="quchip pipeline from declared devices and control parameters through model resolution, simulation, observables, and gradients" width="1084">
 </picture>
 
-QuTiP is the default simulation backend. The optional dynamiqs backend is JAX-native and keeps declared device and control parameters differentiable through a solve. The scqubits integration imports and exports selected device and composite models.
+QuTiP is the default simulation backend. The optional dynamiqs backend is JAX-native and keeps declared device and control parameters differentiable through a solve. The [backend guide](https://docs.quchip.org/guides/choosing-a-backend.html) compares their numerical and workflow tradeoffs. The scqubits integration imports and exports selected device and composite models.
 
 `quchip` uses GHz for ordinary frequencies, ns for time, and mK for temperature. The implemented conventions and approximations are documented in the [physics guide](https://docs.quchip.org/physics).
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -233,13 +233,15 @@ for a closed model and `mesolve` when devices, drives, couplings, or baths
 contribute collapse channels. Adding a resonator quality factor or a bath can
 therefore change the equation without changing the pulse schedule.
 
-For a time-independent QuTiP problem with no explicit solver method or step
-control, quchip uses diagonal propagation at all requested save times when the
-total Hilbert dimension is at most 64 for `sesolve`, or at most 12 for
-`mesolve` (whose Liouvillian dimension is the square of the Hilbert dimension).
-Driven problems, larger spaces, and explicit method or step options keep
-QuTiP's selected adaptive integrator. For dynamiqs, method selection remains
-explicit through `options={"method": ...}`; its default is `Tsit5`.
+For a time-independent QuTiP problem with no explicit solver method, quchip
+uses diagonal propagation at all requested save times when the total Hilbert
+dimension is at most 64 for `sesolve`, or at most 12 for `mesolve` (whose
+Liouvillian dimension is the square of the Hilbert dimension). `diag` does not
+use adaptive tolerances or step controls, so quchip removes `atol`, `rtol`,
+`nsteps`, and `max_step` and logs the discarded options at `INFO` level. Driven
+problems, larger spaces, and an explicit non-`diag` method keep QuTiP's selected
+adaptive integrator. For dynamiqs, method selection remains explicit through
+`options={"method": ...}`; its default is `Tsit5`.
 
 See {doc}`Backend and solver options <guides/choosing-a-backend>` for available
 methods, option syntax, batching, and gradient controls.

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -233,9 +233,16 @@ for a closed model and `mesolve` when devices, drives, couplings, or baths
 contribute collapse channels. Adding a resonator quality factor or a bath can
 therefore change the equation without changing the pulse schedule.
 
-Use the dynamiqs backend when a calculation needs JAX differentiation through
-the solve. Keep graph structure, Hilbert dimensions, and approximation masks
-fixed while tracing.
+For a time-independent QuTiP problem with no explicit solver method or step
+control, quchip uses diagonal propagation at all requested save times when the
+total Hilbert dimension is at most 64 for `sesolve`, or at most 12 for
+`mesolve` (whose Liouvillian dimension is the square of the Hilbert dimension).
+Driven problems, larger spaces, and explicit method or step options keep
+QuTiP's selected adaptive integrator. For dynamiqs, method selection remains
+explicit through `options={"method": ...}`; its default is `Tsit5`.
+
+See {doc}`Backend and solver options <guides/choosing-a-backend>` for available
+methods, option syntax, batching, and gradient controls.
 
 ## Read results at the level of the question
 

--- a/docs/guides/choosing-a-backend.md
+++ b/docs/guides/choosing-a-backend.md
@@ -1,0 +1,233 @@
+# Backend and solver options
+
+quchip can run the same resolved model through
+[QuTiP](https://github.com/qutip/qutip) or
+[dynamiqs](https://github.com/dynamiqs/dynamiqs). Both receive the same
+declared devices, controls, frame, approximation, collapse channels, and
+observables; each supplies its own numerical implementation.
+
+## Select a backend
+
+QuTiP is installed with quchip and is the default:
+
+```python
+chip = Chip(devices, couplings, backend="qutip")
+```
+
+Install the dynamiqs extra before selecting its backend:
+
+```bash
+python -m pip install 'quchip[dynamiqs]'
+```
+
+```python
+chip = Chip(devices, couplings, backend="dynamiqs")
+```
+
+A sequence can use either backend for one call without rebuilding the chip:
+
+```python
+qutip_result = sequence.simulate(tlist=times, backend="qutip")
+dynamiqs_result = sequence.simulate(tlist=times, backend="dynamiqs")
+```
+
+Compare the two results when an observable needs a numerical cross-check.
+
+## Choose the equation
+
+The `solver` argument selects the equation. Leaving it unset follows the
+declared model:
+
+| Model | Automatic solver | Evolved object |
+|---|---|---|
+| No collapse channels | `sesolve` | State vector $|\psi\rangle$ |
+| One or more collapse channels | `mesolve` | Density matrix $\rho$ under the Lindblad master equation |
+
+Both backends implement both equations. Set `solver="mesolve"` explicitly when
+a density-matrix calculation is needed without collapse channels. Setting
+`solver="sesolve"` explicitly on a model with collapse channels leaves those
+channels out of the evolution.
+
+```python
+result = sequence.simulate(
+    tlist=times,
+    solver="mesolve",
+    backend="qutip",
+)
+```
+
+## Pick from the calculation
+
+| Calculation | Available route |
+|---|---|
+| One closed- or open-system solve | QuTiP or dynamiqs |
+| Long evolution under a small constant generator | QuTiP's automatic `diag` method |
+| Large sparse constant closed system | QuTiP's `krylov` method |
+| Non-stiff time-dependent equation | QuTiP adaptive methods or dynamiqs `Tsit5`/`Dopri5`/`Dopri8` |
+| Stiff equation | QuTiP `bdf`/`lsoda` or dynamiqs `Kvaerno3`/`Kvaerno5` |
+| Homogeneous parameter or pulse batch | dynamiqs native vectorized batch or QuTiP process-parallel batch |
+| Heterogeneous problem list | QuTiP process-parallel solves |
+| JAX gradient, `jit`, or accelerator execution | dynamiqs |
+| Master-equation integration with a Rouchon scheme | dynamiqs `Rouchon1`/`Rouchon2`/`Rouchon3` |
+
+## QuTiP methods
+
+QuTiP receives its method as a string in `options`:
+
+```python
+result = sequence.simulate(
+    tlist=times,
+    backend="qutip",
+    options={
+        "method": "vern9",
+        "rtol": 1e-9,
+        "atol": 1e-11,
+        "nsteps": 100_000,
+        "max_step": 0.5,
+    },
+)
+```
+
+`rtol` and `atol` control the adaptive error estimate. `nsteps` caps the number
+of internal steps. `max_step` limits each internal step in ns. The save grid in
+`tlist` controls where results are returned; the method chooses its internal
+steps separately.
+
+| `method` | How it works | What it enables |
+|---|---|---|
+| `adams` | Adaptive multistep method for non-stiff ODEs; QuTiP's default | General closed- and open-system evolution |
+| `bdf` | Implicit adaptive multistep method | Stiff equations with separated time scales |
+| `lsoda` | Switches between Adams and BDF | Problems whose stiffness is not known in advance |
+| `dop853` | Eighth-order explicit Dormand-Prince method | High-accuracy non-stiff evolution |
+| `vern7`, `vern9` | Seventh- and ninth-order explicit Runge-Kutta methods with dense output | High-accuracy trajectories with many save times |
+| `tsit5` | Fifth-order explicit Runge-Kutta method | A lower-order adaptive alternative |
+| `diag` | Diagonalizes a constant Hamiltonian or Liouvillian once, then evaluates the propagator at each save time | Long constant evolution without stepping across the full interval |
+| `krylov` | Applies an approximate exponential in a Krylov subspace | Large sparse, constant `sesolve` problems |
+
+For a constant problem, quchip selects `diag` automatically when:
+
+- the user did not set `method`, `nsteps`, or `max_step`;
+- the resolved Hamiltonian has no time-dependent terms; and
+- the total Hilbert dimension is at most 64 for `sesolve`, or at most 12 for
+  `mesolve`.
+
+The open-system propagator acts on a $d^2$-dimensional vectorized density
+matrix, so its dense diagonalization reaches the practical cap sooner. An
+explicit method or step option always takes precedence over the automatic
+choice.
+
+For a finite pulse inside a long idle interval, quchip derives a QuTiP
+`max_step` from the narrowest pulse window when the user has not supplied one.
+This prevents the adaptive solver from stepping across the pulse without
+sampling it.
+
+`simulate_batch()` uses reusable worker processes for QuTiP batches. Small
+batches stay in the calling process; larger batches distribute independent
+solves across CPU processes.
+
+## dynamiqs methods
+
+dynamiqs receives a method object. Put tolerances and the step budget on that
+object:
+
+```python
+import dynamiqs as dq
+
+result = sequence.simulate(
+    tlist=times,
+    backend="dynamiqs",
+    options={
+        "method": dq.method.Dopri8(
+            rtol=1e-9,
+            atol=1e-11,
+            max_steps=100_000,
+        ),
+    },
+)
+```
+
+| Method object | How it works | What it enables |
+|---|---|---|
+| `dq.method.Tsit5(...)` | Fifth-order explicit adaptive Runge-Kutta method; dynamiqs' default | General differentiable closed- and open-system evolution |
+| `dq.method.Dopri5(...)` | Fifth-order explicit adaptive Dormand-Prince method | An alternative error estimator for non-stiff equations |
+| `dq.method.Dopri8(...)` | Eighth-order explicit adaptive Dormand-Prince method | High-accuracy non-stiff evolution |
+| `dq.method.Kvaerno3(...)`, `Kvaerno5(...)` | Third- or fifth-order implicit adaptive method | Stiff Hamiltonians and Liouvillians |
+| `dq.method.Euler(dt=...)` | First-order fixed-step method | A fixed-grid reference calculation |
+| `dq.method.Rouchon1(dt=...)` | First-order fixed-step master-equation method | `mesolve` with an explicit time step and optional trace normalization |
+| `dq.method.Rouchon2(...)`, `Rouchon3(...)` | Second- or third-order master-equation methods; adaptive by default or fixed-step when `dt` is set | Higher-order Rouchon integration for open systems |
+
+If no method is supplied, quchip leaves dynamiqs on its `Tsit5` default and
+derives a `max_steps` budget. `max_steps` caps the number of internal steps. A
+hard step-size constraint requires a fixed-step method where applicable,
+schedule segmentation, or comparison with a refined calculation.
+
+dynamiqs solves run inside JAX. The first call for a new static structure and
+array shape compiles; later calls with the same structure can reuse the
+compiled solve. `simulate_batch()` stacks a structurally homogeneous batch and
+runs one native vectorized solve. A configured JAX installation determines
+whether execution uses CPU, GPU, or another accelerator.
+
+The default gradient mode supports reverse-mode differentiation such as
+`jax.grad`. Forward mode is available for `jax.jacfwd` and JVP calculations:
+
+```python
+result = sequence.simulate(
+    tlist=times,
+    backend="dynamiqs",
+    options={
+        "method": dq.method.Tsit5(rtol=1e-8, atol=1e-10),
+        "gradient": dq.gradient.Forward(),
+    },
+)
+```
+
+Keep graph structure, Hilbert dimensions, the number of Hamiltonian terms, and
+the number of collapse channels fixed across a compiled optimization loop or
+native batch.
+
+## Options shared by both backends
+
+```python
+result = sequence.simulate(
+    tlist=times,
+    backend=backend_name,
+    options={
+        "store_states": False,
+        "progress_bar": False,
+        "nsteps": 100_000,
+    },
+    e_ops=chip.e_ops(q="n"),
+)
+```
+
+| Option | Effect |
+|---|---|
+| `store_states` | Store or omit the state at every save time; expectation traces can be collected through `e_ops` without retaining the full trajectory |
+| `progress_bar` | Enable or disable progress reporting; quchip maps this to dynamiqs' `progress_meter` name |
+| `nsteps` | Set the internal-step ceiling; quchip maps this to dynamiqs' `max_steps` name |
+| `method` | Select a backend-native integrator: a string for QuTiP, a method object for dynamiqs |
+
+Pass the backend through the `backend=` argument. The `options` dictionary is
+reserved for the selected solver library.
+
+## Frames affect both backends
+
+Both backends solve the same engine result. A frame change can still change the
+numerical problem. A rotating frame may remove fast diagonal evolution, while
+rotating an interaction band can make that band explicitly time-dependent.
+
+```python
+resolved = chip.resolve()
+print(resolved.resolved_frame)
+print(len(resolved.dynamic_terms))
+```
+
+Automatic QuTiP diagonal propagation requires zero dynamic terms. Adaptive
+methods in either backend can also take fewer internal steps when the selected
+frame removes fast oscillations.
+
+## Check the result
+
+Compare the reported observable at two tolerance or step settings, check
+Hilbert-space truncation, and run both backends when they support the chosen
+workflow.

--- a/docs/guides/choosing-a-backend.md
+++ b/docs/guides/choosing-a-backend.md
@@ -106,15 +106,16 @@ steps separately.
 
 For a constant problem, quchip selects `diag` automatically when:
 
-- the user did not set `method`, `nsteps`, or `max_step`;
+- the user did not select another `method`;
 - the resolved Hamiltonian has no time-dependent terms; and
 - the total Hilbert dimension is at most 64 for `sesolve`, or at most 12 for
   `mesolve`.
 
 The open-system propagator acts on a $d^2$-dimensional vectorized density
 matrix, so its dense diagonalization reaches the practical cap sooner. An
-explicit method or step option always takes precedence over the automatic
-choice.
+explicit non-`diag` method always takes precedence. `diag` does not use
+adaptive tolerances or step controls, so quchip removes `atol`, `rtol`,
+`nsteps`, and `max_step` and records that choice at `INFO` level.
 
 For a finite pulse inside a long idle interval, quchip derives a QuTiP
 `max_step` from the narrowest pulse window when the user has not supplied one.

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,11 +30,16 @@ pip install quchip
 
 Optional extras: `quchip[dynamiqs]` for the JAX-native backend, `quchip[viz]` for graph visualization, `quchip[scqubits]` for scqubits interoperability.
 
+The {doc}`backend guide <guides/choosing-a-backend>` shows how to select QuTiP
+or dynamiqs, choose an integration method, and set tolerances, step controls,
+batching, and gradients.
+
 ## Start with a physical question
 
 The guides begin with a small runnable calculation and add one idea at a time:
 
 - {doc}`Define and inspect a chip <guides/defining-and-inspecting-a-chip>`
+- {doc}`Backend and solver options <guides/choosing-a-backend>`
 - {doc}`Statics and parameter studies <guides/statics-and-parameter-studies>`
 - {doc}`Dynamics, pulses, observables, and readout <guides/dynamics-pulses-and-readout>`
 - {doc}`Chip transformations <guides/chip-transformations>`
@@ -68,6 +73,7 @@ The accompanying paper is [quchip: A Differentiable Toolkit for Modeling Quantum
 
 guides/from-sqa-2026
 guides/defining-and-inspecting-a-chip
+guides/choosing-a-backend
 guides/statics-and-parameter-studies
 guides/dynamics-pulses-and-readout
 guides/chip-transformations

--- a/quchip/backend/protocol.py
+++ b/quchip/backend/protocol.py
@@ -653,6 +653,25 @@ class Backend(ABC):
         """
         return dict(options)
 
+    def _resolve_automatic_solver_options(
+        self,
+        options: dict[str, Any],
+        *,
+        user_options: dict[str, Any],
+        engine_result: "EngineResult",
+        solver_name: str,
+        tlist: Any,
+    ) -> dict[str, Any]:
+        """Select a backend-native fast path when the assembled problem is eligible.
+
+        The protocol default preserves the resolved options. Concrete backends
+        may use the engine result's static structure and fixed Hilbert-space
+        dimensions to select a native constant-generator method. Physics values
+        must not be concretized here.
+        """
+        _ = user_options, engine_result, solver_name, tlist
+        return dict(options)
+
     def coerce_state(self, state: State, dims: tuple[int, ...] | None = None) -> State:
         """Convert a foreign-native *state* into this backend's native form.
 
@@ -763,10 +782,11 @@ class Backend(ABC):
             c_ops = self._collapse_operators(problem.engine_result)
             solver_name = problem.solver or ("mesolve" if c_ops else "sesolve")
             solver_names.append(solver_name)
-            opts = self._merge_options(
-                problem.options,
+            opts = self._resolve_problem_options(
+                problem,
                 metadata=problem.engine_result.metadata,
                 tlist=tlist_arr,
+                solver_name=solver_name,
             )
             dict_problems.append(
                 self._element_solver_kwargs(
@@ -851,6 +871,24 @@ class Backend(ABC):
         merged.update(user_options)
         return self.resolve_solver_options(merged, metadata=metadata, tlist=tlist)
 
+    def _resolve_problem_options(
+        self,
+        problem: Any,
+        *,
+        metadata: dict[str, Any],
+        tlist: Any,
+        solver_name: str,
+    ) -> dict[str, Any]:
+        """Merge options and apply one backend-owned automatic-method decision."""
+        resolved = self._merge_options(problem.options, metadata=metadata, tlist=tlist)
+        return self._resolve_automatic_solver_options(
+            resolved,
+            user_options=problem.options,
+            engine_result=problem.engine_result,
+            solver_name=solver_name,
+            tlist=tlist,
+        )
+
     def _resolve_solve_config(
         self,
         problem: Any,
@@ -872,7 +910,12 @@ class Backend(ABC):
         tlist_arr = self.array_module.asarray(problem.tlist, dtype=float)
         c_ops = self._collapse_operators(engine_result)
         solver_name = problem.solver or ("mesolve" if c_ops else "sesolve")
-        opts = self._merge_options(problem.options, metadata=prepared.metadata, tlist=tlist_arr)
+        opts = self._resolve_problem_options(
+            problem,
+            metadata=prepared.metadata,
+            tlist=tlist_arr,
+            solver_name=solver_name,
+        )
         e_ops_arg = problem.e_ops if isinstance(problem.e_ops, list) else None
         return tlist_arr, c_ops, solver_name, opts, e_ops_arg
 

--- a/quchip/backend/qutip.py
+++ b/quchip/backend/qutip.py
@@ -17,6 +17,7 @@ References
 
 from __future__ import annotations
 
+import math
 import os
 import warnings
 from dataclasses import dataclass
@@ -239,6 +240,11 @@ def _sample_coeff_array(signal: Any, sample_tlist: Any) -> np.ndarray:
 # envelope has no discontinuity to ring across and keeps the default cubic
 # order (unspecified below).
 _WINDOWED_COEFFICIENT_ORDER = 1
+
+# QuTiP's diagonal integrator materializes a dense d x d Hamiltonian or
+# d^2 x d^2 Liouvillian. These measured caps keep that setup bounded.
+_MAX_STATIC_HILBERT_DIM = 64
+_MAX_STATIC_LIOUVILLIAN_HILBERT_DIM = 12
 
 
 def _envelope_coefficient(envelope: Any, sample_tlist: Any) -> Any:
@@ -697,6 +703,35 @@ class QuTiPBackend(Backend):
         resolved.pop("gradient", None)
         return resolved
 
+    def _resolve_automatic_solver_options(
+        self,
+        options: dict[str, Any],
+        *,
+        user_options: dict[str, Any],
+        engine_result: Any,
+        solver_name: str,
+        tlist: Any,
+    ) -> dict[str, Any]:
+        """Select QuTiP's diagonal propagator for small constant generators."""
+        _ = tlist
+        resolved = dict(options)
+        if {"method", "nsteps", "max_step"} & user_options.keys() or engine_result.dynamic_terms:
+            return resolved
+
+        dimension = math.prod(engine_result.dims)
+        limit = (
+            _MAX_STATIC_HILBERT_DIM
+            if solver_name == "sesolve"
+            else _MAX_STATIC_LIOUVILLIAN_HILBERT_DIM
+        )
+        if dimension > limit:
+            return resolved
+
+        resolved["method"] = "diag"
+        resolved.pop("nsteps", None)
+        resolved.pop("max_step", None)
+        return resolved
+
     _default_nsteps = staticmethod(default_solver_steps)
 
     def coerce_state(self, state: State, dims: tuple[int, ...] | None = None) -> State:
@@ -920,10 +955,11 @@ class QuTiPBackend(Backend):
             engine_result = problem.engine_result
             c_ops = self._collapse_operators(engine_result)
             solver_name = problem.solver or ("mesolve" if c_ops else "sesolve")
-            opts = self._merge_options(
-                problem.options,
+            opts = self._resolve_problem_options(
+                problem,
                 metadata=engine_result.metadata,
                 tlist=tlist_arr,
+                solver_name=solver_name,
             )
             tasks.append(
                 _QuTiPBatchTask(

--- a/quchip/backend/qutip.py
+++ b/quchip/backend/qutip.py
@@ -17,6 +17,7 @@ References
 
 from __future__ import annotations
 
+import logging
 import math
 import os
 import warnings
@@ -51,6 +52,9 @@ from quchip.engine.ir import (
     signal_children,
 )
 from quchip.utils.jax_utils import maybe_concrete_scalar
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -715,7 +719,21 @@ class QuTiPBackend(Backend):
         """Select QuTiP's diagonal propagator for small constant generators."""
         _ = tlist
         resolved = dict(options)
-        if {"method", "nsteps", "max_step"} & user_options.keys() or engine_result.dynamic_terms:
+
+        adaptive_options = {"atol", "rtol", "nsteps", "max_step"}
+        explicit_method = user_options.get("method")
+        if explicit_method == "diag":
+            discarded = adaptive_options & user_options.keys()
+            for key in adaptive_options:
+                resolved.pop(key, None)
+            if discarded:
+                _LOGGER.info(
+                    "Explicit QuTiP method='diag' discarded unsupported adaptive options: %s.",
+                    ", ".join(sorted(discarded)),
+                )
+            return resolved
+
+        if explicit_method is not None or engine_result.dynamic_terms:
             return resolved
 
         dimension = math.prod(engine_result.dims)
@@ -727,9 +745,16 @@ class QuTiPBackend(Backend):
         if dimension > limit:
             return resolved
 
+        discarded = adaptive_options & user_options.keys()
+        for key in adaptive_options:
+            resolved.pop(key, None)
+        if discarded:
+            _LOGGER.info(
+                "Automatic QuTiP method='diag' discarded unsupported adaptive options: %s.",
+                ", ".join(sorted(discarded)),
+            )
+
         resolved["method"] = "diag"
-        resolved.pop("nsteps", None)
-        resolved.pop("max_step", None)
         return resolved
 
     _default_nsteps = staticmethod(default_solver_steps)

--- a/tests/test_static_propagator_selection.py
+++ b/tests/test_static_propagator_selection.py
@@ -88,15 +88,52 @@ class TestQuTiPStaticPropagatorSelection:
 
         assert options["method"] == "adams"
 
-    @pytest.mark.parametrize("step_option", [{"nsteps": 17}, {"max_step": 0.01}])
-    def test_explicit_step_control_suppresses_automatic_method(self, step_option: dict) -> None:
-        """Explicit QuTiP step controls should retain the adaptive integrator that consumes them."""
-        backend, problem = _static_problem("qutip", options=step_option)
+    def test_explicit_diagonalization_discards_adaptive_tolerances(self) -> None:
+        """Explicit diagonal propagation should discard tolerances that its QuTiP integrator cannot consume."""
+        backend, problem = _static_problem(
+            "qutip",
+            options={"method": "diag", "atol": 1e-10, "rtol": 1e-8},
+        )
 
         options = _resolved_options(backend, problem)
 
-        assert "method" not in options
-        assert all(options[key] == value for key, value in step_option.items())
+        assert options["method"] == "diag"
+        assert "atol" not in options
+        assert "rtol" not in options
+
+    def test_automatic_diagonalization_discards_adaptive_tolerances(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Automatic diagonal propagation should discard inapplicable tolerances and explain that choice."""
+        backend, problem = _static_problem(
+            "qutip",
+            options={"atol": 1e-10, "rtol": 1e-8},
+        )
+
+        with caplog.at_level("INFO", logger="quchip.backend.qutip"):
+            options = _resolved_options(backend, problem)
+
+        assert options["method"] == "diag"
+        assert "atol" not in options
+        assert "rtol" not in options
+        assert "discarded unsupported adaptive options: atol, rtol" in caplog.text
+
+    @pytest.mark.parametrize("step_option", [{"nsteps": 17}, {"max_step": 0.01}])
+    def test_automatic_diagonalization_discards_adaptive_step_control(
+        self,
+        step_option: dict,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Automatic diagonal propagation should discard step controls that have no diagonal equivalent."""
+        backend, problem = _static_problem("qutip", options=step_option)
+
+        with caplog.at_level("INFO", logger="quchip.backend.qutip"):
+            options = _resolved_options(backend, problem)
+
+        assert options["method"] == "diag"
+        assert not step_option.keys() & options.keys()
+        assert "discarded unsupported adaptive options" in caplog.text
 
     def test_driven_problem_retains_adaptive_integrator(self) -> None:
         """Any explicit Hamiltonian time dependence should keep QuTiP's adaptive integrator."""

--- a/tests/test_static_propagator_selection.py
+++ b/tests/test_static_propagator_selection.py
@@ -1,0 +1,130 @@
+"""Automatic constant-generator solver selection at the backend boundary."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from quchip import ChargeDrive, Chip, DuffingTransmon, QuantumSequence, Square
+from quchip.engine import build_problem
+
+
+def _static_problem(
+    backend: str,
+    *,
+    levels: int = 3,
+    T1: float | None = None,
+    points: int = 3,
+    options: dict | None = None,
+):
+    qubit = DuffingTransmon(
+        freq=5.0,
+        anharmonicity=-0.25,
+        levels=levels,
+        label="q",
+        T1=T1,
+    )
+    chip = Chip([qubit], frame="lab", backend=backend)
+    problem = build_problem(
+        chip,
+        [],
+        np.linspace(0.0, 1.0, points),
+        options=options,
+    )
+    return chip.backend, problem
+
+
+def _resolved_options(backend, problem) -> dict:
+    prepared = backend.prepare_hamiltonian(problem.engine_result, problem.tlist)
+    return backend._resolve_solve_config(problem, prepared)[3]
+
+
+class TestQuTiPStaticPropagatorSelection:
+    """QuTiP should diagonalize only eligible constant generators."""
+
+    def test_small_static_closed_problem_selects_diagonalization(self) -> None:
+        """A closed static Hilbert space through dimension 64 should select QuTiP's diagonal propagator."""
+        backend, problem = _static_problem("qutip", levels=64)
+
+        options = _resolved_options(backend, problem)
+
+        assert options["method"] == "diag"
+        assert "nsteps" not in options
+        assert "max_step" not in options
+
+    def test_small_static_open_problem_selects_liouvillian_diagonalization(self) -> None:
+        """A static dissipative Hilbert space through dimension 12 should diagonalize its Liouvillian."""
+        backend, problem = _static_problem("qutip", levels=12, T1=20.0)
+
+        options = _resolved_options(backend, problem)
+
+        assert options["method"] == "diag"
+        assert "nsteps" not in options
+        assert "max_step" not in options
+
+    @pytest.mark.parametrize(
+        ("levels", "T1"),
+        [(65, None), (13, 20.0)],
+        ids=["closed-above-limit", "open-above-limit"],
+    )
+    def test_large_static_problem_retains_adaptive_integrator(
+        self,
+        levels: int,
+        T1: float | None,
+    ) -> None:
+        """Static generators above their dimension limit should retain QuTiP's adaptive default."""
+        backend, problem = _static_problem("qutip", levels=levels, T1=T1)
+
+        options = _resolved_options(backend, problem)
+
+        assert "method" not in options
+        assert "nsteps" in options
+
+    def test_explicit_method_is_never_overridden(self) -> None:
+        """An explicit QuTiP method should remain authoritative for an otherwise eligible problem."""
+        backend, problem = _static_problem("qutip", options={"method": "adams"})
+
+        options = _resolved_options(backend, problem)
+
+        assert options["method"] == "adams"
+
+    @pytest.mark.parametrize("step_option", [{"nsteps": 17}, {"max_step": 0.01}])
+    def test_explicit_step_control_suppresses_automatic_method(self, step_option: dict) -> None:
+        """Explicit QuTiP step controls should retain the adaptive integrator that consumes them."""
+        backend, problem = _static_problem("qutip", options=step_option)
+
+        options = _resolved_options(backend, problem)
+
+        assert "method" not in options
+        assert all(options[key] == value for key, value in step_option.items())
+
+    def test_driven_problem_retains_adaptive_integrator(self) -> None:
+        """Any explicit Hamiltonian time dependence should keep QuTiP's adaptive integrator."""
+        qubit = DuffingTransmon(freq=5.0, anharmonicity=-0.25, levels=3, label="q")
+        drive = ChargeDrive(qubit, label="xy")
+        chip = Chip([qubit], frame="rotating", backend="qutip")
+        chip.wire(drive)
+        sequence = QuantumSequence(chip)
+        sequence.schedule(
+            drive,
+            envelope=Square(duration=1.0, amplitude=0.02),
+            freq=chip.freq(qubit),
+        )
+        problem = sequence.build_problem(tlist=np.linspace(0.0, 1.0, 3))
+
+        options = _resolved_options(chip.backend, problem)
+
+        assert problem.engine_result.dynamic_terms
+        assert "method" not in options
+
+
+@pytest.mark.optional_backend
+def test_dynamiqs_static_problem_retains_adaptive_integrator() -> None:
+    """quchip must not automatically select Dynamiqs' newer matrix-exponential method."""
+    pytest.importorskip("dynamiqs")
+    backend, problem = _static_problem("dynamiqs", levels=3, points=2)
+
+    options = _resolved_options(backend, problem)
+
+    assert "method" not in options
+    assert "max_steps" in options


### PR DESCRIPTION
## Summary

- Automatically select QuTiP's `diag` propagator for static closed systems up to Hilbert dimension 64 and static Lindblad systems up to Hilbert dimension 12.
- Keep driven problems, larger spaces, and explicit non-`diag` methods on QuTiP's adaptive integrators.
- Remove `atol`, `rtol`, `nsteps`, and `max_step` when `diag` is selected because that integrator cannot use them, and report discarded options at `INFO` level.
- Leave dynamiqs method selection unchanged; quchip does not automatically select its newer matrix-exponential method.
- Add a practical backend guide covering QuTiP and dynamiqs solver choices, options, batching, frames, gradients, and backend tradeoffs.

## Verification

- `pre-merge full suite`: passed (the earlier cancelled run is a duplicate)
- `test-fast (Python 3.11)`: passed
- `test-fast (Python 3.12)`: passed
- `lint`: passed
- docs `build`: passed
- `closed-system overhead` benchmark: passed
- Docs-only follow-up: `git diff --check` passed; the full suite was not rerun locally

## Checklist

- [x] This pull request is focused and contains no unrelated changes.
- [x] Changed behavior is covered by tests.
- [x] Relevant documentation is updated.
- [x] Generated files and paired notebooks are synchronized, if applicable.
- [x] `PHYSICS.md` is not affected: this changes solver selection, not the declared Hamiltonian, units, frames, approximations, or dissipation model.

## AI assistance

Codex assisted with implementation, tests, documentation, and review. The solver-selection behavior, limits, discarded-option logging, and verification results are stated explicitly above.
