### PR TITLE
feat: add solve-time coherent inputs

### DIFF
--- a/PHYSICS.md
+++ b/PHYSICS.md
@@ -115,6 +115,7 @@ lowering applies `sqrt(rate)` exactly once.
 ### 3.3.1 Accessible ports
 
 Source: [`quchip/chip/ports.py`](quchip/chip/ports.py),
+[`quchip/control/field.py`](quchip/control/field.py),
 [`quchip/engine/input_output.py`](quchip/engine/input_output.py),
 [`quchip/analysis/vna.py`](quchip/analysis/vna.py)
 
@@ -126,8 +127,34 @@ L_p = exp(i phi_p) sqrt(kappa_p) A_p
 b_out,p = b_in,p + L_p
 ```
 
-The dissipator uses `L_p`. A coherent input `beta_p` in
-`sqrt(photons/ns)` contributes the angular Hamiltonian
+The dissipator uses `L_p`. A scheduled `CoherentInput` consumes the same
+envelope, phase, carrier, and start-time grammar as a classical drive, with
+
+```text
+beta_i(t) = A(t) exp(i theta) exp(-i 2π f t),
+|beta_i|^2 = incident photon flux in photons/ns.
+```
+
+There is no implicit conjugation or factor of one half. For a general resolved
+boundary, the field arriving at each coupling channel is
+
+```text
+c_j(t) = sum_i S_ji beta_i(t),
+H_input(t) = i sum_j (c_j^* L_j - c_j L_j^dagger).
+```
+
+This Hamiltonian is the canonical solver form obtained by composing the
+coherent source `W_beta = (I, beta, 0)` with the resolved SLH model and then
+gauging the displaced collapse operators back to the input-free `L`. The
+collapse channels therefore remain unchanged: applying a coherent field never
+adds a second damping channel.
+
+`ResolvedSLH` itself stays input-free. Per-solve beta programs are retained on
+`EngineResult.coherent_inputs` for later output-field reconstruction. Classical
+`ControlEquipment` transforms do not accept `CoherentInput`; field attenuation,
+phase, crosstalk, and reference-plane delay belong to `PortNetwork`.
+
+For the one-port identity case this reduces to the angular Hamiltonian
 
 ```text
 H_input = i (beta_p^* L_p - beta_p L_p^dagger).

