### PR TITLE
feat: add SLH output observables

### DIFF
--- a/PHYSICS.md
+++ b/PHYSICS.md
@@ -116,6 +116,7 @@ lowering applies `sqrt(rate)` exactly once.
 
 Source: [`quchip/chip/ports.py`](quchip/chip/ports.py),
 [`quchip/control/field.py`](quchip/control/field.py),
+[`quchip/observables.py`](quchip/observables.py),
 [`quchip/engine/input_output.py`](quchip/engine/input_output.py),
 [`quchip/analysis/vna.py`](quchip/analysis/vna.py)
 
@@ -160,8 +161,25 @@ For the one-port identity case this reduces to the angular Hamiltonian
 H_input = i (beta_p^* L_p - beta_p L_p^dagger).
 ```
 
-Mean output, spectra, and correlations use the same `L_p`. For a single
-resonator, `external_quality_factor` gives
+Transient output observables are reconstructed from that same solve-bound
+model:
+
+```text
+<b_out,j> = c_j + <L_j>,
+<X_theta,j> = Re[exp(-i theta) <b_out,j>],
+<b_out,j^dagger b_out,j>
+  = |c_j|^2 + 2 Re[c_j^* <L_j>] + <L_j^dagger L_j>.
+```
+
+`OutputAmplitude`, `OutputQuadrature`, and `OutputPhotonFlux` lower only the
+required `L_j` and `L_j^dagger L_j` moments into backend expectation
+operators. The coherent background is evaluated from the retained beta
+programs; it is not inserted as an identity operator. The last expression is
+normally ordered photon flux. A reciprocal exposure delay shifts the complete
+boundary trace to the reported reference plane, with zero field before the
+simulation's initial boundary data can arrive.
+
+For a single resonator, `external_quality_factor` gives
 `kappa_p = 2π * freq / Q_external`. Internal resonator loss and every port are
 separate collapse channels, so `kappa_total` is their sum.
 
@@ -401,8 +419,17 @@ This makes `result.expect` a **co-rotating readout**: observables are always rep
 `Tr(rho_ss) = 1`. It requires a static resolved Hamiltonian and a unique
 normalized stationary state. `VNA.sweep()` adds continuous-wave port terms in
 their stationary tone frames. Small-signal scattering differentiates the
-output mean around the fixed-tone state; finite-amplitude scattering subtracts
-that operating-point output and divides by the swept input amplitude.
+output mean around the fixed-tone state,
+
+```text
+S_ji(f) = d <b_out,j> / d beta_in,i  at beta_probe -> 0.
+```
+
+The direct term comes from the resolved scalar `S`; the system term comes from
+the stationary response of `L` under the same coherent-input Hamiltonian.
+Finite-power spectroscopy is a `CoherentInput` time-domain simulation, not a
+second VNA probe mode. Fixed finite pumps remain valid VNA operating-point
+fields.
 The engine supplies canonical sources and observables for stationary response,
 spectrum, and correlation queries. Each backend constructs and solves its own
 native Liouvillian.

--- a/docs/guides/choosing-a-backend.md
+++ b/docs/guides/choosing-a-backend.md
@@ -102,8 +102,9 @@ through total Hilbert dimension 16 by default. Change that threshold with
 The dynamiqs backend uses `method="direct"`. dynamiqs does not supply a public
 steady-state solver in the supported release, so quchip constructs the
 Liouvillian, replaces one row with `Tr(rho) = 1`, and calls `jax.numpy.linalg.solve`.
-That path keeps stationary observables and finite-amplitude VNA response inside
-JAX transformations. It reports the residual, nullity, and condition number;
+That path keeps stationary observables, pumped small-signal VNA response, and
+transient output observables inside JAX transformations. It reports the
+residual, nullity, and condition number;
 it does not add a regularizer to a singular generator. Outside JAX tracing a
 non-unique generator raises. Inside `jax.jit`, where Python exceptions cannot
 depend on traced values, the result state is `NaN` when the nullity is not one.

--- a/docs/guides/steady-state-and-vna.md
+++ b/docs/guides/steady-state-and-vna.md
@@ -85,25 +85,60 @@ s21 = result.s21
 s_out_in = result.s(output_port, input_port)
 ```
 
-With no `amplitude`, `sweep()` computes the differential response around the
-current fixed-tone operating point. A finite complex amplitude returns the
-change from that operating point divided by the input amplitude:
+`sweep()` computes the small-signal derivative around the current fixed-tone
+operating point:
 
-```python
-result = vna.sweep(
-    np.linspace(6.75, 6.85, 501),
-    amplitude=np.geomspace(1e-4, 1e-1, 31),
-)
-
-assert result.s21.shape == (31, 501)
-assert np.allclose(result.input_photon_fluxes, abs(result.input_amplitudes) ** 2)
-input_power_watts = result.input_powers
+```text
+S_ji(f) = d <b_out,j> / d beta_in,i  at beta_probe -> 0.
 ```
 
-Every tone amplitude is the incoming field `beta` in `sqrt(photons/ns)` at
-the declared port reference plane. The port rate converts `beta` into the
-Hamiltonian drive. Source power at another reference plane needs its own
-attenuation model.
+The direct background is the resolved network `S`; the device response comes
+from `L` and the stationary Liouvillian. Exposure delays transform both ends
+between the chip boundary and the declared reference planes.
+
+## Finite fields and transient outputs
+
+Use an explicit coherent field simulation for finite-power spectroscopy,
+ring-up, ring-down, reflection, transmission, or emitted wave packets:
+
+```python
+from quchip import (
+    CoherentInput,
+    OutputAmplitude,
+    OutputPhotonFlux,
+    OutputQuadrature,
+    QuantumSequence,
+    Square,
+)
+
+sequence = QuantumSequence(chip)
+sequence.schedule(
+    CoherentInput(input_port),
+    envelope=Square(duration=200.0, amplitude=0.02),
+    freq=6.8,
+)
+transient = sequence.simulate(
+    tlist=np.linspace(0.0, 300.0, 601),
+    e_ops={
+        "transmission": OutputAmplitude(output_port),
+        "I": OutputQuadrature(output_port, phase=0.0),
+        "flux": OutputPhotonFlux(output_port),
+    },
+    partition=False,
+)
+
+b_out = transient.expect("transmission")
+quadrature_i = transient.expect("I")
+photon_flux = transient.expect("flux")
+```
+
+The scheduled amplitude is the incoming field `beta` in
+`sqrt(photons/ns)`, so `abs(beta)**2` is incident photon flux in photons/ns.
+The field follows `b_out = S b_in + L`. `OutputQuadrature(..., phase=theta)`
+uses `Re[exp(-i theta) <b_out>]`; `OutputPhotonFlux` is the normally ordered
+`<b_out^dagger b_out>`. Values are reported at the exposure reference plane;
+the matching `ObservableTrace.raw` is the Markov-boundary trace before its
+outbound delay.
 
 ## Two-tone response
 
@@ -164,7 +199,8 @@ records both `input_port` and `output_port`.
 
 QuTiP exposes several stationary algorithms and dense or sparse linear
 solvers. dynamiqs uses quchip's direct JAX solve for stationary work and keeps
-finite-amplitude response differentiable. Both use the same port operator for
-damping, coherent input, mean output, spectra, and correlations. See the
+small-signal response and transient output traces differentiable. Both use the
+same resolved SLH operators for damping, coherent input, mean output, spectra,
+and correlations. See the
 {doc}`backend guide <choosing-a-backend>` for the concrete solver options and
 links to both projects.

--- a/quchip/__init__.py
+++ b/quchip/__init__.py
@@ -127,6 +127,7 @@ from quchip.engine import (
 )
 from quchip.interop import EigenbasisDevice, ModelMapping
 from quchip.inverse_design import FitADressResult, FitParameterReport, ObservableReport, fit_a_dress
+from quchip.observables import OutputAmplitude, OutputPhotonFlux, OutputQuadrature
 from quchip.results import (
     ObservableTrace,
     PartitionedSimulationResult,
@@ -238,6 +239,9 @@ __all__ = [
     "steadystate_batch",
     "build_steadystate_problem",
     "ObservableTrace",
+    "OutputAmplitude",
+    "OutputQuadrature",
+    "OutputPhotonFlux",
     "SimulationBatchResult",
     "SimulationResult",
     "SteadyStateResult",

--- a/quchip/analysis/vna.py
+++ b/quchip/analysis/vna.py
@@ -20,8 +20,9 @@ from quchip.results.input_output import (
     SParameterResult,
 )
 from quchip.sweep import Sweep, ZippedSweep, _axis_metadata, _iter_axis_points
-from quchip.utils.constants import TWO_PI, hbar
+from quchip.utils.constants import TWO_PI
 from quchip.utils.jax_utils import contains_tracer, maybe_concrete_scalar
+from quchip.utils.labeling import resolve_label
 
 
 @dataclass(frozen=True)
@@ -34,13 +35,20 @@ class PortTone:
     _index: int
 
 
+@dataclass(frozen=True)
+class _ExposureRef:
+    """Validated external SLH exposure retained by label."""
+
+    label: str
+
+
 class VNA:
-    """Sweep one input port and report complex output-field response."""
+    """Sweep one incident exposure and report differential output scattering."""
 
     def __init__(self, chip: Any, *, input: Any, outputs: list[Any] | tuple[Any, ...]) -> None:
         self.chip = chip
-        self.input = chip.port(input)
-        self.outputs = tuple(chip.port(port) for port in outputs)
+        self.input = _resolve_exposure(chip, input)
+        self.outputs = tuple(_resolve_exposure(chip, port) for port in outputs)
         if not self.outputs:
             raise ValueError("VNA requires at least one output port.")
         labels = [port.label for port in self.outputs]
@@ -51,7 +59,7 @@ class VNA:
 
     def pump(self, port: Any, *, freq: Any, amplitude: Any) -> PortTone:
         """Add a fixed background tone and return its variation handle."""
-        resolved = self.chip.port(port)
+        resolved = _resolve_exposure(self.chip, port)
         tone = PortTone(resolved.label, freq, amplitude, len(self._tones))
         self._tones.append(tone)
         return tone
@@ -75,25 +83,20 @@ class VNA:
         self,
         frequencies: Any,
         *variations: Sweep | ZippedSweep,
-        amplitude: Any | None = None,
         options: dict | None = None,
         progress: bool = False,
     ) -> SParameterResult:
-        """Compute differential or finite-amplitude scattering response."""
+        """Compute the differential scattering response around fixed pumps."""
         self._validate_variations(variations)
         freq_values, freq_is_axis = _axis_values(frequencies)
-        amplitude_values, amplitude_is_axis = _amplitude_values(amplitude)
         variation_shape, variation_points = _iter_axis_points(variations)
         shape = variation_shape
-        if amplitude_is_axis:
-            shape += (len(amplitude_values),)
         if freq_is_axis:
             shape += (len(freq_values),)
 
         points = [
-            (coord, params, amplitude_index, probe_amplitude, frequency_index, frequency)
+            (coord, params, frequency_index, frequency)
             for coord, params in variation_points
-            for amplitude_index, probe_amplitude in enumerate(amplitude_values)
             for frequency_index, frequency in enumerate(freq_values)
         ]
         iterator: Any = points
@@ -106,7 +109,7 @@ class VNA:
         steady_states: list[Any] = []
         diagnostics: list[dict[str, Any]] = []
         operating_cache: dict[tuple[tuple[int, ...], int], tuple[Any, Any, Any]] = {}
-        for coord, params, _amplitude_index, probe_amplitude, frequency_index, frequency in iterator:
+        for coord, params, frequency_index, frequency in iterator:
             cache_key = (coord, frequency_index)
             if cache_key not in operating_cache:
                 tones = self._tone_values(params)
@@ -121,33 +124,16 @@ class VNA:
                 operating_cache[cache_key] = (operating_engine, operating, resolved_operators)
             operating_engine, operating, resolved_operators = operating_cache[cache_key]
 
-            if amplitude is None:
-                values = _small_signal_response(
-                    operating_engine,
-                    operating.state,
-                    self.chip.backend,
-                    resolved_operators,
-                    self.input.label,
-                    tuple(port.label for port in self.outputs),
-                )
-                state = operating
-            else:
-                driven_engine = add_port_inputs(
-                    operating_engine,
-                    self.chip.backend,
-                    ((self.input.label, frequency, probe_amplitude),),
-                )
-                driven = _solve_engine(self.chip, driven_engine, options)
-                values = _finite_response(
-                    operating.state,
-                    driven.state,
-                    self.chip.backend,
-                    resolved_operators,
-                    self.input.label,
-                    tuple(port.label for port in self.outputs),
-                    probe_amplitude,
-                )
-                state = driven
+            values = _small_signal_response(
+                operating_engine,
+                operating.state,
+                self.chip.backend,
+                resolved_operators,
+                self.input.label,
+                tuple(port.label for port in self.outputs),
+                frequency,
+            )
+            state = operating
 
             for label, value in values.items():
                 responses[label].append(value)
@@ -167,30 +153,12 @@ class VNA:
             for label, values in responses.items()
         }
         axes = _public_axes(variations, self._tones)
-        if amplitude_is_axis:
-            axes += (("amplitude", amplitude_values),)
         if freq_is_axis:
             axes += (("frequency", freq_values),)
-        photon_fluxes = (
-            None
-            if amplitude is None
-            else xp.abs(xp.asarray(amplitude_values if amplitude_is_axis else amplitude)) ** 2
-        )
         return SParameterResult(
             frequencies=freq_values if freq_is_axis else freq_values[0],
             input_port=self.input.label,
             output_ports=tuple(port.label for port in self.outputs),
-            input_amplitudes=(amplitude_values if amplitude_is_axis else amplitude),
-            input_photon_fluxes=photon_fluxes,
-            input_powers=_input_powers(
-                photon_fluxes,
-                freq_values if freq_is_axis else freq_values[0],
-                amplitude_is_axis=amplitude_is_axis,
-                frequency_is_axis=freq_is_axis,
-                variation_rank=len(variation_shape),
-                result_shape=shape,
-                xp=xp,
-            ),
             axes=axes,
             shape=shape,
             steady_states=tuple(steady_states),
@@ -217,7 +185,7 @@ class VNA:
         coherent carrier is reported separately because it is a delta peak,
         not a finite sampled spectral density.
         """
-        output_port = self.chip.port(output)
+        output_port = _resolve_exposure(self.chip, output)
         frequency_values, _ = _axis_values(frequencies)
         engine, state, operators, incoming = self._stationary_output(options)
         xp = self.chip.backend.array_module
@@ -288,8 +256,8 @@ class VNA:
         order: int,
         options: dict | None,
     ) -> OutputCorrelationResult:
-        output_port = self.chip.port(output)
-        input_port = output_port if input is None else self.chip.port(input)
+        output_port = _resolve_exposure(self.chip, output)
+        input_port = output_port if input is None else _resolve_exposure(self.chip, input)
         delay_values, _ = _axis_values(delays)
         if not contains_tracer(delay_values) and np.any(np.asarray(delay_values) < 0):
             raise ValueError("Stationary output correlations require non-negative delays.")
@@ -367,13 +335,9 @@ class VNA:
         options: dict | None,
     ) -> tuple[EngineResult, Any, dict[str, CanonicalOperator], dict[str, Any]]:
         tones = self._tone_values({})
-        incoming: dict[str, Any] = {}
-        for port_label, _frequency, amplitude in tones:
-            incoming[port_label] = incoming.get(port_label, 0.0) + amplitude
-        target = self.input.resolve_targets(self.chip)[0]
         reference_frequency = next(
             (frequency for port_label, frequency, _ in tones if port_label == self.input.label),
-            getattr(self.chip[target], "freq"),
+            _exposure_reference_frequency(self.chip, self.input.label),
         )
         engine = resolve_stationary_engine(
             self.chip,
@@ -382,7 +346,27 @@ class VNA:
         )
         driven_engine = add_port_inputs(engine, self.chip.backend, tones)
         state = _solve_engine(self.chip, driven_engine, options)
-        return driven_engine, state, port_operators(driven_engine, self.chip.backend), incoming
+        incoming = _stationary_output_backgrounds(driven_engine, tones, self.chip.backend)
+        operators = port_operators(driven_engine, self.chip.backend)
+        xp = self.chip.backend.array_module
+        for channel in driven_engine.slh.external_channels:
+            frequency = (
+                0.0
+                if channel.collapse.frame_frequency is None
+                else channel.collapse.frame_frequency
+            )
+            phase = xp.exp(
+                1j
+                * TWO_PI
+                * xp.asarray(frequency)
+                * xp.asarray(channel.reference_delay)
+            )
+            operators[channel.key] = operators[channel.key].scaled(
+                phase,
+                tag=f"reference_plane:{channel.key}",
+            )
+            incoming[channel.key] = phase * incoming[channel.key]
+        return driven_engine, state, operators, incoming
 
     def _tone_values(self, params: dict[str, Any]) -> tuple[tuple[str, Any, Any], ...]:
         tones: list[tuple[str, Any, Any]] = []
@@ -402,13 +386,24 @@ def _axis_values(values: Any) -> tuple[Any, bool]:
     return array, True
 
 
-def _amplitude_values(amplitude: Any | None) -> tuple[Any, bool]:
-    if amplitude is None or np.ndim(amplitude) == 0:
-        return (amplitude,), False
-    array = amplitude if hasattr(amplitude, "shape") else np.asarray(amplitude)
-    if len(array) == 0:
-        raise ValueError("VNA amplitude sweep cannot be empty.")
-    return array, True
+def _resolve_exposure(chip: Any, value: Any) -> _ExposureRef:
+    """Resolve a Port object or label against the external SLH boundary."""
+    label = resolve_label(value)
+    available = [channel.key for channel in chip.resolve().slh.external_channels]
+    if label not in available:
+        raise ValueError(f"Unknown VNA exposure {label!r}. Available exposures: {available}.")
+    return _ExposureRef(label)
+
+
+def _exposure_reference_frequency(chip: Any, label: str) -> Any:
+    """Return the exposure carrier in the chip's natural rotating frame."""
+    resolved = chip.resolve(frame="rotating")
+    for channel in resolved.slh.external_channels:
+        if channel.key == label:
+            frequency = channel.collapse.frame_frequency
+            return 0.0 if frequency is None else frequency
+    available = [channel.key for channel in resolved.slh.external_channels]
+    raise ValueError(f"Unknown VNA exposure {label!r}. Available exposures: {available}.")
 
 
 def _public_axis_name(name: str, tones: list[PortTone]) -> str:
@@ -443,28 +438,31 @@ def _solve_engine(chip: Any, engine: EngineResult, options: dict | None) -> Any:
     return solve_steadystate_problem(problem)
 
 
-def _finite_response(
-    operating_state: Any,
-    driven_state: Any,
+def _stationary_output_backgrounds(
+    engine: EngineResult,
+    tones: tuple[tuple[str, Any, Any], ...],
     backend: Any,
-    port_operators: dict[str, CanonicalOperator],
-    input_label: str,
-    output_labels: tuple[str, ...],
-    amplitude: Any,
 ) -> dict[str, Any]:
+    """Return ``S beta`` at each Markov boundary for fixed reference-plane tones."""
     xp = backend.array_module
-    if not contains_tracer(amplitude) and np.ndim(amplitude) == 0 and complex(amplitude) == 0:
-        raise ValueError("Finite-amplitude VNA response requires a nonzero input amplitude.")
-    operating = xp.asarray(backend.to_array(operating_state), dtype=complex)
-    driven = xp.asarray(backend.to_array(driven_state), dtype=complex)
-    response: dict[str, Any] = {}
-    for label in output_labels:
-        operator = xp.asarray(port_operators[label].to_dense())
-        change = xp.trace(operator @ (driven - operating))
-        if label == input_label:
-            change = change + xp.asarray(amplitude)
-        response[label] = change / xp.asarray(amplitude)
-    return response
+    external = engine.slh.external_channels
+    exposure_index = {channel.key: index for index, channel in enumerate(external)}
+    incident = [xp.asarray(0.0 + 0.0j) for _ in external]
+    for label, frequency, amplitude in tones:
+        index = exposure_index[label]
+        incident[index] = incident[index] + xp.asarray(amplitude) * xp.exp(
+            1j * TWO_PI * xp.asarray(frequency) * xp.asarray(external[index].reference_delay)
+        )
+    return {
+        channel.key: sum(
+            (
+                xp.asarray(engine.slh.S[output_index, input_index]) * beta
+                for input_index, beta in enumerate(incident)
+            ),
+            start=xp.asarray(0.0 + 0.0j),
+        )
+        for output_index, channel in enumerate(external)
+    }
 
 
 def _small_signal_response(
@@ -474,15 +472,24 @@ def _small_signal_response(
     port_operators: dict[str, CanonicalOperator],
     input_label: str,
     output_labels: tuple[str, ...],
+    frequency: Any,
 ) -> dict[str, Any]:
     """Evaluate the port response through the backend stationary resolvent."""
     xp = backend.array_module
     rho = xp.asarray(backend.to_array(state), dtype=complex)
-    input_operator = xp.asarray(port_operators[input_label].to_dense(), dtype=complex)
+    external = engine.slh.external_channels
+    exposure_index = {channel.key: index for index, channel in enumerate(external)}
+    input_index = exposure_index[input_label]
+    template = port_operators[external[0].key]
+    input_operator = xp.zeros(template.shape, dtype=complex)
+    for output_index, channel in enumerate(external):
+        input_operator = input_operator + xp.conj(
+            xp.asarray(engine.slh.S[output_index, input_index])
+        ) * xp.asarray(port_operators[channel.key].to_dense(), dtype=complex)
     input_dag = xp.conj(xp.swapaxes(input_operator, -1, -2))
     source = _canonical_matrix(
         input_dag @ rho - rho @ input_dag,
-        port_operators[input_label],
+        template,
         tag=f"linear-response-source:{input_label}",
     )
     response = backend.stationary_resolvent(
@@ -491,10 +498,21 @@ def _small_signal_response(
         tuple((label, port_operators[label]) for label in output_labels),
         (0.0,),
     )
-    return {
-        label: (1.0 if label == input_label else 0.0) + response[label][0]
-        for label in output_labels
-    }
+    input_phase = xp.exp(
+        1j * TWO_PI * xp.asarray(frequency) * xp.asarray(external[input_index].reference_delay)
+    )
+    result: dict[str, Any] = {}
+    for label in output_labels:
+        output_index = exposure_index[label]
+        output_phase = xp.exp(
+            1j
+            * TWO_PI
+            * xp.asarray(frequency)
+            * xp.asarray(external[output_index].reference_delay)
+        )
+        boundary = xp.asarray(engine.slh.S[output_index, input_index]) + response[label][0]
+        result[label] = input_phase * output_phase * boundary
+    return result
 
 
 def _output_field_matrix(operator: CanonicalOperator, incoming: Any, xp: Any) -> Any:
@@ -516,27 +534,3 @@ def _canonical_matrix(
         subsystem_labels=template.subsystem_labels,
         tag=tag,
     )
-
-
-def _input_powers(
-    photon_fluxes: Any | None,
-    frequencies: Any,
-    *,
-    amplitude_is_axis: bool,
-    frequency_is_axis: bool,
-    variation_rank: int,
-    result_shape: tuple[int, ...],
-    xp: Any,
-) -> Any | None:
-    """Convert GHz and photons/ns to coherent input power in watts."""
-    if photon_fluxes is None:
-        return None
-    flux = xp.asarray(photon_fluxes)
-    frequency = xp.asarray(frequencies)
-    if amplitude_is_axis and frequency_is_axis:
-        flux = flux[..., None]
-    power = hbar * TWO_PI * 1e18 * flux * frequency
-    if not result_shape:
-        return power
-    power = xp.reshape(power, (1,) * variation_rank + tuple(power.shape))
-    return xp.broadcast_to(power, result_shape)

--- a/quchip/engine/__init__.py
+++ b/quchip/engine/__init__.py
@@ -152,7 +152,9 @@ def build_problem(
         (backend selection is chip-owned).
     e_ops : dict, optional
         Observables keyed by device label (or a 2-tuple of labels for a
-        two-body observable).
+        two-body observable). A string trace name may instead map to an
+        ``OutputAmplitude``, ``OutputQuadrature``, or ``OutputPhotonFlux``
+        spec for an accessible SLH exposure.
     initial_state : optional
         Initial state; ``None`` defaults to the chip ground state.
 

--- a/quchip/engine/input_output.py
+++ b/quchip/engine/input_output.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from quchip.chip.partition import connected_components
 from quchip.engine.ir import CanonicalOperator, EngineResult, StaticTerm
+from quchip.utils.constants import TWO_PI
 from quchip.utils.jax_utils import maybe_concrete_scalar
 
 
@@ -23,9 +24,32 @@ def resolve_stationary_engine(
     if not port_frequencies:
         raise ValueError("Stationary port analysis requires at least one tone frequency.")
 
+    reference = port_frequencies[0][1]
+    one_carrier = all(
+        same_frequency(reference, frequency)
+        for _, frequency in port_frequencies[1:]
+    )
+    if one_carrier:
+        engine = chip.resolve(frame=reference)
+        _validate_port_frequencies(engine, port_frequencies)
+        if engine.dynamic_terms:
+            raise ValueError(
+                "The selected tones leave dynamic Hamiltonian terms after frame and approximation resolution. "
+                "Use QuantumSequence for time evolution; periodic/Floquet steady states are not supported."
+            )
+        return engine
+
     device_frequencies: dict[str, Any] = {}
     for port_label, frequency in port_frequencies:
-        for target in chip.port(port_label).resolve_targets(chip):
+        try:
+            targets = chip.port(port_label).resolve_targets(chip)
+        except KeyError as exc:
+            raise ValueError(
+                "Distinct stationary tones through composed PortNetwork exposures "
+                "are not representable by one static frame. Use QuantumSequence "
+                "for time evolution."
+            ) from exc
+        for target in targets:
             assigned = device_frequencies.get(target)
             if assigned is not None and not same_frequency(assigned, frequency):
                 raise ValueError(
@@ -52,12 +76,7 @@ def resolve_stationary_engine(
             )
         device_frequencies.update({label: reference for label in component})
 
-    reference = port_frequencies[0][1]
-    one_carrier = all(
-        same_frequency(reference, frequency)
-        for _, frequency in port_frequencies[1:]
-    )
-    engine = chip.resolve(frame=reference if one_carrier else device_frequencies)
+    engine = chip.resolve(frame=device_frequencies)
     if engine.dynamic_terms:
         raise ValueError(
             "The selected tones leave dynamic Hamiltonian terms after frame and approximation resolution. "
@@ -71,8 +90,7 @@ def port_operators(engine: EngineResult, backend: Any) -> dict[str, CanonicalOpe
     """Return each resolved ``L_p = exp(i phi) sqrt(kappa) A_p`` operator."""
     operators: dict[str, CanonicalOperator] = {}
     for channel in engine.slh.external_channels:
-        term = channel.collapse
-        operators[term.label] = channel.coupling.with_metadata(tag=f"port:{term.label}")
+        operators[channel.key] = channel.coupling.with_metadata(tag=f"port:{channel.key}")
     return operators
 
 
@@ -85,18 +103,33 @@ def add_port_inputs(
     if not tones:
         return engine
     xp = backend.array_module
+    external = engine.slh.external_channels
     operators = port_operators(engine, backend)
+    exposure_index = {channel.key: index for index, channel in enumerate(external)}
     _validate_port_frequencies(
         engine,
         tuple((port_label, frequency) for port_label, frequency, _ in tones),
     )
-    terms = list(engine.applied_hamiltonian.static_terms)
+    incident = [xp.asarray(0.0 + 0.0j) for _ in external]
     for port_label, frequency, amplitude in tones:
-        coupling = operators[port_label]
+        input_index = exposure_index[port_label]
+        delay = external[input_index].reference_delay
+        incident[input_index] = incident[input_index] + xp.asarray(amplitude) * xp.exp(
+            1j * TWO_PI * xp.asarray(frequency) * xp.asarray(delay)
+        )
+
+    terms = list(engine.applied_hamiltonian.static_terms)
+    for output_index, channel in enumerate(external):
+        coefficient = xp.asarray(0.0 + 0.0j)
+        for input_index, amplitude in enumerate(incident):
+            coefficient = coefficient + xp.asarray(
+                engine.slh.S[output_index, input_index]
+            ) * amplitude
+        coupling = operators[channel.key]
         values = coupling.to_dense()
         h_input = 1j * (
-            xp.conj(xp.asarray(amplitude)) * values
-            - xp.asarray(amplitude) * xp.conj(xp.swapaxes(values, -1, -2))
+            xp.conj(coefficient) * values
+            - coefficient * xp.conj(xp.swapaxes(values, -1, -2))
         )
         terms.append(
             StaticTerm(
@@ -105,10 +138,10 @@ def add_port_inputs(
                     dims=coupling.dims,
                     basis=coupling.basis,
                     subsystem_labels=coupling.subsystem_labels,
-                    tag=f"input:{port_label}",
+                    tag=f"input:{channel.key}",
                 ),
                 origin="port",
-                metadata={"port": port_label},
+                metadata={"port": channel.key},
             )
         )
     return engine.with_applied_hamiltonian_terms(static_terms=tuple(terms))
@@ -119,7 +152,10 @@ def _validate_port_frequencies(
     port_frequencies: tuple[tuple[str, Any], ...],
 ) -> None:
     """Check that every requested tone matches its resolved port phase."""
-    port_terms = {term.label: term for term in engine.port_terms}
+    port_terms = {
+        channel.key: channel.collapse_term
+        for channel in engine.slh.external_channels
+    }
     for port_label, frequency in port_frequencies:
         if port_label not in port_terms:
             raise ValueError(f"Unknown resolved port {port_label!r}.")

--- a/quchip/engine/observables.py
+++ b/quchip/engine/observables.py
@@ -18,6 +18,11 @@ This module performs the two operations that tie those frames together:
   transformation applied to each band — equivalent to moving the
   observable from the simulation frame to the control frame.
 
+Output-field specs take a parallel path: they lower the resolved ``L`` and
+``L dagger L`` moments before the solve, then reconstruct ``S beta + L`` from
+the solve-bound coherent inputs and propagate it to the exposure reference
+plane afterward.
+
 Observable reconstruction reads per-device demodulation frequencies from
 :class:`~quchip.engine.ir.ResolvedFrame` and forms the demodulation
 phase ``exp(i · 2π · ω · w · t)``. This is the inverse of the
@@ -27,13 +32,20 @@ rotating-frame shift applied to the Hamiltonian during assembly.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Mapping, Sequence
+from typing import Any, Literal, Mapping, Sequence
 
 import numpy as np
 
 from quchip.backend import Backend, SolverResult
 from quchip.chip.chip import Chip
 from quchip.engine.ir import ResolvedFrame
+from quchip.observables import (
+    OutputAmplitude,
+    OutputObservable,
+    OutputPhotonFlux,
+    OutputQuadrature,
+    is_output_observable,
+)
 from quchip.results.results import ObservableTrace
 from quchip.utils.constants import TWO_PI
 from quchip.utils.jax_utils import array_namespace as _array_namespace
@@ -62,6 +74,15 @@ class BandMeta:
     sub_index: int | None = None
 
 
+@dataclass(frozen=True)
+class OutputMeta:
+    """Reconstruction recipe for one solver-facing output operator."""
+
+    key: EOpKey
+    observable: OutputObservable
+    role: Literal["amplitude", "flux"]
+
+
 def _resolve_eop_key(key: Any) -> EOpKey:
     if isinstance(key, str):
         return key
@@ -75,7 +96,8 @@ def decompose_eops(
     chip: Chip,
     backend: Backend,
     bases: Mapping[str, Any] | None = None,
-) -> tuple[list[Any], list[BandMeta]]:
+    engine_result: Any | None = None,
+) -> tuple[list[Any], list[BandMeta | OutputMeta]]:
     """Flatten dict-form ``e_ops`` into ``(ops, meta)`` ready for the solver.
 
     Supported key shapes:
@@ -86,6 +108,9 @@ def decompose_eops(
     * ``("label_a", "label_b")`` with a tuple ``(op_a, op_b)`` — each
       operator is split into single-mode bands on its device and all
       band pairs are tensored, producing two-body ``(w_a, w_b)`` bands.
+    * A string trace name with an ``OutputAmplitude``, ``OutputQuadrature``,
+      or ``OutputPhotonFlux`` value — the required resolved SLH moments are
+      lowered directly and reconstructed after the solve.
 
     For each band, the returned :class:`BandMeta` records the original
     key, the weight, and the sub-index (distinguishing entries when the
@@ -96,12 +121,30 @@ def decompose_eops(
         bases = chip.resolve().bases
 
     flat_ops: list[Any] = []
-    meta: list[BandMeta] = []
+    meta: list[BandMeta | OutputMeta] = []
 
     dims = chip.dims
 
     for raw_key, val in e_ops_dict.items():
         key = _resolve_eop_key(raw_key)
+
+        if is_output_observable(val):
+            if not isinstance(key, str):
+                raise ValueError("Output observable trace names must be strings.")
+            if engine_result is None:
+                raise ValueError(
+                    "Output observables require a resolved transient solve; "
+                    "pass them to QuantumSequence.simulate(..., e_ops=...)."
+                )
+            _append_output_eops(
+                flat_ops,
+                meta,
+                key=key,
+                observable=val,
+                engine_result=engine_result,
+                backend=backend,
+            )
+            continue
 
         if isinstance(key, str):
             device_label = key
@@ -191,6 +234,49 @@ def decompose_eops(
         raise ValueError("e_ops dict keys must be device labels (str) or 2-tuples of device labels")
 
     return flat_ops, meta
+
+
+def _append_output_eops(
+    flat_ops: list[Any],
+    meta: list[BandMeta | OutputMeta],
+    *,
+    key: EOpKey,
+    observable: OutputObservable,
+    engine_result: Any,
+    backend: Backend,
+) -> None:
+    """Lower one field recipe to the moments the backend must evaluate."""
+    external = {channel.key: channel for channel in engine_result.slh.external_channels}
+    channel = external.get(observable.exposure)
+    if channel is None:
+        raise ValueError(
+            f"Unknown output exposure {observable.exposure!r}. "
+            f"Available exposures: {list(external)}."
+        )
+
+    coupling = channel.coupling
+    flat_ops.append(backend.from_canonical_operator(coupling))
+    meta.append(OutputMeta(key=key, observable=observable, role="amplitude"))
+    if not isinstance(observable, OutputPhotonFlux):
+        return
+
+    values = coupling.to_dense()
+    xp = backend.array_module
+    number = xp.conj(xp.swapaxes(values, -1, -2)) @ values
+    from quchip.engine.ir import CanonicalOperator
+
+    flat_ops.append(
+        backend.from_canonical_operator(
+            CanonicalOperator.from_dense(
+                number,
+                dims=coupling.dims,
+                basis=coupling.basis,
+                subsystem_labels=coupling.subsystem_labels,
+                tag=f"output_flux:{observable.exposure}",
+            )
+        )
+    )
+    meta.append(OutputMeta(key=key, observable=observable, role="flux"))
 
 
 def recombine_expect(
@@ -287,8 +373,9 @@ def build_observable_traces(
     tlist: np.ndarray,
     chip: Chip,
     *,
-    dict_meta: list[BandMeta],
+    dict_meta: list[BandMeta | OutputMeta],
     resolved_frame: ResolvedFrame,
+    engine_result: Any,
 ) -> dict[EOpKey, ObservableTrace | list[ObservableTrace]]:
     """Wrap solver expectations into phase-corrected :class:`ObservableTrace` objects.
 
@@ -298,15 +385,21 @@ def build_observable_traces(
     e_ops keys. Each value is an :class:`ObservableTrace` (or a list
     when the user supplied multiple operators for the same key).
     """
-    del chip  # recombination uses the resolved frame metadata
+    del chip  # reconstruction uses resolved solve metadata
     raw_expect = solver_result.expect
     if isinstance(raw_expect, dict):
         flat_expect: Sequence[Any] = list(raw_expect.values())
     else:
         flat_expect = raw_expect or []
+    ordinary_expect = [
+        values
+        for values, meta in zip(flat_expect, dict_meta, strict=True)
+        if isinstance(meta, BandMeta)
+    ]
+    ordinary_meta = [meta for meta in dict_meta if isinstance(meta, BandMeta)]
     band_sum, phase_corrected = recombine_expect(
-        flat_expect=flat_expect,
-        meta_list=dict_meta,
+        flat_expect=ordinary_expect,
+        meta_list=ordinary_meta,
         tlist=tlist,
         frame_freqs=resolved_frame.demod_freqs,
         direction="demodulate",
@@ -321,4 +414,100 @@ def build_observable_traces(
             ]
         else:
             traces[key] = ObservableTrace(values=values, raw=raw)
+    traces.update(
+        _build_output_traces(
+            flat_expect,
+            dict_meta,
+            tlist=tlist,
+            engine_result=engine_result,
+        )
+    )
     return traces
+
+
+def _build_output_traces(
+    flat_expect: Sequence[Any],
+    meta_list: Sequence[BandMeta | OutputMeta],
+    *,
+    tlist: Any,
+    engine_result: Any,
+) -> dict[EOpKey, ObservableTrace]:
+    """Reconstruct ``b_out = S b_in + L`` moments at reference planes."""
+    output_pairs = [
+        (values, meta)
+        for values, meta in zip(flat_expect, meta_list, strict=True)
+        if isinstance(meta, OutputMeta)
+    ]
+    if not output_pairs:
+        return {}
+
+    sample = output_pairs[0][0]
+    xp = _array_namespace(sample)
+    times = xp.asarray(tlist, dtype=float)
+    external = engine_result.slh.external_channels
+    exposure_index = {channel.key: index for index, channel in enumerate(external)}
+    incident = [xp.zeros_like(times, dtype=complex) for _ in external]
+    from quchip.engine.ir import evaluate_signal_program
+
+    for bound in engine_result.coherent_inputs:
+        index = exposure_index.get(bound.exposure)
+        if index is not None:
+            incident[index] = incident[index] + evaluate_signal_program(
+                bound.beta,
+                times,
+                xp=xp,
+            )
+
+    grouped: dict[EOpKey, dict[str, Any]] = {}
+    specs: dict[EOpKey, OutputObservable] = {}
+    for values, meta in output_pairs:
+        grouped.setdefault(meta.key, {})[meta.role] = xp.asarray(values)
+        specs[meta.key] = meta.observable
+
+    traces: dict[EOpKey, ObservableTrace] = {}
+    for key, moments in grouped.items():
+        observable = specs[key]
+        output_index = exposure_index[observable.exposure]
+        channel = external[output_index]
+        direct = xp.zeros_like(times, dtype=complex)
+        for input_index, beta in enumerate(incident):
+            direct = direct + xp.asarray(engine_result.slh.S[output_index, input_index]) * beta
+
+        frame_frequency = (
+            0.0
+            if channel.collapse.frame_frequency is None
+            else channel.collapse.frame_frequency
+        )
+        carrier = xp.exp(-1j * TWO_PI * xp.asarray(frame_frequency) * times)
+        lowering = carrier * moments["amplitude"]
+        field = direct + lowering
+
+        if isinstance(observable, OutputAmplitude):
+            boundary = field
+        elif isinstance(observable, OutputQuadrature):
+            boundary = xp.real(xp.exp(-1j * xp.asarray(observable.phase)) * field)
+        else:
+            number = xp.real(moments["flux"])
+            boundary = (
+                xp.abs(direct) ** 2
+                + 2.0 * xp.real(xp.conj(direct) * lowering)
+                + number
+            )
+        values = _delay_trace(boundary, times, channel.reference_delay, xp)
+        traces[key] = ObservableTrace(values=values, raw=boundary)
+    return traces
+
+
+def _delay_trace(values: Any, times: Any, delay: Any, xp: Any) -> Any:
+    """Propagate one boundary trace to its reciprocal external reference plane."""
+    from quchip.utils.jax_utils import maybe_concrete_scalar
+
+    concrete = maybe_concrete_scalar(delay)
+    if concrete is not None and concrete == 0.0:
+        return values
+    query = times - xp.asarray(delay)
+    real = xp.interp(query, times, xp.real(values), left=0.0, right=0.0)
+    if not xp.iscomplexobj(values):
+        return real
+    imag = xp.interp(query, times, xp.imag(values), left=0.0, right=0.0)
+    return real + 1j * imag

--- a/quchip/engine/problem.py
+++ b/quchip/engine/problem.py
@@ -206,6 +206,7 @@ def _prepare_context_eops(
         context.chip,
         context.chip.backend,
         engine_result.bases,
+        engine_result=engine_result,
     )
 
 

--- a/quchip/observables.py
+++ b/quchip/observables.py
@@ -1,0 +1,51 @@
+"""Public solve-time observables for accessible SLH output fields."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, TypeAlias
+
+from quchip.utils.labeling import resolve_label
+
+
+@dataclass(frozen=True)
+class OutputAmplitude:
+    r"""Mean output field ``<b_out>`` at one exposure reference plane."""
+
+    exposure: str
+
+    def __init__(self, exposure: str | Any) -> None:
+        object.__setattr__(self, "exposure", resolve_label(exposure))
+
+
+@dataclass(frozen=True)
+class OutputQuadrature:
+    r"""Mean field quadrature ``Re[exp(-i phase) <b_out>]``."""
+
+    exposure: str
+    phase: Any = 0.0
+
+    def __init__(self, exposure: str | Any, *, phase: Any = 0.0) -> None:
+        object.__setattr__(self, "exposure", resolve_label(exposure))
+        object.__setattr__(self, "phase", phase)
+
+
+@dataclass(frozen=True)
+class OutputPhotonFlux:
+    r"""Normally ordered output photon flux ``<b_out dagger b_out>``."""
+
+    exposure: str
+
+    def __init__(self, exposure: str | Any) -> None:
+        object.__setattr__(self, "exposure", resolve_label(exposure))
+
+
+OutputObservable: TypeAlias = OutputAmplitude | OutputQuadrature | OutputPhotonFlux
+
+
+def is_output_observable(value: Any) -> bool:
+    """Return whether *value* is a public output-field observable spec."""
+    return isinstance(value, (OutputAmplitude, OutputQuadrature, OutputPhotonFlux))
+
+
+__all__ = ["OutputAmplitude", "OutputPhotonFlux", "OutputQuadrature"]

--- a/quchip/results/input_output.py
+++ b/quchip/results/input_output.py
@@ -13,24 +13,16 @@ from quchip.utils.labeling import resolve_label
 
 @dataclass(frozen=True)
 class SParameterResult:
-    """Complex port response over a declared VNA sweep grid."""
+    """Complex small-signal scattering over a declared VNA sweep grid."""
 
     frequencies: Any
     input_port: str
     output_ports: tuple[str, ...]
-    input_amplitudes: Any | None
-    input_photon_fluxes: Any | None
-    input_powers: Any | None
     axes: tuple[tuple[str, Any], ...]
     shape: tuple[int, ...]
     steady_states: tuple[Any, ...]
     diagnostics: tuple[Mapping[str, Any], ...]
     _response: Mapping[tuple[str, str], Any] = field(repr=False)
-
-    @property
-    def input_power_unit(self) -> str:
-        """Unit of :attr:`input_powers`."""
-        return "W"
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "_response", MappingProxyType(dict(self._response)))

--- a/quchip/results/results.py
+++ b/quchip/results/results.py
@@ -531,13 +531,19 @@ def _wrap(
     tlist: Any,
     e_ops_meta: Any,
     resolved_frame: Any,
+    engine_result: Any,
 ) -> SimulationResult:
     observable_traces = None
     if e_ops_meta is not None:
         from quchip.engine.observables import build_observable_traces
 
         observable_traces = build_observable_traces(
-            solver_result, tlist, chip, dict_meta=e_ops_meta, resolved_frame=resolved_frame
+            solver_result,
+            tlist,
+            chip,
+            dict_meta=e_ops_meta,
+            resolved_frame=resolved_frame,
+            engine_result=engine_result,
         )
     return SimulationResult(
         solver_result=solver_result,
@@ -563,6 +569,7 @@ def wrap_solver_result(solver_result: SolverResult, problem: SolveProblem, backe
         tlist=problem.tlist,
         e_ops_meta=problem.e_ops_meta,
         resolved_frame=problem.resolved_frame,
+        engine_result=problem.engine_result,
     )
 
 
@@ -580,6 +587,7 @@ def wrap_solver_results_from_batch(
             tlist=problem.tlist,
             e_ops_meta=problem.e_ops_meta,
             resolved_frame=problem.resolved_frame,
+            engine_result=problem.engine_result,
         )
         for solver_result, problem in zip(solver_results, batch.problems)
     ]

--- a/tests/test_output_observables.py
+++ b/tests/test_output_observables.py
@@ -1,0 +1,304 @@
+"""Transient output fields derived from the solve-bound SLH model."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import numpy as np
+import pytest
+
+from quchip import (
+    Chip,
+    CoherentInput,
+    OutputAmplitude,
+    OutputPhotonFlux,
+    OutputQuadrature,
+    PortNetwork,
+    QuantumSequence,
+    Resonator,
+    Square,
+)
+
+
+def _one_port_chip(
+    *,
+    rate: float = 0.04,
+    delay: float = 0.0,
+    backend: str = "qutip",
+) -> tuple[Chip, Resonator]:
+    resonator = Resonator(freq=0.2, levels=4, label="r")
+    network = PortNetwork(label="line")
+    port = network.port("coupler", target=resonator, rate=rate)
+    network.expose(
+        "readout",
+        input=port.input,
+        output=port.output,
+        delay=delay,
+    )
+    return Chip([resonator], port_network=network, frame="lab", backend=backend), resonator
+
+
+def test_output_observable_specs_are_immutable_and_validate_the_exposure_label() -> None:
+    """Output specifications are immutable and require a valid exposure label."""
+    amplitude = OutputAmplitude("readout")
+    quadrature = OutputQuadrature("readout", phase=0.3)
+    flux = OutputPhotonFlux("readout")
+
+    assert amplitude.exposure == quadrature.exposure == flux.exposure == "readout"
+    assert quadrature.phase == pytest.approx(0.3)
+    with pytest.raises(FrozenInstanceError):
+        amplitude.exposure = "other"  # type: ignore[misc]
+
+
+def test_output_amplitude_is_s_beta_plus_l_expectation() -> None:
+    """Output amplitude evaluates the resolved S beta plus L relation."""
+    rate = 0.04
+    beta = 0.12 + 0.05j
+    chip, resonator = _one_port_chip(rate=rate)
+    sequence = QuantumSequence(chip)
+    sequence.schedule(
+        CoherentInput("readout"),
+        envelope=Square(duration=2.0, amplitude=abs(beta)),
+        phase=np.angle(beta),
+    )
+    times = np.linspace(0.0, 2.0, 41)
+
+    result = sequence.simulate(
+        tlist=times,
+        e_ops={
+            "field": OutputAmplitude("readout"),
+            resonator: resonator.lowering_operator(),
+        },
+        partition=False,
+    )
+
+    lowering = result.observable_traces["r"]
+    assert not isinstance(lowering, list)
+    expected = beta + np.sqrt(rate) * lowering.raw
+    np.testing.assert_allclose(result.expect("field"), expected, atol=2e-8)
+
+
+def test_output_quadrature_uses_half_sum_convention() -> None:
+    """Output quadrature uses the documented half-sum field convention."""
+    chip, _ = _one_port_chip()
+    phase = 0.37
+    sequence = QuantumSequence(chip)
+    sequence.schedule(
+        CoherentInput("readout"),
+        envelope=Square(duration=1.0, amplitude=0.15),
+        phase=0.21,
+    )
+
+    result = sequence.simulate(
+        tlist=np.linspace(0.0, 1.0, 21),
+        e_ops={
+            "field": OutputAmplitude("readout"),
+            "quadrature": OutputQuadrature("readout", phase=phase),
+        },
+        partition=False,
+    )
+
+    np.testing.assert_allclose(
+        result.expect("quadrature"),
+        np.real(np.exp(-1j * phase) * result.expect("field")),
+        atol=2e-8,
+    )
+
+
+def test_output_photon_flux_includes_spontaneous_emission() -> None:
+    """Normally ordered output flux includes spontaneous emission from L."""
+    rate = 0.04
+    chip, resonator = _one_port_chip(rate=rate)
+    times = np.linspace(0.0, 4.0, 41)
+
+    result = QuantumSequence(chip).simulate(
+        tlist=times,
+        initial_state={resonator: 1},
+        e_ops={"flux": OutputPhotonFlux("readout")},
+        partition=False,
+    )
+
+    np.testing.assert_allclose(
+        result.expect("flux"),
+        rate * np.exp(-rate * times),
+        atol=2e-7,
+    )
+
+
+def test_scattering_routes_the_direct_coherent_background() -> None:
+    """Output fields include coherent background routed by scattering."""
+    left = Resonator(freq=0.2, levels=2, label="left")
+    right = Resonator(freq=0.3, levels=2, label="right")
+    network = PortNetwork(scattering=[[0.0, 1.0], [1.0, 0.0]], label="swap")
+    network.port("left", target=left, rate=0.04)
+    network.port("right", target=right, rate=0.09)
+    chip = Chip([left, right], port_network=network, frame="lab")
+    sequence = QuantumSequence(chip)
+    sequence.schedule(
+        CoherentInput("left"),
+        envelope=Square(duration=0.2, amplitude=0.2),
+    )
+
+    result = sequence.simulate(
+        tlist=np.linspace(0.0, 0.2, 5),
+        e_ops={
+            "left_out": OutputAmplitude("left"),
+            "right_out": OutputAmplitude("right"),
+        },
+        partition=False,
+    )
+
+    assert result.expect("left_out")[0] == pytest.approx(0.0)
+    assert result.expect("right_out")[0] == pytest.approx(0.2)
+
+
+def test_reference_delay_is_applied_reciprocally_to_emitted_flux() -> None:
+    """Reference delay shifts emitted fields outward with the reciprocal convention."""
+    rate = 0.04
+    delay = 0.2
+    chip, resonator = _one_port_chip(rate=rate, delay=delay)
+    times = np.linspace(0.0, 1.0, 11)
+
+    result = QuantumSequence(chip).simulate(
+        tlist=times,
+        initial_state={resonator: 1},
+        e_ops={"flux": OutputPhotonFlux("readout")},
+        partition=False,
+    )
+
+    expected = np.where(
+        times < delay,
+        0.0,
+        rate * np.exp(-rate * (times - delay)),
+    )
+    np.testing.assert_allclose(result.expect("flux"), expected, atol=2e-7)
+
+
+def test_reference_delay_applies_on_both_sides_of_direct_scattering() -> None:
+    """Reference delay shifts incident and reported coherent fields reciprocally."""
+    delay = 0.2
+    chip, _ = _one_port_chip(delay=delay)
+    sequence = QuantumSequence(chip)
+    sequence.schedule(
+        CoherentInput("readout"),
+        envelope=Square(duration=0.5, amplitude=0.2),
+    )
+    times = np.linspace(0.0, 0.8, 9)
+
+    result = sequence.simulate(
+        tlist=times,
+        e_ops={"field": OutputAmplitude("readout")},
+        partition=False,
+    )
+
+    np.testing.assert_allclose(result.expect("field")[times < 2 * delay], 0.0, atol=2e-8)
+    assert result.expect("field")[4] == pytest.approx(0.2, abs=2e-4)
+
+
+def test_multiple_coherent_inputs_on_one_exposure_add_before_output_evaluation() -> None:
+    """Incident fields on one exposure add before output evaluation."""
+    chip, _ = _one_port_chip(rate=0.04)
+    sequence = QuantumSequence(chip)
+    sequence.schedule(CoherentInput("readout"), envelope=Square(duration=1.0, amplitude=0.1))
+    sequence.schedule(
+        CoherentInput("readout"),
+        envelope=Square(duration=1.0, amplitude=0.2),
+        phase=np.pi / 2,
+    )
+
+    result = sequence.simulate(
+        tlist=np.linspace(0.0, 1.0, 11),
+        e_ops={
+            "field": OutputAmplitude("readout"),
+            "flux": OutputPhotonFlux("readout"),
+        },
+        partition=False,
+    )
+
+    assert result.expect("field")[0] == pytest.approx(0.1 + 0.2j)
+    assert result.expect("flux")[0] == pytest.approx(0.1**2 + 0.2**2)
+
+
+def test_unknown_output_exposure_reports_the_available_boundary() -> None:
+    """Output evaluation rejects unknown exposures and reports valid choices."""
+    chip, _ = _one_port_chip()
+
+    with pytest.raises(ValueError, match="Unknown output exposure.*readout"):
+        QuantumSequence(chip).build_problem(
+            tlist=np.linspace(0.0, 1.0, 11),
+            e_ops={"field": OutputAmplitude("missing")},
+        )
+
+
+def test_output_observables_follow_sequence_batch_axes() -> None:
+    """Output observables preserve ordinary sequence batch axes."""
+    chip, _ = _one_port_chip()
+    sequence = QuantumSequence(chip)
+    handle = sequence.schedule(
+        CoherentInput("readout"),
+        envelope=Square(duration=0.5, amplitude=0.1),
+    )
+
+    result = sequence.simulate_batch(
+        handle.vary("amplitude", [0.1, 0.2]),
+        tlist=np.linspace(0.0, 0.5, 6),
+        e_ops={"field": OutputAmplitude("readout")},
+        progress=False,
+    )
+
+    assert result.expect("field").shape == (2, 6)
+    np.testing.assert_allclose(result.expect("field")[:, 0], [0.1, 0.2], atol=2e-8)
+
+
+def test_qutip_and_dynamiqs_output_observables_agree() -> None:
+    """QuTiP and Dynamiqs agree on amplitude and photon-flux traces."""
+    pytest.importorskip("dynamiqs")
+
+    def traces(backend: str) -> tuple[np.ndarray, np.ndarray]:
+        chip, _ = _one_port_chip(backend=backend)
+        sequence = QuantumSequence(chip)
+        sequence.schedule(
+            CoherentInput("readout"),
+            envelope=Square(duration=1.0, amplitude=0.15),
+        )
+        result = sequence.simulate(
+            tlist=np.linspace(0.0, 1.0, 21),
+            e_ops={
+                "field": OutputAmplitude("readout"),
+                "flux": OutputPhotonFlux("readout"),
+            },
+            partition=False,
+        )
+        return np.asarray(result.expect("field")), np.asarray(result.expect("flux"))
+
+    qutip = traces("qutip")
+    dynamiqs = traces("dynamiqs")
+    np.testing.assert_allclose(dynamiqs[0], qutip[0], atol=2e-7)
+    np.testing.assert_allclose(dynamiqs[1], qutip[1], atol=2e-7)
+
+
+def test_dynamiqs_output_quadrature_is_differentiable() -> None:
+    """Dynamiqs output quadrature remains differentiable through a solve."""
+    pytest.importorskip("dynamiqs")
+    import jax
+    import jax.numpy as jnp
+
+    chip, _ = _one_port_chip(backend="dynamiqs")
+
+    def final_quadrature(amplitude: object) -> object:
+        sequence = QuantumSequence(chip)
+        sequence.schedule(
+            CoherentInput("readout"),
+            envelope=Square(duration=0.5, amplitude=amplitude),
+        )
+        result = sequence.simulate(
+            tlist=jnp.linspace(0.0, 0.5, 6),
+            e_ops={"I": OutputQuadrature("readout")},
+            partition=False,
+        )
+        return result.expect("I")[-1]
+
+    value, gradient = jax.jit(jax.value_and_grad(final_quadrature))(jnp.asarray(0.1))
+    assert jnp.isfinite(value)
+    assert jnp.isfinite(gradient)
+    assert gradient != 0.0

--- a/tests/test_vna.py
+++ b/tests/test_vna.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import inspect
+
 import numpy as np
 import pytest
 
@@ -12,6 +14,7 @@ from quchip import (
     DuffingTransmon,
     KerrCavity,
     Port,
+    PortNetwork,
     Resonator,
     Sweep,
     VNA,
@@ -106,6 +109,43 @@ def test_two_sided_transmission_is_unit_magnitude_on_resonance() -> None:
     np.testing.assert_allclose(np.abs(result.s11) ** 2 + np.abs(result.s21) ** 2, [1.0], atol=2e-8)
 
 
+def test_vna_uses_network_exposure_labels_and_scattering_background() -> None:
+    """VNA queries named network exposures and retains direct scattering."""
+    resonator = Resonator(freq=6.0, levels=6, label="r")
+    network = PortNetwork(label="line")
+    port = network.port("chip_port", target=resonator, rate=0.04)
+    phase = network.phase_shift("phase", phase=np.pi / 2)
+    network.cascade(port, phase)
+    network.expose("readout", input=port.input, output=phase.output)
+    chip = Chip([resonator], port_network=network)
+
+    result = VNA(chip, input="readout", outputs=["readout"]).sweep([5.98, 6.0, 6.02])
+
+    detuning = 2 * np.pi * (resonator.freq - np.asarray([5.98, 6.0, 6.02]))
+    expected = 1j * (1.0 - 0.04 / (0.02 + 1j * detuning))
+    np.testing.assert_allclose(result.s11, expected, atol=2e-8)
+
+
+def test_vna_reference_delay_is_reciprocal() -> None:
+    """VNA phase accumulates the reciprocal external reference-plane delay."""
+    def response(delay: float) -> complex:
+        resonator = Resonator(freq=6.0, levels=5, label="r")
+        network = PortNetwork(label="line")
+        port = network.port("chip_port", target=resonator, rate=0.04)
+        network.expose(
+            "readout",
+            input=port.input,
+            output=port.output,
+            delay=delay,
+        )
+        chip = Chip([resonator], port_network=network)
+        return complex(VNA(chip, input="readout", outputs=["readout"]).sweep([6.01]).s11[0])
+
+    delay = 0.125
+    expected_phase = np.exp(1j * 2.0 * 2.0 * np.pi * 6.01 * delay)
+    assert response(delay) == pytest.approx(expected_phase * response(0.0), abs=2e-8)
+
+
 @pytest.mark.parametrize("internal_rate,external_rate", [(0.04, 0.02), (0.02, 0.02), (0.01, 0.03)])
 def test_resonance_distinguishes_undercritical_and_overcoupling(
     internal_rate: float,
@@ -119,44 +159,9 @@ def test_resonance_distinguishes_undercritical_and_overcoupling(
     np.testing.assert_allclose(result.s11, [expected], atol=2e-8)
 
 
-def test_finite_input_amplitudes_form_an_axis_and_record_flux() -> None:
-    _, input_port, output_port, chip = _linear_resonator(kappa_in=0.02, kappa_out=0.03)
-    assert output_port is not None
-    amplitudes = np.array([1e-3, 2e-3, 4e-3])
-
-    result = VNA(chip, input=input_port, outputs=[output_port]).sweep(
-        np.array([5.99, 6.0]),
-        amplitude=amplitudes,
-    )
-
-    assert result.shape == (3, 2)
-    assert result.s21.shape == (3, 2)
-    np.testing.assert_allclose(result.input_amplitudes, amplitudes)
-    np.testing.assert_allclose(result.input_photon_fluxes, np.abs(amplitudes) ** 2)
-    assert result.input_powers.shape == (3, 2)
-    assert result.input_power_unit == "W"
-    np.testing.assert_allclose(result.s21[0], result.s21[1], atol=2e-7)
-
-
-def test_finite_amplitude_sweep_reuses_each_undriven_operating_state(monkeypatch) -> None:
-    """The baseline solve is shared across amplitudes at the same frequency."""
-    import quchip.analysis.vna as vna_module
-
-    _, input_port, _, chip = _linear_resonator(kappa_in=0.04)
-    original = vna_module._solve_engine
-    calls = 0
-
-    def counted(*args, **kwargs):
-        nonlocal calls
-        calls += 1
-        return original(*args, **kwargs)
-
-    monkeypatch.setattr(vna_module, "_solve_engine", counted)
-    VNA(chip, input=input_port, outputs=[input_port]).sweep(
-        [5.99, 6.0], amplitude=[0.01, 0.02, 0.03]
-    )
-
-    assert calls == 2 + 2 * 3
+def test_vna_probe_has_no_finite_amplitude_mode() -> None:
+    """Finite-power spectroscopy belongs to CoherentInput simulations."""
+    assert "amplitude" not in inspect.signature(VNA.sweep).parameters
 
 
 def test_vna_rejects_sweep_axes_it_does_not_own() -> None:
@@ -239,17 +244,20 @@ def test_qutip_and_dynamiqs_vna_response_agree() -> None:
     np.testing.assert_allclose(np.asarray(response("dynamiqs")), response("qutip"), atol=2e-8)
 
 
-def test_dynamiqs_finite_response_is_jittable_and_differentiable() -> None:
+def test_dynamiqs_pumped_small_signal_response_is_jittable_and_differentiable() -> None:
+    """Pumped Dynamiqs small-signal response is JIT-safe and differentiable."""
     pytest.importorskip("dynamiqs")
     import jax
     import jax.numpy as jnp
 
     resonator = Resonator(freq=6.0, levels=3, label="r")
     port = Port(resonator, rate=0.04, label="p")
-    vna = VNA(Chip([resonator], ports=[port], backend="dynamiqs"), input=port, outputs=[port])
+    chip = Chip([resonator], ports=[port], backend="dynamiqs")
 
     def reflection(amplitude):
-        return jnp.real(vna.sweep(jnp.asarray([6.0]), amplitude=amplitude).s11[0])
+        vna = VNA(chip, input=port, outputs=[port])
+        vna.pump(port, freq=6.0, amplitude=amplitude)
+        return jnp.real(vna.sweep([6.0]).s11[0])
 
     value = jax.jit(reflection)(jnp.asarray(0.01))
     gradient = jax.grad(reflection)(jnp.asarray(0.01))
@@ -258,16 +266,9 @@ def test_dynamiqs_finite_response_is_jittable_and_differentiable() -> None:
     assert jnp.isfinite(gradient)
 
 
-@pytest.mark.parametrize(
-    ("amplitude", "frequency"),
-    [(0.01, 6.0), (None, 6.01)],
-    ids=["finite", "small-signal"],
-)
 def test_dynamiqs_explicit_port_frequency_is_jittable_and_differentiable(
-    amplitude: float | None,
-    frequency: float,
 ) -> None:
-    """Finite and differential VNA paths preserve an explicit port's traced frequency."""
+    """Small-signal VNA preserves an explicit port's traced frequency."""
     pytest.importorskip("dynamiqs")
     import jax
     import jax.numpy as jnp
@@ -278,9 +279,9 @@ def test_dynamiqs_explicit_port_frequency_is_jittable_and_differentiable(
     vna = VNA(Chip([resonator], ports=[port], backend="dynamiqs"), input=port, outputs=[port])
 
     def reflection(frequency):
-        return jnp.real(vna.sweep(jnp.asarray([frequency]), amplitude=amplitude).s11[0])
+        return jnp.real(vna.sweep(jnp.asarray([frequency])).s11[0])
 
-    value, gradient = jax.jit(jax.value_and_grad(reflection))(jnp.asarray(frequency))
+    value, gradient = jax.jit(jax.value_and_grad(reflection))(jnp.asarray(6.01))
 
     assert jnp.isfinite(value)
     assert jnp.isfinite(gradient)
@@ -293,7 +294,9 @@ def test_resonantly_driven_two_level_population_matches_optical_bloch_solution()
     port = Port(qubit, rate=decay_rate, label="drive")
     chip = Chip([qubit], ports=[port])
 
-    result = VNA(chip, input=port, outputs=[port]).sweep([5.0], amplitude=amplitude)
+    vna = VNA(chip, input=port, outputs=[port])
+    vna.pump(port, freq=5.0, amplitude=amplitude)
+    result = vna.sweep([5.0])
     state = np.asarray(result.steady_states[0].state.full())
     excited_population = np.real(state[1, 1])
     expected = 4 * amplitude**2 / (decay_rate + 8 * amplitude**2)
@@ -358,7 +361,9 @@ def test_nonlinear_stationary_state_matches_long_time_master_equation() -> None:
     cavity = KerrCavity(freq=6.0, kerr=0.03, levels=8, label="c")
     port = Port(cavity, rate=0.05, label="p")
     chip = Chip([cavity], ports=[port], backend="qutip")
-    stationary = VNA(chip, input=port, outputs=[port]).sweep([6.0], amplitude=amplitude)
+    vna = VNA(chip, input=port, outputs=[port])
+    vna.pump(port, freq=6.0, amplitude=amplitude)
+    stationary = vna.sweep([6.0])
 
     engine = chip.resolve(frame={"c": 6.0})
     backend = chip.backend


### PR DESCRIPTION
## Summary

- add `OutputAmplitude`, `OutputQuadrature`, and `OutputPhotonFlux` as dict-form `e_ops` specs for any exposed SLH channel
- lower only the required resolved moments (`L` and `L dagger L`), then reconstruct `b_out = S b_in + L` from solve-bound coherent inputs after either backend returns
- report transient fields at reciprocal exposure reference planes, with normally ordered photon flux and JAX-safe delay interpolation
- make VNA inputs and outputs resolve network exposure labels, take direct feedthrough from scalar `S`, and retain only the small-signal derivative contract; finite probe power now belongs to explicit `CoherentInput` simulation, while fixed pumps remain operating-point fields

The quadrature convention is `Re[exp(-i theta) <b_out>]`. Exposure delays act once inbound and once outbound under the package's `exp(-i 2 pi f t)` field convention.

## Diff audit

The staged change is +881/-231 overall:

- production Python: +434/-157 (net +277)
- tests: +362/-53
- physics and user docs: +85/-21

The VNA rewrite itself is +117/-123 and deletes the finite-amplitude probe branch, power-axis result fields, and identity-feedthrough assumptions. The production growth is concentrated in one generalized observable recipe/reconstruction path (+196/-7) and the three minimal public specs (+51). It does not add a solver, backend-specific output implementation, or device-specific response formula. The larger positive test diff covers the new field algebra, normal ordering, scattering, reciprocal delays, batching, JIT gradients, backend parity, and the intentional VNA API contraction.

## Verification

- `pytest -q`: 1745 passed, 74 warnings
- focused output/VNA/demod/dispatch suite: 93 passed, 11 warnings
- Ruff: passed
- mypy: 118 source files passed
- compileall: passed
- Sphinx HTML: succeeded with 337 pre-existing duplicate-object/toctree warnings
- wheel and sdist: built successfully; both include `quchip/observables.py` and exclude the local v0.3 control documents

## Checklist

- [x] This pull request is focused and contains no unrelated changes.
- [x] Changed behavior is covered by tests, or no behavior changed.
- [x] Relevant documentation and examples are updated.
- [x] Generated files and paired notebooks are synchronized, if applicable. No generated notebook pair changed.
- [x] `PHYSICS.md` is updated, or is not relevant: updated with the output, quadrature, flux, delay, and small-signal conventions.

## AI assistance

AI assistance was used for implementation, tests, documentation, and verification. The author reviewed the architecture and remains accountable for the changes.