--- a/quchip/__init__.py
+++ b/quchip/__init__.py
@@ -65,6 +65,8 @@ from quchip.chip import (
 )
 from quchip.control import (
     ChargeDrive,
+    CoherentInput,
+    ControlEndpoint,
     ControlEquipment,
     CouplingDrive,
     Crosstalk,
@@ -255,6 +257,8 @@ __all__ = [
     "hbar",
     "Phi_0",
     # Control
+    "CoherentInput",
+    "ControlEndpoint",
     "CouplingDrive",
     "DeviceDrive",
     "Delay",

--- a/quchip/control/__init__.py
+++ b/quchip/control/__init__.py
@@ -2,6 +2,7 @@
 
 from quchip.control.equipment import ControlEquipment, CrosstalkMatrix
 from quchip.control.signal import AnalyticSignal, Crosstalk, Delay, Gain, SignalTransform
+from quchip.control.field import CoherentInput, ControlEndpoint
 from quchip.control.drive import (
     BaseDrive,
     ChargeDrive,
@@ -26,6 +27,8 @@ __all__ = [
     # Drive classes
     "BaseDrive",
     "AnalyticSignal",
+    "CoherentInput",
+    "ControlEndpoint",
     "CouplingDrive",
     "DeviceDrive",
     "SignalTransform",

--- a/quchip/control/equipment.py
+++ b/quchip/control/equipment.py
@@ -174,6 +174,12 @@ class ControlEquipment:
         *,
         signal_chain: list[SignalTransform] | None = None,
     ) -> None:
+        invalid = [line for line in lines if not isinstance(line, BaseDrive)]
+        if invalid:
+            raise TypeError(
+                "ControlEquipment lines must be BaseDrive instances; coherent field "
+                "inputs are scheduled directly and propagate through PortNetwork."
+            )
         self._lines = list(lines)
         self._signal_chain = list(signal_chain) if signal_chain else []
 

--- a/quchip/control/field.py
+++ b/quchip/control/field.py
@@ -1,0 +1,69 @@
+"""Solve-time coherent field controls.
+
+Field inputs share the sequence scheduling grammar with classical drive lines,
+but remain independent of :class:`~quchip.control.drive.BaseDrive` and
+:class:`~quchip.control.equipment.ControlEquipment`. Their target is an
+external SLH exposure rather than a device or coupling.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+from quchip.control.signal import AnalyticSignal
+from quchip.utils.labeling import auto_label, resolve_label
+
+
+@runtime_checkable
+class ControlEndpoint(Protocol):
+    """Structural endpoint accepted by the sequence scheduling grammar.
+
+    Existing :class:`~quchip.control.drive.BaseDrive` implementations satisfy
+    this protocol without inheritance. A field endpoint supplies the same
+    label, target-label, and signal-building boundary while owning different
+    downstream physics.
+    """
+
+    label: str
+
+    @property
+    def target_label(self) -> str | None:
+        """Return the endpoint's device, coupling, or field-exposure label."""
+        ...
+
+    def signal(self, pulse: Any, target: Any) -> AnalyticSignal:
+        """Build the complete analytic signal for one scheduled pulse."""
+        ...
+
+
+@dataclass(frozen=True, init=False)
+class CoherentInput:
+    r"""Coherent incident field bound to one external network exposure.
+
+    The scheduled analytic signal is interpreted directly as
+    ``beta(t) = A(t) exp(i theta) exp(-i 2*pi*f*t)`` in ``1/sqrt(ns)``.
+    Consequently ``abs(beta)**2`` is photon flux in photons/ns.
+    """
+
+    exposure: str
+    label: str
+
+    def __init__(self, exposure: str | Any, *, label: str | None = None) -> None:
+        exposure_label = resolve_label(exposure)
+        object.__setattr__(self, "exposure", exposure_label)
+        object.__setattr__(
+            self,
+            "label",
+            label if label is not None else auto_label("coherent_input"),
+        )
+
+    @property
+    def target_label(self) -> str:
+        """Return the external exposure receiving the incident field."""
+        return self.exposure
+
+    def signal(self, pulse: Any, target: Any = None) -> AnalyticSignal:
+        """Build beta from the existing envelope, phase, carrier, and timing grammar."""
+        _ = target
+        return AnalyticSignal.from_pulse(pulse)

--- a/quchip/control/sequence.py
+++ b/quchip/control/sequence.py
@@ -1,9 +1,10 @@
 """Declarative pulse programming for a :class:`~quchip.chip.chip.Chip`.
 
 :class:`QuantumSequence` is the user-facing scheduling API. It tracks
-per-``(device, drive)`` timing cursors, per-device virtual-Z phase
-frames, and cross-device barriers, then materializes the schedule into
-:class:`~quchip.engine.ir.DriveOp` objects for the engine.
+per-endpoint timing cursors, per-device virtual-Z phase frames, and
+cross-device barriers, then materializes the schedule into classical
+:class:`~quchip.engine.ir.DriveOp` and field
+:class:`~quchip.engine.ir.CoherentOp` records for the engine.
 
 Conventions
 -----------
@@ -60,8 +61,9 @@ from quchip.control.drive import (
     PhaseDrive,
 )
 from quchip.control.envelopes import Envelope
+from quchip.control.field import CoherentInput, ControlEndpoint
 from quchip.devices.base import BaseDevice
-from quchip.engine.ir import DriveOp, EngineResult, HamiltonianTemplate
+from quchip.engine.ir import CoherentOp, ControlOp, DriveOp, EngineResult, HamiltonianTemplate
 from quchip.engine.assembly import (
     build_engine_result,
     compile_hamiltonian_template,
@@ -97,6 +99,7 @@ class _PulseEntry:
     freq: float | None
     requested_start_time: float | None
     phase: float
+    coherent_input: CoherentInput | None = None
 
 
 @dataclass(frozen=True)
@@ -148,7 +151,7 @@ class QuantumSequence:
     conveniences :meth:`charge`, :meth:`phase`, :meth:`flux`);
     synchronize channels with :meth:`barrier` and :meth:`delay`. The
     schedule is materialized lazily into
-    :class:`~quchip.engine.ir.DriveOp` objects by :meth:`build_problem`
+    engine control-operation records by :meth:`build_problem`
     and :meth:`build_batch`.
 
     Wherever a device/drive is expected, either the object itself or its
@@ -322,9 +325,37 @@ class QuantumSequence:
         )
         return PulseHandle(self, len(self._entries) - 1)
 
+    def _schedule_on_coherent_input(
+        self,
+        coherent_input: CoherentInput,
+        *,
+        envelope: Envelope,
+        freq: float | None,
+        start_time: float | None = None,
+        phase: float = 0.0,
+    ) -> PulseHandle:
+        exposures = [channel.key for channel in self._chip.resolve().slh.external_channels]
+        if coherent_input.exposure not in exposures:
+            raise ValueError(
+                f"Unknown coherent-input exposure {coherent_input.exposure!r}. "
+                f"Available exposures: {exposures}."
+            )
+        self._entries.append(
+            _PulseEntry(
+                target_label=coherent_input.exposure,
+                drive_label=coherent_input.label,
+                envelope=envelope,
+                freq=freq,
+                requested_start_time=start_time,
+                phase=phase,
+                coherent_input=coherent_input,
+            )
+        )
+        return PulseHandle(self, len(self._entries) - 1)
+
     def schedule(
         self,
-        target: str | BaseDrive | BaseDevice | BaseCoupling,
+        target: str | ControlEndpoint | BaseDevice | BaseCoupling,
         *,
         envelope: Envelope,
         freq: float | None = None,
@@ -335,9 +366,11 @@ class QuantumSequence:
 
         Parameters
         ----------
-        target : str | BaseDrive | BaseDevice | BaseCoupling
+        target : str | ControlEndpoint | BaseDevice | BaseCoupling
             Accepted forms, resolved in this order:
 
+            * :class:`~quchip.control.field.CoherentInput` — scheduled on its
+              external SLH exposure without entering ``ControlEquipment``.
             * :class:`BaseDrive` — scheduled directly on that drive.
             * :class:`BaseDevice` — uses the device's first connected
               drive; pass the drive object explicitly when a device
@@ -371,6 +404,14 @@ class QuantumSequence:
             Per-pulse phase offset, composed with any accumulated
             virtual-Z.
         """
+        if isinstance(target, CoherentInput):
+            return self._schedule_on_coherent_input(
+                target,
+                envelope=envelope,
+                freq=freq,
+                start_time=start_time,
+                phase=phase,
+            )
         if isinstance(target, BaseDrive):
             drive = target
         else:
@@ -531,8 +572,8 @@ class QuantumSequence:
         return _cursor_max(cursors.values()) if cursors else 0.0
 
     @property
-    def scheduled_ops(self) -> tuple[DriveOp, ...]:
-        """Materialize and return the scheduled :class:`DriveOp` tuple."""
+    def scheduled_ops(self) -> tuple[ControlOp, ...]:
+        """Materialize scheduled classical-drive and coherent-field operations."""
         return tuple(self._materialize_drive_ops())
 
     @property
@@ -575,8 +616,8 @@ class QuantumSequence:
         overrides: Mapping[tuple[int, str], Any] | None = None,
         *,
         collect_ops: bool,
-    ) -> tuple[dict[tuple[str, str], Any], dict[str, Any], list[DriveOp]]:
-        """Replay ``_entries`` into final cursors, floors, and (optionally) DriveOps.
+    ) -> tuple[dict[tuple[str, str], Any], dict[str, Any], list[ControlOp]]:
+        """Replay ``_entries`` into final cursors, floors, and optional control ops.
 
         This is the single implementation of the delay-shift, barrier-alignment,
         floor, default-start, and virtual-Z phase semantics. Both the cursor
@@ -590,7 +631,7 @@ class QuantumSequence:
 
         ``overrides`` maps ``(entry_index, field) -> value``; only ``duration``
         (on a delay entry or pulse envelope) and ``start_time``/``freq``/``phase``
-        (on a pulse) affect the replay. ``collect_ops`` gates DriveOp building
+        (on a pulse) affect the replay. ``collect_ops`` gates operation building
         and the per-device drive lookup needed for virtual-Z routing.
         """
         overrides = {} if overrides is None else dict(overrides)
@@ -604,9 +645,12 @@ class QuantumSequence:
                 if isinstance(line, CouplingDrive):
                     assert line.target_label is not None
                     cursors[(line.target_label, line.label)] = 0.0
+        for entry in self._entries:
+            if isinstance(entry, _PulseEntry) and entry.coherent_input is not None:
+                cursors[(entry.target_label, entry.drive_label)] = 0.0
         floors: dict[str, Any] = {}
         phases: dict[str, Any] = {dev.label: 0.0 for dev in self._chip.devices}
-        drive_ops: list[DriveOp] = []
+        drive_ops: list[ControlOp] = []
 
         for entry_index, entry in enumerate(self._entries):
             if isinstance(entry, _FrameShiftEntry):
@@ -678,30 +722,41 @@ class QuantumSequence:
                 freq = overrides.get((entry_index, "freq"), entry.freq)
                 phase = overrides.get((entry_index, "phase"), entry.phase)
                 phase_offset = phase
-                if freq is not None:
+                if freq is not None and entry.coherent_input is None:
                     phase_offset = phase_offset + phases.get(entry.target_label, 0.0)
-                drive_ops.append(
-                    DriveOp(
-                        target_label=entry.target_label,
-                        envelope=envelope,
-                        freq=freq,
-                        start_time=start_time,
-                        phase_offset=phase_offset,
-                        drive_label=entry.drive_label,
+                if entry.coherent_input is None:
+                    drive_ops.append(
+                        DriveOp(
+                            target_label=entry.target_label,
+                            envelope=envelope,
+                            freq=freq,
+                            start_time=start_time,
+                            phase_offset=phase_offset,
+                            drive_label=entry.drive_label,
+                        )
                     )
-                )
+                else:
+                    drive_ops.append(
+                        CoherentOp(
+                            coherent_input=entry.coherent_input,
+                            envelope=envelope,
+                            freq=freq,
+                            start_time=start_time,
+                            phase_offset=phase_offset,
+                        )
+                    )
             cursors[key] = start_time + envelope.duration
         return cursors, floors, drive_ops
 
     def _replay_cursors(
         self, overrides: Mapping[tuple[int, str], Any] | None = None
     ) -> tuple[dict[tuple[str, str], Any], dict[str, Any]]:
-        """Replay ``_entries`` to their final ``(cursors, floors)`` without building DriveOps."""
+        """Replay ``_entries`` to final ``(cursors, floors)`` without building operations."""
         cursors, floors, _ = self._replay(overrides, collect_ops=False)
         return cursors, floors
 
-    def _materialize_drive_ops(self, overrides: Mapping[tuple[int, str], Any] | None = None) -> list[DriveOp]:
-        """Replay ``_entries`` into the scheduled :class:`DriveOp` list."""
+    def _materialize_drive_ops(self, overrides: Mapping[tuple[int, str], Any] | None = None) -> list[ControlOp]:
+        """Replay ``_entries`` into the scheduled control-operation list."""
         return self._replay(overrides, collect_ops=True)[2]
 
     def build_problem(

--- a/quchip/control/signal.py
+++ b/quchip/control/signal.py
@@ -53,6 +53,17 @@ from quchip.utils.registry import Registrable
 SignalKey = tuple[str, int]  # (line_label, source_index)
 
 
+def _reject_field_endpoint(value: Any, *, transform: str) -> None:
+    """Keep field propagation in PortNetwork rather than control equipment."""
+    from quchip.control.field import CoherentInput
+
+    if isinstance(value, CoherentInput):
+        raise TypeError(
+            f"{transform} does not accept CoherentInput. Use PortNetwork scattering "
+            "or an exposure reference-plane delay for field propagation."
+        )
+
+
 @dataclass(frozen=True)
 class AnalyticSignal:
     """Complete complex classical signal delivered on one control line.
@@ -187,6 +198,7 @@ class Delay(SignalTransform):
     _parameter_names = ("delta_t",)
 
     def __init__(self, line: str | Any, delta_t: float) -> None:
+        _reject_field_endpoint(line, transform="ControlEquipment.Delay")
         object.__setattr__(self, "line", resolve_label(line))
         object.__setattr__(self, "delta_t", delta_t)
 
@@ -222,6 +234,7 @@ class Gain(SignalTransform):
     _parameter_names = ("factor",)
 
     def __init__(self, line: str | Any, factor: complex) -> None:
+        _reject_field_endpoint(line, transform="ControlEquipment.Gain")
         object.__setattr__(self, "line", resolve_label(line))
         object.__setattr__(self, "factor", factor)
 
@@ -297,6 +310,8 @@ class Crosstalk(SignalTransform):
         theta: float = 0.0,
         delay: float = 0.0,
     ) -> None:
+        _reject_field_endpoint(source, transform="ControlEquipment.Crosstalk")
+        _reject_field_endpoint(victim, transform="ControlEquipment.Crosstalk")
         object.__setattr__(self, "source", resolve_label(source))
         object.__setattr__(self, "victim", resolve_label(victim))
         object.__setattr__(self, "beta", beta)

--- a/quchip/engine/__init__.py
+++ b/quchip/engine/__init__.py
@@ -139,8 +139,8 @@ def build_problem(
     ----------
     chip : Chip
         The chip whose Hamiltonian, frame, and backend are assembled.
-    drive_ops : list of DriveOp
-        Scheduled drive operations, typically produced by a
+    drive_ops : list of ControlOp
+        Scheduled classical-drive or coherent-field operations, typically produced by a
         :class:`~quchip.control.sequence.QuantumSequence`.
     tlist : array_like
         Solver time grid in ns.
@@ -203,8 +203,8 @@ def build_engine_result(chip: Any, drive_ops: list, **kwargs: Any) -> EngineResu
     ----------
     chip : Chip
         The chip whose device, coupling, and drive Hamiltonians are assembled.
-    drive_ops : list of DriveOp
-        Scheduled drive operations to embed as dynamic terms.
+    drive_ops : list of ControlOp
+        Scheduled classical-drive or coherent-field operations to embed as dynamic terms.
     **kwargs
         Forwarded to
         :func:`quchip.engine.assembly.build_engine_result`
@@ -248,8 +248,8 @@ def simulate(
     ----------
     chip : Chip
         The chip to simulate.
-    drive_ops : list of DriveOp
-        Scheduled drive operations, typically produced by a
+    drive_ops : list of ControlOp
+        Scheduled classical-drive or coherent-field operations, typically produced by a
         :class:`~quchip.control.sequence.QuantumSequence`.
     tlist : array_like
         Solver time grid in ns.

--- a/quchip/engine/assembly.py
+++ b/quchip/engine/assembly.py
@@ -77,11 +77,15 @@ from quchip.declarative.expr import (
 )
 from quchip.engine.ir import HamiltonianTemplate
 from quchip.engine.ir import (
+    BoundCoherentInput,
     CanonicalOperator,
     Carrier,
     CollapseTerm,
+    CoherentOp,
+    Conjugate,
     Constant,
     DroppedTerm,
+    DriveOp,
     DynamicTerm,
     EngineResult,
     HamiltonianProgram,
@@ -90,6 +94,7 @@ from quchip.engine.ir import (
     ResolvedFrame,
     ScalarModulation,
     SignalProgram,
+    Scale,
     StaticTerm,
     TermOrigin,
     _as_time_coefficient,
@@ -103,7 +108,11 @@ from quchip.engine.basis import (
 )
 from quchip.engine.solver_hints import _solver_hint_metadata, _static_diagonal_span
 from quchip.utils.constants import TWO_PI
-from quchip.utils.jax_utils import array_namespace, contains_tracer, maybe_concrete_scalar
+from quchip.utils.jax_utils import (
+    array_namespace,
+    contains_tracer,
+    maybe_concrete_scalar,
+)
 from quchip.engine.bands import (
     _decompose_product_canonical_bands,
     decompose_canonical_bands,
@@ -115,7 +124,7 @@ from quchip.engine.bands import (
 
 if TYPE_CHECKING:
     from quchip.chip.chip import Chip
-    from quchip.engine.ir import DriveOp
+    from quchip.engine.ir import ControlOp
 
 
 def _weight_zero_dropped_term(*, source: str, device_label: str, drive_freq: Any) -> DroppedTerm:
@@ -902,6 +911,18 @@ class CompiledDriveTerm:
 
 
 @dataclass(frozen=True)
+class CompiledCoherentTerm:
+    """One ``S[j, i] beta_i`` contribution to the canonical source drive."""
+
+    operation_index: int
+    exposure: str
+    scattering: Any
+    lowering: CanonicalOperator
+    raising: CanonicalOperator
+    frame_frequency: Any
+
+
+@dataclass(frozen=True)
 class _StructuralDrop:
     """Template-cached pointer to a carrier-driven weight-zero band drop.
 
@@ -1114,10 +1135,13 @@ def _compile_drive_terms(
 
 def _build_delivered_signals(
     chip: "Chip",
-    drive_ops: list["DriveOp"],
+    drive_ops: list["ControlOp"],
 ) -> list[_DeliveredSignal]:
     """Build, transform, and route complete signals to destination drives."""
-    resolved = _resolve_drives(chip, drive_ops)
+    resolved = _resolve_drives(
+        chip,
+        [operation for operation in drive_ops if isinstance(operation, DriveOp)],
+    )
     raw_signals: dict[tuple[str, int], AnalyticSignal] = {}
     for source_index, (drive, drive_op, target) in enumerate(resolved):
         signal = drive.signal(drive_op, target)
@@ -1148,6 +1172,144 @@ def _build_delivered_signals(
             )
         )
     return delivered
+
+
+def _is_concrete_zero(value: Any) -> bool:
+    """Return whether *value* is safely known to be scalar zero."""
+    if contains_tracer(value):
+        return False
+    try:
+        concrete = np.asarray(value)
+    except Exception:
+        return False
+    return concrete.ndim == 0 and bool(concrete == 0)
+
+
+def _compile_coherent_terms(
+    slh: ResolvedSLH,
+    control_ops: list["ControlOp"],
+) -> tuple[CompiledCoherentTerm, ...]:
+    """Compile operator skeletons for coherent-source composition.
+
+    Cascading ``W_beta = (I, beta, 0)`` before ``(S, L, H)`` gives
+    ``c = S beta``. Canonicalizing the displaced collapse operators back to
+    the input-free ``L`` produces ``H_beta = i(c* L - c L dagger)``.
+    """
+    external = slh.external_channels
+    exposure_index = {channel.key: index for index, channel in enumerate(external)}
+    compiled: list[CompiledCoherentTerm] = []
+    for operation_index, operation in enumerate(control_ops):
+        if not isinstance(operation, CoherentOp):
+            continue
+        input_index = exposure_index.get(operation.exposure)
+        if input_index is None:
+            raise ValueError(
+                f"Unknown coherent-input exposure {operation.exposure!r}. "
+                f"Available exposures: {list(exposure_index)}."
+            )
+        for output_index, channel in enumerate(external):
+            scattering = slh.S[output_index, input_index]
+            if _is_concrete_zero(scattering):
+                continue
+            lowering = channel.coupling.with_metadata(
+                tag=f"coherent_input:{operation.exposure}:{channel.key}:L"
+            )
+            dense = lowering.to_dense()
+            xp = array_namespace(dense)
+            raising = CanonicalOperator.from_dense(
+                xp.conj(xp.swapaxes(dense, -1, -2)),
+                dims=lowering.dims,
+                basis=lowering.basis,
+                subsystem_labels=lowering.subsystem_labels,
+                tag=f"coherent_input:{operation.exposure}:{channel.key}:Ldagger",
+            )
+            compiled.append(
+                CompiledCoherentTerm(
+                    operation_index=operation_index,
+                    exposure=operation.exposure,
+                    scattering=scattering,
+                    lowering=lowering,
+                    raising=raising,
+                    frame_frequency=(
+                        0.0
+                        if channel.collapse.frame_frequency is None
+                        else channel.collapse.frame_frequency
+                    ),
+                )
+            )
+    return tuple(compiled)
+
+
+def _frame_shifted(program: SignalProgram, frequency: Any) -> SignalProgram:
+    """Attach one operator-frame phase unless it is concretely zero."""
+    if _is_concrete_zero(frequency):
+        return program
+    return Multiply((program, Carrier(freq=TWO_PI * frequency, sign=-1)))
+
+
+def _instantiate_coherent_terms(
+    template: HamiltonianTemplate,
+    control_ops: list["ControlOp"],
+) -> tuple[tuple[DynamicTerm, ...], tuple[BoundCoherentInput, ...]]:
+    """Bind beta programs and materialize their solve-applied Hamiltonian."""
+    external = {channel.key: channel for channel in template.slh.external_channels}
+    boundary_signals: dict[int, AnalyticSignal] = {}
+    bound: list[BoundCoherentInput] = []
+    for operation_index, operation in enumerate(control_ops):
+        if not isinstance(operation, CoherentOp):
+            continue
+        channel = external[operation.exposure]
+        reference = operation.coherent_input.signal(operation, channel)
+        if not isinstance(reference, AnalyticSignal):
+            raise TypeError(
+                f"{type(operation.coherent_input).__name__}.signal() must return "
+                f"AnalyticSignal, got {type(reference).__name__}."
+            )
+        boundary = (
+            reference
+            if _is_concrete_zero(channel.reference_delay)
+            else reference.shifted(channel.reference_delay)
+        )
+        boundary_signals[operation_index] = boundary
+        bound.append(
+            BoundCoherentInput(
+                exposure=operation.exposure,
+                source_label=operation.coherent_input.label,
+                beta=boundary.program,
+                reference_beta=reference.program,
+            )
+        )
+
+    dynamic: list[DynamicTerm] = []
+    for compiled in template.coherent_terms:
+        beta = boundary_signals[compiled.operation_index].program
+        xp = array_namespace(compiled.scattering)
+        scattering = xp.asarray(compiled.scattering)
+        lowering_signal = _frame_shifted(
+            Scale(Conjugate(beta), factor=1j * xp.conj(scattering)),
+            compiled.frame_frequency,
+        )
+        raising_signal = _frame_shifted(
+            Scale(beta, factor=-1j * scattering),
+            -compiled.frame_frequency,
+        )
+        dynamic.extend(
+            (
+                DynamicTerm(
+                    operator=compiled.lowering,
+                    time_dependence=ScalarModulation(signal=lowering_signal),
+                    origin="port",
+                    tag=f"coherent_input:{compiled.exposure}",
+                ),
+                DynamicTerm(
+                    operator=compiled.raising,
+                    time_dependence=ScalarModulation(signal=raising_signal),
+                    origin="port",
+                    tag=f"coherent_input:{compiled.exposure}",
+                ),
+            )
+        )
+    return tuple(dynamic), tuple(bound)
 
 
 def _drive_scalar_program(
@@ -1197,7 +1359,7 @@ def _collect_dropped_terms(chip: "Chip", resolved_frame: "ResolvedFrame") -> tup
 
 def _validate_variant_drive_ops(
     template: HamiltonianTemplate,
-    drive_ops: list["DriveOp"],
+    drive_ops: list["ControlOp"],
 ) -> None:
     """Check that *drive_ops* match the template's drive, target, and envelope shape."""
     reference_ops = template.reference_drive_ops
@@ -1208,6 +1370,11 @@ def _validate_variant_drive_ops(
         )
 
     for index, (reference_op, variant_op) in enumerate(zip(reference_ops, drive_ops)):
+        if type(variant_op) is not type(reference_op):
+            raise ValueError(
+                f"Variant control op {index} uses {type(variant_op).__name__}, "
+                f"expected {type(reference_op).__name__}."
+            )
         if variant_op.target_label != reference_op.target_label:
             raise ValueError(
                 f"Variant drive op {index} targets '{variant_op.target_label}', expected '{reference_op.target_label}'."
@@ -1229,7 +1396,7 @@ def _validate_variant_drive_ops(
 
 def _template_from_engine_result(
     chip: "Chip",
-    drive_ops: list["DriveOp"],
+    drive_ops: list["ControlOp"],
     base_result: EngineResult,
     resolved_frame: "ResolvedFrame",
 ) -> HamiltonianTemplate:
@@ -1249,6 +1416,7 @@ def _template_from_engine_result(
         subsystem_labels=subsystem_labels,
         approximation=base_result.approximation,
     )
+    coherent_terms = _compile_coherent_terms(base_result.slh, drive_ops)
     return HamiltonianTemplate(
         resolved_frame=resolved_frame,
         approximation=base_result.approximation,
@@ -1257,6 +1425,7 @@ def _template_from_engine_result(
         static_terms=base_result.slh.H.static_terms,
         invariant_dynamic_terms=base_result.slh.H.dynamic_terms,
         drive_terms=drive_terms,
+        coherent_terms=coherent_terms,
         reference_drive_ops=tuple(drive_ops),
         dropped_terms=base_result.dropped_terms,
         weight_zero_drops=weight_zero_drops,
@@ -1269,7 +1438,7 @@ def _template_from_engine_result(
 
 def compile_hamiltonian_template(
     chip: "Chip",
-    drive_ops: list["DriveOp"],
+    drive_ops: list["ControlOp"],
     *,
     resolved_frame: "ResolvedFrame",
     approximation: Approximation | None = None,
@@ -1388,6 +1557,7 @@ def compile_hamiltonian_template(
     )
     if chip.port_network is not None:
         slh = chip.port_network.resolve(slh)
+    coherent_terms = _compile_coherent_terms(slh, drive_ops)
     # Static terms are invariant across a homogeneous sweep, including any
     # Hamiltonian generated by network composition. Store the bound in GHz.
     resolved_static_span = _static_diagonal_span(slh.H.static_terms)
@@ -1402,6 +1572,7 @@ def compile_hamiltonian_template(
         static_terms=slh.H.static_terms,
         invariant_dynamic_terms=slh.H.dynamic_terms,
         drive_terms=drive_terms,
+        coherent_terms=coherent_terms,
         reference_drive_ops=tuple(drive_ops),
         dropped_terms=_collect_dropped_terms(chip, resolved_frame) + tuple(coupling_dropped),
         weight_zero_drops=weight_zero_drops,
@@ -1414,7 +1585,7 @@ def compile_hamiltonian_template(
 
 def instantiate_engine_result(
     template: HamiltonianTemplate,
-    drive_ops: list["DriveOp"],
+    drive_ops: list["ControlOp"],
     chip: "Chip",
 ) -> EngineResult:
     """Rebuild signal-program leaves from *drive_ops* and attach them to the template's operators."""
@@ -1481,13 +1652,15 @@ def instantiate_engine_result(
             )
         )
 
-    applied_dynamic_terms = tuple(
+    applied_drive_terms = tuple(
         replace(
             term,
             time_dependence=ScalarModulation(signal=_simplify_signal(term.time_dependence.signal)),
         )
         for term in fresh_terms
     )
+    coherent_terms, coherent_inputs = _instantiate_coherent_terms(template, drive_ops)
+    applied_dynamic_terms = applied_drive_terms + coherent_terms
     dynamic_terms = template.invariant_dynamic_terms + applied_dynamic_terms
 
     metadata: dict[str, Any] = {"frame": str(template.resolved_frame)}
@@ -1506,6 +1679,7 @@ def instantiate_engine_result(
     return EngineResult(
         slh=slh,
         applied_hamiltonian=HamiltonianProgram(dynamic_terms=applied_dynamic_terms),
+        coherent_inputs=coherent_inputs,
         dims=dims,
         metadata=metadata,
         dropped_terms=template.dropped_terms + tuple(fresh_dropped),
@@ -1518,7 +1692,7 @@ def instantiate_engine_result(
 
 def build_engine_result(
     chip: "Chip",
-    drive_ops: list["DriveOp"],
+    drive_ops: list["ControlOp"],
     *,
     resolved_frame: "ResolvedFrame",
     approximation: Approximation | None = None,
@@ -1538,8 +1712,8 @@ def build_engine_result(
     chip : Chip
         The chip whose device, coupling, and drive Hamiltonians are
         assembled (2π applied at this boundary).
-    drive_ops : list of DriveOp
-        Scheduled drive operations to embed as dynamic terms.
+    drive_ops : list of ControlOp
+        Scheduled classical-drive or coherent-field operations to embed as dynamic terms.
     resolved_frame : ResolvedFrame
         Resolved frame carrying the per-device frame frequencies,
         demodulation frequencies, and frame mode.

--- a/quchip/engine/ir.py
+++ b/quchip/engine/ir.py
@@ -1252,6 +1252,21 @@ class DroppedTerm:
 
 
 @dataclass(frozen=True)
+class BoundCoherentInput:
+    """One solve-bound incident field, retained outside input-free SLH.
+
+    ``reference_beta`` is the signal scheduled at the authored external
+    reference plane. ``beta`` includes the exposure's inbound propagation
+    delay and is the field composed with the Markov boundary.
+    """
+
+    exposure: str
+    source_label: str
+    beta: SignalProgram
+    reference_beta: SignalProgram
+
+
+@dataclass(frozen=True)
 class EngineResult:
     """Backend-neutral resolved physics passed to backends.
 
@@ -1278,6 +1293,7 @@ class EngineResult:
 
     slh: ResolvedSLH
     applied_hamiltonian: HamiltonianProgram = field(default_factory=HamiltonianProgram)
+    coherent_inputs: tuple[BoundCoherentInput, ...] = ()
     dims: tuple[int, ...] = ()
     metadata: dict[str, Any] = field(default_factory=dict)
     dropped_terms: tuple[DroppedTerm, ...] = ()
@@ -1364,6 +1380,10 @@ class EngineResult:
                 tuple(
                     (term.amplitude, term.frequency)
                     for term in self.dropped_terms
+                ),
+                tuple(
+                    (item.beta, item.reference_beta)
+                    for item in self.coherent_inputs
                 ),
                 basis_payloads,
                 authored_values,
@@ -1519,6 +1539,7 @@ class HamiltonianTemplate:
     static_terms: tuple[Any, ...] = ()              # tuple[StaticTerm, ...]
     invariant_dynamic_terms: tuple[Any, ...] = ()   # tuple[DynamicTerm, ...]
     drive_terms: tuple[Any, ...] = ()               # tuple[assembly.CompiledDriveTerm, ...]
+    coherent_terms: tuple[Any, ...] = ()            # tuple[assembly.CompiledCoherentTerm, ...]
     reference_drive_ops: tuple[Any, ...] = ()       # tuple[DriveOp, ...]
     dropped_terms: tuple[Any, ...] = ()             # tuple[DroppedTerm, ...]
     #: Single-tone weight-zero bands dropped structurally under RWA during engine assembly.
@@ -1753,3 +1774,32 @@ class DriveOp:
     start_time: float = 0.0
     phase_offset: float = 0.0
     drive_label: str = ""
+
+
+@dataclass(frozen=True)
+class CoherentOp:
+    """Coherent field operation scheduled on an external SLH exposure."""
+
+    coherent_input: Any
+    envelope: Envelope
+    freq: float | None = None
+    start_time: float = 0.0
+    phase_offset: float = 0.0
+
+    @property
+    def exposure(self) -> str:
+        """Return the external exposure receiving this incident field."""
+        return self.coherent_input.exposure
+
+    @property
+    def target_label(self) -> str:
+        """Alias the exposure for common solve-window diagnostics."""
+        return self.exposure
+
+    @property
+    def drive_label(self) -> str:
+        """Alias the endpoint label for common scheduling diagnostics."""
+        return self.coherent_input.label
+
+
+ControlOp: TypeAlias = DriveOp | CoherentOp

--- a/quchip/engine/problem.py
+++ b/quchip/engine/problem.py
@@ -22,7 +22,7 @@ import numpy as np
 
 from quchip.approximations import Approximation
 from quchip.engine.ir import (
-    DriveOp,
+    ControlOp,
     EngineResult,
     ScalarModulation,
     SolveBatch,
@@ -103,7 +103,7 @@ def _validate_tlist(tlist: Any) -> None:
         raise ValueError("tlist must be strictly increasing.")
 
 
-def _validate_drive_op_window(drive_op: DriveOp, tlist: Any) -> None:
+def _validate_drive_op_window(drive_op: ControlOp, tlist: Any) -> None:
     """Require *drive_op*'s pulse window to overlap ``tlist`` with positive measure.
 
     Raises ``ValueError`` unless
@@ -127,8 +127,8 @@ def _validate_drive_op_window(drive_op: DriveOp, tlist: Any) -> None:
         )
 
 
-def validate_drive_ops_window(drive_ops: list[DriveOp], tlist: Any) -> None:
-    """Validate every ``DriveOp`` in *drive_ops* against :func:`_validate_drive_op_window`."""
+def validate_drive_ops_window(drive_ops: list[ControlOp], tlist: Any) -> None:
+    """Validate every scheduled control op against its solve interval."""
     for drive_op in drive_ops:
         _validate_drive_op_window(drive_op, tlist)
 
@@ -140,7 +140,7 @@ def prepare_solve_problem_context(
     solver: str | None = None,
     options: dict | None = None,
     e_ops: dict | None = None,
-    drive_ops: list[DriveOp] | None = None,
+    drive_ops: list[ControlOp] | None = None,
     approximation: Approximation | None = None,
 ) -> SolveProblemContext:
     """Resolve the frame and retain authored observables and state specifications.
@@ -325,7 +325,7 @@ def build_solve_batch_from_results(
 
 def build_solve_problem(
     chip: Chip,
-    drive_ops: list[DriveOp],
+    drive_ops: list[ControlOp],
     tlist: Any,
     *,
     solver: str | None = None,

--- a/tests/test_coherent_input.py
+++ b/tests/test_coherent_input.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import jax
+import jax.numpy as jnp
+
+from quchip import (
+    ChargeDrive,
+    Chip,
+    CoherentInput,
+    ControlEndpoint,
+    ControlEquipment,
+    Delay,
+    DuffingTransmon,
+    PortNetwork,
+    QuantumSequence,
+    Resonator,
+    Square,
+)
+from quchip import Crosstalk, Gain
+from quchip.control.drive import BaseDrive
+from quchip.engine.ir import CoherentOp, evaluate_signal_program
+
+
+def _one_port_chip(*, rate: float = 0.04, delay: float = 0.0) -> tuple[Chip, Resonator]:
+    resonator = Resonator(freq=5.0, levels=2, label="r")
+    network = PortNetwork(label="line")
+    port = network.port("coupler", target=resonator, rate=rate)
+    if delay:
+        network.expose("feedline", input=port.input, output=port.output, delay=delay)
+    chip = Chip([resonator], port_network=network, frame="lab")
+    return chip, resonator
+
+
+def _dynamic_matrix(engine: object, time: float) -> np.ndarray:
+    terms = engine.dynamic_terms  # type: ignore[attr-defined]
+    matrix = np.zeros(terms[0].operator.shape, dtype=complex)
+    for term in terms:
+        coefficient = evaluate_signal_program(term.time_dependence.signal, time)
+        matrix = matrix + np.asarray(term.operator.to_dense()) * coefficient
+    return matrix
+
+
+def test_control_endpoint_is_structural_and_coherent_input_is_not_a_drive() -> None:
+    """Drives and coherent sources share the endpoint protocol without sharing a type."""
+    resonator = Resonator(freq=5.0, levels=2, label="r")
+    drive = ChargeDrive(target=resonator, label="charge")
+    source = CoherentInput("feedline", label="probe")
+
+    assert isinstance(drive, ControlEndpoint)
+    assert isinstance(source, ControlEndpoint)
+    assert not isinstance(source, BaseDrive)
+    assert source.target_label == "feedline"
+
+
+def test_sequence_schedules_coherent_input_through_the_common_endpoint_grammar() -> None:
+    """Coherent sources use the common sequence scheduling grammar."""
+    chip, _ = _one_port_chip()
+    source = CoherentInput("coupler", label="probe")
+    sequence = QuantumSequence(chip)
+
+    sequence.schedule(
+        source,
+        envelope=Square(duration=2.0, amplitude=0.3),
+        freq=5.0,
+        phase=0.2,
+    )
+
+    (operation,) = sequence.scheduled_ops
+    assert isinstance(operation, CoherentOp)
+    assert operation.coherent_input is source
+    assert operation.exposure == "coupler"
+    assert sequence.channel_cursors == {("coupler", "probe"): 2.0}
+
+
+def test_coherent_input_binds_to_engine_result_without_mutating_resolved_slh() -> None:
+    """Solve-time fields add drive terms without entering immutable resolved SLH."""
+    chip, _ = _one_port_chip(rate=0.04)
+    input_free = chip.resolve().slh
+    source = CoherentInput("coupler", label="probe")
+    sequence = QuantumSequence(chip)
+    sequence.schedule(source, envelope=Square(duration=2.0, amplitude=0.3))
+
+    engine = sequence.build_problem(tlist=np.linspace(0.0, 2.0, 21)).engine_result
+
+    np.testing.assert_allclose(engine.slh.S, input_free.S)
+    np.testing.assert_allclose(engine.slh.L[0].to_dense(), input_free.L[0].to_dense())
+    assert input_free.H.dynamic_terms == ()
+    assert engine.slh.H.dynamic_terms == ()
+    assert len(engine.collapse_terms) == len(input_free.channels) == 1
+    assert len(engine.coherent_inputs) == 1
+    assert engine.coherent_inputs[0].exposure == "coupler"
+    assert evaluate_signal_program(engine.coherent_inputs[0].beta, 1.0) == pytest.approx(0.3)
+
+    lowering = np.asarray(input_free.L[0].to_dense())
+    expected = 1j * (0.3 * lowering - 0.3 * lowering.conj().T)
+    np.testing.assert_allclose(_dynamic_matrix(engine, 1.0), expected)
+
+
+def test_beta_uses_the_existing_complex_signal_convention_without_rescaling() -> None:
+    """Incident beta follows the existing amplitude, phase, and carrier convention."""
+    chip, _ = _one_port_chip()
+    amplitude = 0.4
+    phase = 0.3
+    frequency = 0.75
+    sequence = QuantumSequence(chip)
+    sequence.schedule(
+        CoherentInput("coupler"),
+        envelope=Square(duration=1.0, amplitude=amplitude),
+        freq=frequency,
+        phase=phase,
+    )
+    engine = sequence.build_problem(tlist=np.linspace(0.0, 1.0, 11)).engine_result
+
+    time = 0.2
+    expected = amplitude * np.exp(1j * phase) * np.exp(-1j * 2.0 * np.pi * frequency * time)
+    assert evaluate_signal_program(engine.coherent_inputs[0].beta, time) == pytest.approx(expected)
+
+
+def test_scattering_routes_incident_beta_before_it_drives_the_system() -> None:
+    """Boundary scattering routes incident beta before Hamiltonian coupling."""
+    left = Resonator(freq=5.0, levels=2, label="left")
+    right = Resonator(freq=6.0, levels=2, label="right")
+    network = PortNetwork(scattering=[[0.0, 1.0], [1.0, 0.0]], label="swap")
+    network.port("left", target=left, rate=0.04)
+    network.port("right", target=right, rate=0.09)
+    chip = Chip([left, right], port_network=network, frame="lab")
+    sequence = QuantumSequence(chip)
+    sequence.schedule(
+        CoherentInput("left"),
+        envelope=Square(duration=1.0, amplitude=0.2),
+    )
+
+    engine = sequence.build_problem(tlist=np.linspace(0.0, 1.0, 11)).engine_result
+
+    left_l, right_l = (np.asarray(operator.to_dense()) for operator in engine.slh.L[:2])
+    expected = 1j * (0.2 * right_l - 0.2 * right_l.conj().T)
+    np.testing.assert_allclose(_dynamic_matrix(engine, 0.5), expected)
+    assert not np.allclose(expected, 1j * (0.2 * left_l - 0.2 * left_l.conj().T))
+
+
+def test_complex_scattering_phase_enters_c_equals_s_beta_with_correct_conjugation() -> None:
+    """Complex scattering enters the coherent Hamiltonian with SLH conjugation."""
+    resonator = Resonator(freq=5.0, levels=2, label="r")
+    network = PortNetwork(scattering=[[1j]], label="phase")
+    network.port("feedline", target=resonator, rate=0.04)
+    chip = Chip([resonator], port_network=network, frame="lab")
+    sequence = QuantumSequence(chip)
+    sequence.schedule(
+        CoherentInput("feedline"),
+        envelope=Square(duration=1.0, amplitude=0.2),
+    )
+    engine = sequence.build_problem(tlist=np.linspace(0.0, 1.0, 11)).engine_result
+
+    coupling = np.asarray(engine.slh.L[0].to_dense())
+    c = 1j * 0.2
+    expected = 1j * (np.conj(c) * coupling - c * coupling.conj().T)
+    np.testing.assert_allclose(_dynamic_matrix(engine, 0.5), expected)
+
+
+def test_resonant_coherent_input_is_static_in_the_matching_rotating_frame() -> None:
+    """A resonant coherent field is static in its matching rotating frame."""
+    resonator = Resonator(freq=5.0, levels=2, label="r")
+    network = PortNetwork(label="line")
+    network.port("feedline", target=resonator, rate=0.04)
+    chip = Chip([resonator], port_network=network, frame="rotating")
+    sequence = QuantumSequence(chip)
+    sequence.schedule(
+        CoherentInput("feedline"),
+        envelope=Square(duration=1.0, amplitude=0.2),
+        freq=5.0,
+    )
+    engine = sequence.build_problem(tlist=np.linspace(0.0, 1.0, 11)).engine_result
+
+    np.testing.assert_allclose(_dynamic_matrix(engine, 0.2), _dynamic_matrix(engine, 0.7))
+
+
+def test_exposure_delay_shifts_incident_beta_at_the_system_boundary() -> None:
+    """An exposure delay shifts the incident field at the system reference plane."""
+    chip, _ = _one_port_chip(delay=0.25)
+    sequence = QuantumSequence(chip)
+    sequence.schedule(
+        CoherentInput("feedline"),
+        envelope=Square(duration=1.0, amplitude=0.2),
+    )
+    engine = sequence.build_problem(tlist=np.linspace(0.0, 1.5, 16)).engine_result
+
+    beta = engine.coherent_inputs[0].beta
+    assert evaluate_signal_program(beta, 0.1) == pytest.approx(0.0)
+    assert evaluate_signal_program(beta, 0.5) == pytest.approx(0.2)
+
+
+def test_control_equipment_delay_rejects_a_coherent_input() -> None:
+    """Field delay belongs to network exposure rather than control equipment."""
+    with pytest.raises(TypeError, match="reference-plane delay"):
+        Delay(CoherentInput("feedline"), 0.2)
+
+
+def test_control_equipment_rejects_field_inputs_and_field_transforms() -> None:
+    """Control equipment and transforms reject field-source endpoints."""
+    source = CoherentInput("feedline")
+    with pytest.raises(TypeError, match="BaseDrive"):
+        ControlEquipment([source])  # type: ignore[list-item]
+    with pytest.raises(TypeError, match="PortNetwork"):
+        Gain(source, 0.5)
+    with pytest.raises(TypeError, match="PortNetwork"):
+        Crosstalk(source, "charge", beta=0.1)
+
+
+def test_unknown_exposure_is_rejected_at_schedule_time() -> None:
+    """Scheduling rejects a coherent source bound to an unknown exposure."""
+    chip, _ = _one_port_chip()
+
+    with pytest.raises(ValueError, match="Unknown coherent-input exposure"):
+        QuantumSequence(chip).schedule(
+            CoherentInput("missing"),
+            envelope=Square(duration=1.0, amplitude=0.2),
+        )
+
+
+def test_coherent_and_direct_charge_drives_are_equivalent_when_calibrated() -> None:
+    """Calibrated charge and port drives produce the same Hamiltonian term."""
+    rate = 0.04
+    beta = 0.3
+    transmon = DuffingTransmon(
+        freq=5.0,
+        anharmonicity=-0.25,
+        levels=3,
+        label="q",
+    )
+    charge = ChargeDrive(target=transmon, label="charge")
+    equipment = ControlEquipment([charge])
+    network = PortNetwork(label="line")
+    network.port("feedline", target=transmon, rate=rate)
+    chip = Chip(
+        [transmon],
+        control_equipment=equipment,
+        port_network=network,
+        frame="lab",
+    )
+
+    direct = QuantumSequence(chip)
+    direct.schedule(
+        charge,
+        envelope=Square(
+            duration=1.0,
+            amplitude=beta * np.sqrt(rate) / (2.0 * np.pi),
+        ),
+    )
+    field = QuantumSequence(chip)
+    field.schedule(
+        CoherentInput("feedline"),
+        envelope=Square(duration=1.0, amplitude=beta),
+    )
+
+    direct_engine = direct.build_problem(tlist=np.linspace(0.0, 1.0, 11)).engine_result
+    field_engine = field.build_problem(tlist=np.linspace(0.0, 1.0, 11)).engine_result
+    np.testing.assert_allclose(
+        _dynamic_matrix(field_engine, 0.5),
+        _dynamic_matrix(direct_engine, 0.5),
+    )
+
+
+def test_coherent_amplitude_remains_batchable() -> None:
+    """Coherent amplitude participates in ordinary sequence batching."""
+    chip, _ = _one_port_chip()
+    sequence = QuantumSequence(chip)
+    handle = sequence.schedule(
+        CoherentInput("coupler"),
+        envelope=Square(duration=1.0, amplitude=0.1),
+    )
+
+    batch = sequence.build_batch(
+        handle.vary("amplitude", [0.1, 0.25]),
+        tlist=np.linspace(0.0, 1.0, 11),
+    )
+
+    assert [
+        evaluate_signal_program(problem.engine_result.coherent_inputs[0].beta, 0.5)
+        for problem in batch
+    ] == pytest.approx([0.1, 0.25])
+
+
+def test_coherent_amplitude_is_jax_differentiable_through_assembly() -> None:
+    """Coherent amplitude remains differentiable through solve assembly."""
+    chip, _ = _one_port_chip()
+
+    def norm(amplitude: object) -> object:
+        sequence = QuantumSequence(chip)
+        sequence.schedule(
+            CoherentInput("coupler"),
+            envelope=Square(duration=1.0, amplitude=amplitude),
+        )
+        engine = sequence.build_problem(tlist=jnp.linspace(0.0, 1.0, 11)).engine_result
+        matrix = sum(
+            (
+                term.operator.to_dense()
+                * evaluate_signal_program(term.time_dependence.signal, 0.5, xp=jnp)
+                for term in engine.dynamic_terms
+            ),
+            start=jnp.zeros((2, 2), dtype=complex),
+        )
+        return jnp.real(jnp.vdot(matrix, matrix))
+
+    gradient = jax.grad(norm)(jnp.asarray(0.2))
+    assert np.isfinite(float(gradient))
+    assert float(gradient) > 0.0
+
+
+def test_qutip_and_dynamiqs_solve_the_same_coherent_input_problem() -> None:
+    """QuTiP and Dynamiqs agree on the same coherent-input evolution."""
+    pytest.importorskip("dynamiqs")
+    final_populations: list[float] = []
+    for backend in ("qutip", "dynamiqs"):
+        resonator = Resonator(freq=5.0, levels=5, label="r")
+        network = PortNetwork(label="line")
+        network.port("feedline", target=resonator, rate=0.04)
+        chip = Chip(
+            [resonator],
+            port_network=network,
+            frame="rotating",
+            backend=backend,
+        )
+        sequence = QuantumSequence(chip)
+        sequence.schedule(
+            CoherentInput("feedline"),
+            envelope=Square(duration=4.0, amplitude=0.5),
+            freq=5.0,
+        )
+        result = sequence.simulate(
+            tlist=np.linspace(0.0, 4.0, 41),
+            e_ops={resonator: resonator.number_operator()},
+            partition=False,
+        )
+        final_populations.append(float(np.real(result.expect_values(resonator)[-1])))
+
+    assert final_populations[0] > 0.1
+    assert final_populations[1] == pytest.approx(final_populations[0], rel=1e-5)


### PR DESCRIPTION
## Summary

- Add the structural `ControlEndpoint` protocol, which existing `BaseDrive` classes satisfy, plus an independent immutable `CoherentInput` endpoint that uses the same `QuantumSequence.schedule(...)` envelope, phase, carrier, timing, and batch grammar.
- Bind beta only during solve assembly. The immutable `ResolvedSLH` remains input-free; `EngineResult.coherent_inputs` retains reference-plane and boundary beta programs for later output reconstruction, while collapse channels remain unchanged.
- Derive coherent driving from the resolved boundary itself: `c = S beta` and `H_beta = i sum_j(c_j* L_j - c_j L_j dagger)`. Complex scattering, composed couplings, frames, and exposure delays therefore enter through the existing SLH and signal IR rather than component-specific cases.
- Keep field propagation in `PortNetwork`: control-equipment delay/gain/crosstalk reject coherent endpoints, while exposure delay shifts the inbound field. Preserve pulse batching and JAX differentiation, and verify equivalent QuTiP/Dynamiqs solves.

## Scope and diff

Production Python changes are +426/-50; focused tests add 339 lines and physics documentation is +29/-2. The positive production delta has three retained owners: the 69-line public endpoint module; about 150 lines for the one template-cached `S beta` source compiler and canonical Hamiltonian materializer; and the sequence/IR plumbing that carries a second control-op kind and solve-bound beta records through ordinary and batched problems. The remaining changes are exports, type/documentation updates, and explicit control-equipment boundary checks.

This is generalized framework rather than duplicated drive or backend logic. There are no resonator-, transmon-, VNA-, QuTiP-, or Dynamiqs-specific coherent-input branches. Removing the compiler would lose scattering/composed-`L` physics; removing the template layer would rebuild operator adjoints for every sweep point; merging `CoherentInput` into `BaseDrive` or `ControlEquipment` would give field propagation the wrong owner.

## Verification

- complete suite: 1733 passed
- core lane: 1378 passed, 355 deselected
- physics-sentinel lane: 54 passed
- focused coherent-input tests: 15 passed
- optional backend absent: the QuTiP/Dynamiqs parity test skips cleanly
- focused coherent-input plus PortNetwork tests: 31 passed
- QuTiP/Dynamiqs coherent-input population agreement: relative tolerance 1e-5
- Ruff: all checks passed
- mypy: no issues in 117 source files
- compileall: passed
- Sphinx: build succeeded (337 pre-existing autosummary/toctree warnings)
- `uv build`: sdist and wheel succeeded; `quchip/control/field.py` is present and local v0.3 design/progress files are absent
- `git diff --check`: clean

## Checklist

- [x] This pull request is focused and contains no unrelated changes.
- [x] Changed behavior is covered by tests, or no behavior changed.
- [x] Relevant documentation and examples are updated.
- [x] Generated files and paired notebooks are synchronized, if applicable.
- [x] `PHYSICS.md` is updated, or is not relevant: updated with solve-bound beta, immutable input-free `ResolvedSLH`, and coherent-source conventions.

## AI assistance

Codex assisted with implementation, test construction, diff review, and verification. I reviewed the SLH source composition, gauge-canonical Hamiltonian, signal/frame conventions, ownership boundaries, and submitted changes and remain accountable for them.
