### PR TITLE
Simplify field input-output workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ This file records notable user-visible changes to quchip.
 
 - Added an immutable, input-free scalar-S SLH normal form to every resolved engine snapshot. With no ports, ordinary closed/open-system quchip workflows retain their existing behavior.
 - Added `PortNetwork` for symbolic series composition, named exposures, convenient scalar scattering, reciprocal reference-plane delays, and unitary vacuum dilation of attenuation.
-- Added solve-time `CoherentInput` scheduling through the shared control-endpoint grammar; coherent amplitudes are in `sqrt(photons/ns)` and are not stored on `ResolvedSLH`.
-- Added transient `OutputAmplitude`, `OutputQuadrature`, and `OutputPhotonFlux` observables derived from the same `b_out = S b_in + L` boundary. VNA probing is explicitly small signal; finite-power spectroscopy uses a coherent-input simulation.
+- Added external-plane input scheduling through `network.expose(...).input`; coherent amplitudes are in `sqrt(photons/ns)` and are not stored on `ResolvedSLH`.
+- Added complete transient field traces through `result.output(plane)`, with complex amplitude, arbitrary post-solve quadratures, normally ordered photon flux, and the pre-delay Markov-boundary values derived from the same `b_out = S b_in + L` model. VNA probing remains small signal.
 
 ### Resolved analysis and transformations
 

--- a/PHYSICS.md
+++ b/PHYSICS.md
@@ -128,8 +128,9 @@ L_p = exp(i phi_p) sqrt(kappa_p) A_p
 b_out,p = b_in,p + L_p
 ```
 
-The dissipator uses `L_p`. A scheduled `CoherentInput` consumes the same
-envelope, phase, carrier, and start-time grammar as a classical drive, with
+The dissipator uses `L_p`. Scheduling an external plane's `input` consumes the
+same envelope, phase, carrier, and start-time grammar as a classical drive,
+with
 
 ```text
 beta_i(t) = A(t) exp(i theta) exp(-i 2π f t),
@@ -152,7 +153,7 @@ adds a second damping channel.
 
 `ResolvedSLH` itself stays input-free. Per-solve beta programs are retained on
 `EngineResult.coherent_inputs` for later output-field reconstruction. Classical
-`ControlEquipment` transforms do not accept `CoherentInput`; field attenuation,
+`ControlEquipment` transforms do not accept field inputs; field attenuation,
 phase, crosstalk, and reference-plane delay belong to `PortNetwork`.
 
 For the one-port identity case this reduces to the angular Hamiltonian
@@ -171,13 +172,15 @@ model:
   = |c_j|^2 + 2 Re[c_j^* <L_j>] + <L_j^dagger L_j>.
 ```
 
-`OutputAmplitude`, `OutputQuadrature`, and `OutputPhotonFlux` lower only the
-required `L_j` and `L_j^dagger L_j` moments into backend expectation
-operators. The coherent background is evaluated from the retained beta
-programs; it is not inserted as an identity operator. The last expression is
-normally ordered photon flux. A reciprocal exposure delay shifts the complete
-boundary trace to the reported reference plane, with zero field before the
-simulation's initial boundary data can arrive.
+An external plane's `output` request lowers `L_j` and `L_j^dagger L_j` into
+backend expectation operators. `result.output(plane)` returns the reconstructed
+complex amplitude and normally ordered photon flux; any quadrature phase is a
+post-solve projection of the complex amplitude. The coherent background is
+evaluated from the retained beta programs rather than inserted as an identity
+operator. A reciprocal exposure delay shifts the complete boundary trace to
+the reported reference plane, with zero field before the simulation's initial
+boundary data can arrive. The result also retains both moments at the Markov
+boundary before that delay.
 
 For a single resonator, `external_quality_factor` gives
 `kappa_p = 2π * freq / Q_external`. Internal resonator loss and every port are
@@ -432,9 +435,9 @@ S_ji(f) = d <b_out,j> / d beta_in,i  at beta_probe -> 0.
 
 The direct term comes from the resolved scalar `S`; the system term comes from
 the stationary response of `L` under the same coherent-input Hamiltonian.
-Finite-power spectroscopy is a `CoherentInput` time-domain simulation, not a
-second VNA probe mode. Fixed finite pumps remain valid VNA operating-point
-fields.
+Finite-power spectroscopy schedules an external-plane input in a time-domain
+simulation; it is not a second VNA probe mode. Fixed finite pumps remain valid
+VNA operating-point fields.
 The engine supplies canonical sources and observables for stationary response,
 spectrum, and correlation queries. Each backend constructs and solves its own
 native Liouvillian.

--- a/RELEASE_NOTES_0.3.0.md
+++ b/RELEASE_NOTES_0.3.0.md
@@ -21,16 +21,16 @@ external reciprocal reference plane only. They do not enter the Markov model.
 
 ## Drives and measured fields
 
-`CoherentInput` uses the normal sequence scheduling grammar. Its complex
-amplitude is bound when a solve is built, outside immutable `ResolvedSLH`, and
-`abs(beta)**2` is photon flux in photons/ns. Direct charge/flux drives and
-coherent port fields therefore share one scheduling grammar while
-retaining their different physical couplings.
+`network.expose(...)` returns the external reference plane used for both
+directions. Schedule `plane.input` with the normal sequence grammar; its
+complex amplitude is bound when a solve is built, outside immutable
+`ResolvedSLH`, and `abs(beta)**2` is photon flux in photons/ns.
 
-Transient output amplitude, quadrature, and normally ordered photon flux are
-computed from the resolved `b_out = S b_in + L` relation. The VNA remains a
-strict small-signal derivative about fixed operating fields. Finite-power
-spectroscopy is an explicit coherent-input simulation.
+Request `plane.output` once, then read the complex amplitude, any quadrature,
+and normally ordered photon flux from `result.output(plane)`. All three come
+from the resolved `b_out = S b_in + L` relation. The VNA remains a strict
+small-signal derivative about fixed operating fields. Finite-power
+spectroscopy uses the same external-plane input.
 
 ## Analysis and reductions
 

--- a/docs/guides/steady-state-and-vna.md
+++ b/docs/guides/steady-state-and-vna.md
@@ -47,7 +47,7 @@ occupations = states.expect(r)
 ## Separate internal loss from measured ports
 
 ```python
-from quchip import Chip, Port, Resonator
+from quchip import Chip, PortNetwork, Resonator
 
 r = Resonator(
     freq=6.8,
@@ -56,9 +56,18 @@ r = Resonator(
     label="readout",
 )
 
-input_port = Port(r, external_quality_factor=15_000, label="in")
-output_port = Port(r, external_quality_factor=18_000, label="out")
-chip = Chip([r], ports=[input_port, output_port])
+network = PortNetwork(label="feedline")
+input_port = network.port(
+    "in",
+    target=r,
+    external_quality_factor=15_000,
+)
+output_port = network.port(
+    "out",
+    target=r,
+    external_quality_factor=18_000,
+)
+chip = Chip([r], port_network=network)
 ```
 
 The resonator owns its unobserved loss. Each port owns one accessible external
@@ -77,24 +86,23 @@ as one boundary object:
 ```python
 from quchip import PortNetwork
 
-network = PortNetwork(label="measurement_line")
-coupler = network.port(
+measurement_network = PortNetwork(label="measurement_line")
+coupler = measurement_network.port(
     "coupler",
     target=r,
     external_quality_factor=15_000,
 )
-cable = network.phase_shift("cable", phase=0.12)
-network.cascade(coupler, cable)
-network.expose(
+cable = measurement_network.phase_shift("cable", phase=0.12)
+measurement_network.cascade(coupler, cable)
+vna_plane = measurement_network.expose(
     "vna_plane",
     input=coupler.input,
     output=cable.output,
     delay=3.2,
 )
 
-chip = Chip([r])
-chip.connect_network(network)
-resolved = chip.resolve()
+measurement_chip = Chip([r], port_network=measurement_network)
+resolved = measurement_chip.resolve()
 print(resolved.slh.S)
 print(resolved.slh.L)
 ```
@@ -137,42 +145,33 @@ Use an explicit coherent field simulation for finite-power spectroscopy,
 ring-up, ring-down, reflection, transmission, or emitted wave packets:
 
 ```python
-from quchip import (
-    CoherentInput,
-    OutputAmplitude,
-    OutputPhotonFlux,
-    OutputQuadrature,
-    QuantumSequence,
-    Square,
-)
+from quchip import QuantumSequence, Square
 
-sequence = QuantumSequence(chip)
+sequence = QuantumSequence(measurement_chip)
 sequence.schedule(
-    CoherentInput(input_port),
+    vna_plane.input,
     envelope=Square(duration=200.0, amplitude=0.02),
     freq=6.8,
 )
 transient = sequence.simulate(
     tlist=np.linspace(0.0, 300.0, 601),
-    e_ops={
-        "transmission": OutputAmplitude(output_port),
-        "I": OutputQuadrature(output_port, phase=0.0),
-        "flux": OutputPhotonFlux(output_port),
-    },
+    e_ops={vna_plane: vna_plane.output},
 )
 
-b_out = transient.expect("transmission")
-quadrature_i = transient.expect("I")
-photon_flux = transient.expect("flux")
+field = transient.output(vna_plane)
+b_out = field.amplitude
+quadrature_i = field.quadrature(phase=0.0)
+photon_flux = field.photon_flux
 ```
 
 The scheduled amplitude is the incoming field `beta` in
 `sqrt(photons/ns)`, so `abs(beta)**2` is incident photon flux in photons/ns.
-The field follows `b_out = S b_in + L`. `OutputQuadrature(..., phase=theta)`
-uses `Re[exp(-i theta) <b_out>]`; `OutputPhotonFlux` is the normally ordered
+The field follows `b_out = S b_in + L`. `field.quadrature(phase=theta)` uses
+`Re[exp(-i theta) <b_out>]`, so changing the analysis phase does not require
+another solve. `field.photon_flux` is the normally ordered
 `<b_out^dagger b_out>`. Values are reported at the exposure reference plane;
-the matching `ObservableTrace.raw` is the Markov-boundary trace before its
-outbound delay.
+`field.raw_amplitude` and `field.raw_photon_flux` retain the Markov-boundary
+traces before the outbound delay.
 
 ## Two-tone response
 

--- a/quchip/__init__.py
+++ b/quchip/__init__.py
@@ -44,7 +44,6 @@ from quchip.backend import get_default_backend, set_default_backend  # noqa: E40
 from quchip.chip import (
     ActivePatchResult,
     Bath,
-    FieldTerminal,
     Port,
     PortNetwork,
     Capacitive,
@@ -55,7 +54,6 @@ from quchip.chip import (
     DressedResult,
     EliminationResult,
     KerrMatrix,
-    SLHComponent,
     TunableCapacitive,
     active_patch,
     eliminate,
@@ -65,8 +63,6 @@ from quchip.chip import (
 )
 from quchip.control import (
     ChargeDrive,
-    CoherentInput,
-    ControlEndpoint,
     ControlEquipment,
     CouplingDrive,
     Crosstalk,
@@ -127,7 +123,6 @@ from quchip.engine import (
 )
 from quchip.interop import EigenbasisDevice, ModelMapping
 from quchip.inverse_design import FitADressResult, FitParameterReport, ObservableReport, fit_a_dress
-from quchip.observables import OutputAmplitude, OutputPhotonFlux, OutputQuadrature
 from quchip.results import (
     ObservableTrace,
     PartitionedSimulationResult,
@@ -212,9 +207,7 @@ __all__ = [
     "KerrMatrix",
     "Bath",
     "Port",
-    "FieldTerminal",
     "PortNetwork",
-    "SLHComponent",
     "ChipTransform",
     "EliminationResult",
     "eliminate",
@@ -239,9 +232,6 @@ __all__ = [
     "steadystate_batch",
     "build_steadystate_problem",
     "ObservableTrace",
-    "OutputAmplitude",
-    "OutputQuadrature",
-    "OutputPhotonFlux",
     "SimulationBatchResult",
     "SimulationResult",
     "SteadyStateResult",
@@ -261,8 +251,6 @@ __all__ = [
     "hbar",
     "Phi_0",
     # Control
-    "CoherentInput",
-    "ControlEndpoint",
     "CouplingDrive",
     "DeviceDrive",
     "Delay",

--- a/quchip/chip/__init__.py
+++ b/quchip/chip/__init__.py
@@ -10,7 +10,7 @@ into a solver-ready problem. Dressed-state analysis lives in
 from quchip.chip.analysis import DressedResult, KerrMatrix
 from quchip.chip.baths import Bath
 from quchip.chip.chip import Chip
-from quchip.chip.port_network import FieldTerminal, PortNetwork, SLHComponent
+from quchip.chip.port_network import PortNetwork
 from quchip.chip.ports import Port
 from quchip.chip.couplings import Capacitive, Coupling, CrossKerr, TunableCapacitive
 from quchip.chip.retarget import register_retarget_rule
@@ -30,9 +30,7 @@ __all__ = [
     "KerrMatrix",
     "Bath",
     "Port",
-    "FieldTerminal",
     "PortNetwork",
-    "SLHComponent",
     "Capacitive",
     "Coupling",
     "CrossKerr",

--- a/quchip/chip/chip.py
+++ b/quchip/chip/chip.py
@@ -182,8 +182,6 @@ class Chip:
         Chip-specific backend. ``None`` uses the process default.
     baths : list[Bath], optional
         Shared or collective unobserved environments.
-    ports : list[Port], optional
-        Compatibility shorthand for an identity-exposed :class:`PortNetwork`.
     port_network : PortNetwork, optional
         Complete accessible field boundary. Attach at most one network.
 
@@ -207,7 +205,6 @@ class Chip:
         basis: Literal["native", "eigen"] = "native",
         backend: str | Backend | None = None,
         baths: list[Bath] | None = None,
-        ports: list[Port] | None = None,
         port_network: PortNetwork | None = None,
     ) -> None:
         duplicates = [lbl for lbl, count in Counter(d.label for d in devices).items() if count > 1]
@@ -236,14 +233,10 @@ class Chip:
         for bath in baths or ():
             self._validate_bath(bath)
         self._baths = tuple(baths) if baths else ()
-        if ports and port_network is not None:
-            raise ValueError("Pass either ports or port_network, not both.")
         if port_network is not None and not isinstance(port_network, PortNetwork):
             raise TypeError(
                 f"Expected a PortNetwork, got {type(port_network).__name__}: {port_network!r}"
             )
-        if port_network is None and ports:
-            port_network = PortNetwork.from_ports(ports)
         network_ports = () if port_network is None else port_network.ports
         port_duplicates = [lbl for lbl, n in Counter(port.label for port in network_ports).items() if n > 1]
         if port_duplicates:
@@ -1366,7 +1359,7 @@ class Chip:
                     else (
                         self._port_network.label,
                         tuple(component.label for component in self._port_network.components),
-                        self._port_network.exposures,
+                        tuple(exposure.label for exposure in self._port_network.exposures),
                     )
                 ),
                 "frame": self._frame_spec,

--- a/quchip/chip/partition.py
+++ b/quchip/chip/partition.py
@@ -190,6 +190,7 @@ def _distribute_control_lines(
 def _build_component_chip(chip: "Chip", clone: "Chip", index: int, group: list[str], lines: list[Any]) -> "Chip":
     """Assemble one component's solve-ready sub-chip: its devices, internal couplings, baths, frame, equipment."""
     from quchip.chip.chip import Chip as _Chip
+    from quchip.chip.port_network import PortNetwork
     from quchip.control.equipment import ControlEquipment
 
     member_set = set(group)
@@ -206,6 +207,7 @@ def _build_component_chip(chip: "Chip", clone: "Chip", index: int, group: list[s
         {k: v for k, v in clone.frame.items() if k in member_set}
         if isinstance(clone.frame, dict) else clone.frame
     )
+    ports = _component_ports(clone, member_set)
     sub = _Chip(
         devices=devices,
         couplings=couplings or None,
@@ -214,7 +216,7 @@ def _build_component_chip(chip: "Chip", clone: "Chip", index: int, group: list[s
         approximation=clone.approximation,
         backend=clone._backend,
         baths=_component_baths(clone, member_set) or None,
-        ports=_component_ports(clone, member_set) or None,
+        port_network=PortNetwork.from_ports(ports) if ports else None,
     )
     equipment = clone.control_equipment
     if equipment is not None and lines:

--- a/quchip/chip/port_network.py
+++ b/quchip/chip/port_network.py
@@ -14,7 +14,9 @@ from quchip.utils.jax_utils import contains_tracer, maybe_concrete_scalar, selec
 from quchip.utils.labeling import auto_label, resolve_label
 
 if TYPE_CHECKING:
+    from quchip.control.field import CoherentInput
     from quchip.engine.ir import ResolvedSLH
+    from quchip.observables import OutputField
 
 
 TerminalDirection = Literal["input", "output"]
@@ -109,13 +111,46 @@ class SLHComponent:
         )
 
 
-@dataclass(frozen=True)
-class _Exposure:
+@dataclass(frozen=True, eq=False)
+class FieldExposure:
+    """One named reciprocal reference plane on a :class:`PortNetwork`."""
+
     label: str
-    input_key: TerminalKey
-    output_key: TerminalKey
+    _input_key: TerminalKey = field(repr=False)
+    _output_key: TerminalKey = field(repr=False)
     delay: Any = 0.0
-    hidden: bool = False
+    _hidden: bool = field(default=False, repr=False)
+    _network_token: object = field(repr=False, compare=False, kw_only=True)
+
+    def __eq__(self, other: object) -> bool:
+        """Compare stable plane identity within one network."""
+        return (
+            isinstance(other, FieldExposure)
+            and self._network_token is other._network_token
+            and self.label == other.label
+        )
+
+    def __hash__(self) -> int:
+        """Hash stable plane identity within one network."""
+        return hash((id(self._network_token), self.label))
+
+    @property
+    def input(self) -> "CoherentInput":
+        """Return the coherent-field endpoint scheduled at this plane."""
+        if self._hidden:
+            raise AttributeError("Hidden vacuum channels cannot be driven.")
+        from quchip.control.field import CoherentInput
+
+        return CoherentInput(self.label, label=f"{self.label}.input")
+
+    @property
+    def output(self) -> "OutputField":
+        """Return the complete transient output-field request for this plane."""
+        if self._hidden:
+            raise AttributeError("Hidden vacuum channels are not observable.")
+        from quchip.observables import OutputField
+
+        return OutputField(self.label)
 
 
 @dataclass
@@ -157,7 +192,7 @@ class PortNetwork:
         self._component_parameters: dict[str, dict[str, Any]] = {}
         self._connections: dict[TerminalKey, TerminalKey] = {}
         self._used_outputs: dict[TerminalKey, TerminalKey] = {}
-        self._exposures: list[_Exposure] = []
+        self._exposures: list[FieldExposure] = []
 
     @classmethod
     def from_ports(
@@ -184,9 +219,23 @@ class PortNetwork:
         return tuple(self._components.values())
 
     @property
-    def exposures(self) -> tuple[str, ...]:
-        """Return explicitly authored external exposure labels."""
-        return tuple(exposure.label for exposure in self._exposures if not exposure.hidden)
+    def exposures(self) -> tuple[FieldExposure, ...]:
+        """Return the complete external reference planes in channel order."""
+        return tuple(exposure for exposure in self._effective_exposures() if not exposure._hidden)
+
+    def exposure(self, exposure: str | FieldExposure) -> FieldExposure:
+        """Return one external reference plane by object or label."""
+        if isinstance(exposure, FieldExposure) and exposure._network_token is not self._token:
+            raise ValueError(f"Exposure {exposure.label!r} belongs to another PortNetwork.")
+        label = resolve_label(exposure)
+        exposures = self.exposures
+        for candidate in exposures:
+            if candidate.label == label:
+                return candidate
+        raise KeyError(
+            f"No exposure labeled {label!r}. Available: "
+            f"{[candidate.label for candidate in exposures]}"
+        )
 
     @property
     def S(self) -> Any:
@@ -201,7 +250,7 @@ class PortNetwork:
             for (output, input_), value in self._authored_scattering.items():
                 values[f"scattering.{resolve_label(output)}.{resolve_label(input_)}"] = value
         for exposure in self._exposures:
-            if not exposure.hidden:
+            if not exposure._hidden:
                 values[f"exposure.{exposure.label}.delay"] = exposure.delay
         for label, parameters in self._component_parameters.items():
             for name, value in parameters.items():
@@ -378,8 +427,8 @@ class PortNetwork:
         input: FieldTerminal,
         output: FieldTerminal,
         delay: Any = 0.0,
-    ) -> None:
-        """Name one external input/output pair and its reciprocal reference delay."""
+    ) -> FieldExposure:
+        """Name and return one external input/output reference plane."""
         self._validate_terminal(input, "input")
         self._validate_terminal(output, "output")
         self._reject_hidden_terminal(input)
@@ -398,7 +447,15 @@ class PortNetwork:
                 concrete = None
         if concrete is not None and concrete < 0:
             raise ValueError("Exposure delay must be non-negative.")
-        self._exposures.append(_Exposure(label, input.key, output.key, delay))
+        exposure = FieldExposure(
+            label,
+            input.key,
+            output.key,
+            delay,
+            _network_token=self._token,
+        )
+        self._exposures.append(exposure)
+        return exposure
 
     def validate_for(self, chip: Any) -> None:
         """Validate every quantum port target against ``chip``."""
@@ -424,7 +481,7 @@ class PortNetwork:
             ),
             tuple(self._connections.items()),
             tuple(
-                (item.label, item.input_key, item.output_key, self._cache_value(item.delay))
+                (item.label, item._input_key, item._output_key, self._cache_value(item.delay))
                 for item in self._exposures
             ),
             self._cache_value(self._authored_scattering),
@@ -482,7 +539,7 @@ class PortNetwork:
                     replace(
                         port_channels[exposure.label],
                         key=exposure.label,
-                        accessibility="hidden" if exposure.hidden else "exposed",
+                        accessibility="hidden" if exposure._hidden else "exposed",
                         reference_delay=exposure.delay,
                     )
                 )
@@ -497,7 +554,7 @@ class PortNetwork:
             channels.append(
                 SLHChannel(
                     key=exposure.label,
-                    accessibility="hidden" if exposure.hidden else "exposed",
+                    accessibility="hidden" if exposure._hidden else "exposed",
                     collapse=template,
                     coupling_operator=coupling,
                     reference_delay=exposure.delay,
@@ -559,8 +616,8 @@ class PortNetwork:
             "exposures": [
                 {
                     "label": exposure.label,
-                    "input": list(exposure.input_key),
-                    "output": list(exposure.output_key),
+                    "input": list(exposure._input_key),
+                    "output": list(exposure._output_key),
                     "delay": self._serialize_scalar(exposure.delay),
                 }
                 for exposure in self._exposures
@@ -610,11 +667,12 @@ class PortNetwork:
             network._used_outputs[output_key] = input_key
         for payload in data.get("exposures", []):
             network._exposures.append(
-                _Exposure(
+                FieldExposure(
                     payload["label"],
                     tuple(payload["input"]),
                     tuple(payload["output"]),
                     cls._deserialize_scalar(payload.get("delay", 0.0)),
+                    _network_token=network._token,
                 )
             )
         return network
@@ -661,7 +719,10 @@ class PortNetwork:
                 )
         copied._connections = dict(self._connections)
         copied._used_outputs = dict(self._used_outputs)
-        copied._exposures = list(self._exposures)
+        copied._exposures = [
+            replace(exposure, _network_token=copied._token)
+            for exposure in self._exposures
+        ]
         copied._component_kinds = dict(self._component_kinds)
         copied._component_parameters = {
             label: dict(parameters)
@@ -791,12 +852,12 @@ class PortNetwork:
         self._components[component.label] = component
         return component
 
-    def _effective_exposures(self) -> tuple[_Exposure, ...]:
+    def _effective_exposures(self) -> tuple[FieldExposure, ...]:
         exposed = list(self._exposures)
         used = {
             key
             for exposure in self._exposures
-            for key in (exposure.input_key, exposure.output_key)
+            for key in (exposure._input_key, exposure._output_key)
         }
         for component in self.components:
             if not any(port is not None for port in component._local_ports):
@@ -810,26 +871,34 @@ class PortNetwork:
                 or output_key in used
             )
             if not touched:
-                exposed.append(_Exposure(component.label, input_key, output_key))
-        hidden: list[_Exposure] = []
+                exposed.append(
+                    FieldExposure(
+                        component.label,
+                        input_key,
+                        output_key,
+                        _network_token=self._token,
+                    )
+                )
+        hidden: list[FieldExposure] = []
         for component in self.components:
             for input_name, output_name, label in component._hidden_pairs:
                 hidden.append(
-                    _Exposure(
+                    FieldExposure(
                         label,
                         (component.label, input_name),
                         (component.label, output_name),
-                        hidden=True,
+                        _hidden=True,
+                        _network_token=self._token,
                     )
                 )
         return tuple((*exposed, *hidden))
 
     def _compile(
         self,
-    ) -> tuple[tuple[_Exposure, ...], Any, list[dict[str, Any]], list[tuple[str, str, Any]]]:
+    ) -> tuple[tuple[FieldExposure, ...], Any, list[dict[str, Any]], list[tuple[str, str, Any]]]:
         exposures = self._effective_exposures()
-        covered_inputs = {exposure.input_key for exposure in exposures}
-        covered_outputs = {exposure.output_key for exposure in exposures}
+        covered_inputs = {exposure._input_key for exposure in exposures}
+        covered_outputs = {exposure._output_key for exposure in exposures}
         all_inputs = {
             (component.label, name) for component in self.components for name in component.input_names
         }
@@ -852,7 +921,7 @@ class PortNetwork:
         for column, exposure in enumerate(exposures):
             basis = [0.0] * size
             basis[column] = 1.0
-            input_fields[exposure.input_key] = _AffineField(basis, {})
+            input_fields[exposure._input_key] = _AffineField(basis, {})
 
         pending = list(self._components)
         generated_pairs: list[tuple[str, str, Any]] = []
@@ -900,13 +969,13 @@ class PortNetwork:
             if not progressed:
                 raise ValueError("PortNetwork contains instantaneous feedback or a connection cycle.")
 
-        rows = [output_fields[exposure.output_key] for exposure in exposures]
+        rows = [output_fields[exposure._output_key] for exposure in exposures]
         scattering_rows = [row.scattering for row in rows]
         xp = select_array_module(contains_tracer(scattering_rows))
         scattering = xp.asarray(scattering_rows, dtype=complex)
         coupling_maps = [row.coupling for row in rows]
 
-        external_count = sum(not exposure.hidden for exposure in exposures)
+        external_count = sum(not exposure._hidden for exposure in exposures)
         boundary = self._boundary_scattering(tuple(exposure.label for exposure in exposures[:external_count]))
         if boundary is not None:
             boundary_xp = select_array_module(contains_tracer((scattering, boundary)))
@@ -1122,7 +1191,7 @@ class PortNetwork:
 
     def _terminal_is_exposed(self, terminal: FieldTerminal) -> bool:
         return any(
-            terminal.key in (exposure.input_key, exposure.output_key)
+            terminal.key in (exposure._input_key, exposure._output_key)
             for exposure in self._exposures
         )
 
@@ -1184,4 +1253,4 @@ class PortNetwork:
             return False
 
 
-__all__ = ["FieldTerminal", "PortNetwork", "SLHComponent"]
+__all__ = ["PortNetwork"]

--- a/quchip/chip/serialization.py
+++ b/quchip/chip/serialization.py
@@ -78,7 +78,6 @@ def deserialize_chip(data: dict[str, Any]) -> "Chip":
         "devices",
         "couplings",
         "baths",
-        "ports",
         "port_network",
         "control_equipment",
     }
@@ -105,16 +104,11 @@ def deserialize_chip(data: dict[str, Any]) -> "Chip":
 
     baths = [Bath.from_dict(bd) for bd in data.get("baths", [])]
     from quchip.chip.port_network import PortNetwork
-    from quchip.chip.ports import Port
-
-    if "port_network" in data and "ports" in data:
-        raise TypeError("Serialized Chip cannot contain both 'ports' and 'port_network'.")
     port_network = (
         PortNetwork.from_dict(data["port_network"])
         if "port_network" in data
         else None
     )
-    ports = [Port.from_dict(pd) for pd in data.get("ports", [])]
 
     control_equipment = (
         ControlEquipment.from_dict(data["control_equipment"], device_map, coupling_map)
@@ -131,7 +125,6 @@ def deserialize_chip(data: dict[str, Any]) -> "Chip":
         approximation=approximation,
         basis=cast(Literal["native", "eigen"], data.get("basis", "native")),
         baths=baths or None,
-        ports=ports or None,
         port_network=port_network,
     )
     if control_equipment is not None:

--- a/quchip/control/__init__.py
+++ b/quchip/control/__init__.py
@@ -2,7 +2,6 @@
 
 from quchip.control.equipment import ControlEquipment, CrosstalkMatrix
 from quchip.control.signal import AnalyticSignal, Crosstalk, Delay, Gain, SignalTransform
-from quchip.control.field import CoherentInput, ControlEndpoint
 from quchip.control.drive import (
     BaseDrive,
     ChargeDrive,
@@ -27,8 +26,6 @@ __all__ = [
     # Drive classes
     "BaseDrive",
     "AnalyticSignal",
-    "CoherentInput",
-    "ControlEndpoint",
     "CouplingDrive",
     "DeviceDrive",
     "SignalTransform",

--- a/quchip/control/sequence.py
+++ b/quchip/control/sequence.py
@@ -369,8 +369,8 @@ class QuantumSequence:
         target : str | ControlEndpoint | BaseDevice | BaseCoupling
             Accepted forms, resolved in this order:
 
-            * :class:`~quchip.control.field.CoherentInput` — scheduled on its
-              external SLH exposure without entering ``ControlEquipment``.
+            * ``network.expose(...).input`` — scheduled at that external
+              reference plane without entering ``ControlEquipment``.
             * :class:`BaseDrive` — scheduled directly on that drive.
             * :class:`BaseDevice` — uses the device's first connected
               drive; pass the drive object explicitly when a device

--- a/quchip/control/signal.py
+++ b/quchip/control/signal.py
@@ -59,8 +59,8 @@ def _reject_field_endpoint(value: Any, *, transform: str) -> None:
 
     if isinstance(value, CoherentInput):
         raise TypeError(
-            f"{transform} does not accept CoherentInput. Use PortNetwork scattering "
-            "or an exposure reference-plane delay for field propagation."
+            f"{transform} does not accept an external-plane input. Use PortNetwork "
+            "scattering or a reference-plane delay for field propagation."
         )
 
 

--- a/quchip/engine/__init__.py
+++ b/quchip/engine/__init__.py
@@ -152,9 +152,9 @@ def build_problem(
         (backend selection is chip-owned).
     e_ops : dict, optional
         Observables keyed by device label (or a 2-tuple of labels for a
-        two-body observable). A string trace name may instead map to an
-        ``OutputAmplitude``, ``OutputQuadrature``, or ``OutputPhotonFlux``
-        spec for an accessible SLH exposure.
+        two-body observable). An external-plane object may instead map to its
+        ``plane.output`` request; read the complete field afterward with
+        ``result.output(plane)``.
     initial_state : optional
         Initial state; ``None`` defaults to the chip ground state.
 

--- a/quchip/engine/observables.py
+++ b/quchip/engine/observables.py
@@ -18,10 +18,10 @@ This module performs the two operations that tie those frames together:
   transformation applied to each band — equivalent to moving the
   observable from the simulation frame to the control frame.
 
-Output-field specs take a parallel path: they lower the resolved ``L`` and
-``L dagger L`` moments before the solve, then reconstruct ``S beta + L`` from
-the solve-bound coherent inputs and propagate it to the exposure reference
-plane afterward.
+An external-plane output request takes a parallel path: one request lowers
+both the resolved ``L`` and ``L dagger L`` moments before the solve. Afterward,
+quchip reconstructs ``S beta + L`` from the solve-bound input and propagates
+the complete field trace to the requested reference plane.
 
 Observable reconstruction reads per-device demodulation frequencies from
 :class:`~quchip.engine.ir.ResolvedFrame` and forms the demodulation
@@ -39,14 +39,8 @@ import numpy as np
 from quchip.backend import Backend, SolverResult
 from quchip.chip.chip import Chip
 from quchip.engine.ir import ResolvedFrame
-from quchip.observables import (
-    OutputAmplitude,
-    OutputObservable,
-    OutputPhotonFlux,
-    OutputQuadrature,
-    is_output_observable,
-)
-from quchip.results.results import ObservableTrace
+from quchip.observables import OutputField, is_output_field
+from quchip.results.results import ObservableTrace, OutputFieldTrace
 from quchip.utils.constants import TWO_PI
 from quchip.utils.jax_utils import array_namespace as _array_namespace
 from quchip.utils.labeling import resolve_label
@@ -79,7 +73,7 @@ class OutputMeta:
     """Reconstruction recipe for one solver-facing output operator."""
 
     key: EOpKey
-    observable: OutputObservable
+    observable: OutputField
     role: Literal["amplitude", "flux"]
 
 
@@ -108,9 +102,8 @@ def decompose_eops(
     * ``("label_a", "label_b")`` with a tuple ``(op_a, op_b)`` — each
       operator is split into single-mode bands on its device and all
       band pairs are tensored, producing two-body ``(w_a, w_b)`` bands.
-    * A string trace name with an ``OutputAmplitude``, ``OutputQuadrature``,
-      or ``OutputPhotonFlux`` value — the required resolved SLH moments are
-      lowered directly and reconstructed after the solve.
+    * A string trace name with an ``OutputField`` value — the resolved first
+      and normally ordered second moments are reconstructed after the solve.
 
     For each band, the returned :class:`BandMeta` records the original
     key, the weight, and the sub-index (distinguishing entries when the
@@ -122,15 +115,21 @@ def decompose_eops(
 
     flat_ops: list[Any] = []
     meta: list[BandMeta | OutputMeta] = []
+    output_exposures: set[str] = set()
 
     dims = chip.dims
 
     for raw_key, val in e_ops_dict.items():
         key = _resolve_eop_key(raw_key)
 
-        if is_output_observable(val):
+        if is_output_field(val):
             if not isinstance(key, str):
                 raise ValueError("Output observable trace names must be strings.")
+            if val.exposure in output_exposures:
+                raise ValueError(
+                    f"Output exposure {val.exposure!r} may be requested only once per solve."
+                )
+            output_exposures.add(val.exposure)
             if engine_result is None:
                 raise ValueError(
                     "Output observables require a resolved transient solve; "
@@ -139,7 +138,6 @@ def decompose_eops(
             _append_output_eops(
                 flat_ops,
                 meta,
-                key=key,
                 observable=val,
                 engine_result=engine_result,
                 backend=backend,
@@ -240,8 +238,7 @@ def _append_output_eops(
     flat_ops: list[Any],
     meta: list[BandMeta | OutputMeta],
     *,
-    key: EOpKey,
-    observable: OutputObservable,
+    observable: OutputField,
     engine_result: Any,
     backend: Backend,
 ) -> None:
@@ -256,9 +253,13 @@ def _append_output_eops(
 
     coupling = channel.coupling
     flat_ops.append(backend.from_canonical_operator(coupling))
-    meta.append(OutputMeta(key=key, observable=observable, role="amplitude"))
-    if not isinstance(observable, OutputPhotonFlux):
-        return
+    meta.append(
+        OutputMeta(
+            key=observable.exposure,
+            observable=observable,
+            role="amplitude",
+        )
+    )
 
     values = coupling.to_dense()
     xp = backend.array_module
@@ -276,7 +277,13 @@ def _append_output_eops(
             )
         )
     )
-    meta.append(OutputMeta(key=key, observable=observable, role="flux"))
+    meta.append(
+        OutputMeta(
+            key=observable.exposure,
+            observable=observable,
+            role="flux",
+        )
+    )
 
 
 def recombine_expect(
@@ -376,7 +383,10 @@ def build_observable_traces(
     dict_meta: list[BandMeta | OutputMeta],
     resolved_frame: ResolvedFrame,
     engine_result: Any,
-) -> dict[EOpKey, ObservableTrace | list[ObservableTrace]]:
+) -> tuple[
+    dict[EOpKey, ObservableTrace | list[ObservableTrace]],
+    dict[EOpKey, OutputFieldTrace],
+]:
     """Wrap solver expectations into phase-corrected :class:`ObservableTrace` objects.
 
     Pulls the flat per-band expectations out of *solver_result*, calls
@@ -414,15 +424,15 @@ def build_observable_traces(
             ]
         else:
             traces[key] = ObservableTrace(values=values, raw=raw)
-    traces.update(
+    return (
+        traces,
         _build_output_traces(
             flat_expect,
             dict_meta,
             tlist=tlist,
             engine_result=engine_result,
-        )
+        ),
     )
-    return traces
 
 
 def _build_output_traces(
@@ -431,7 +441,7 @@ def _build_output_traces(
     *,
     tlist: Any,
     engine_result: Any,
-) -> dict[EOpKey, ObservableTrace]:
+) -> dict[EOpKey, OutputFieldTrace]:
     """Reconstruct ``b_out = S b_in + L`` moments at reference planes."""
     output_pairs = [
         (values, meta)
@@ -459,12 +469,12 @@ def _build_output_traces(
             )
 
     grouped: dict[EOpKey, dict[str, Any]] = {}
-    specs: dict[EOpKey, OutputObservable] = {}
+    specs: dict[EOpKey, OutputField] = {}
     for values, meta in output_pairs:
         grouped.setdefault(meta.key, {})[meta.role] = xp.asarray(values)
         specs[meta.key] = meta.observable
 
-    traces: dict[EOpKey, ObservableTrace] = {}
+    traces: dict[EOpKey, OutputFieldTrace] = {}
     for key, moments in grouped.items():
         observable = specs[key]
         output_index = exposure_index[observable.exposure]
@@ -482,19 +492,20 @@ def _build_output_traces(
         lowering = carrier * moments["amplitude"]
         field = direct + lowering
 
-        if isinstance(observable, OutputAmplitude):
-            boundary = field
-        elif isinstance(observable, OutputQuadrature):
-            boundary = xp.real(xp.exp(-1j * xp.asarray(observable.phase)) * field)
-        else:
-            number = xp.real(moments["flux"])
-            boundary = (
-                xp.abs(direct) ** 2
-                + 2.0 * xp.real(xp.conj(direct) * lowering)
-                + number
-            )
-        values = _delay_trace(boundary, times, channel.reference_delay, xp)
-        traces[key] = ObservableTrace(values=values, raw=boundary)
+        number = xp.real(moments["flux"])
+        boundary_flux = (
+            xp.abs(direct) ** 2
+            + 2.0 * xp.real(xp.conj(direct) * lowering)
+            + number
+        )
+        traces[key] = OutputFieldTrace(
+            exposure=observable.exposure,
+            times=times,
+            amplitude=_delay_trace(field, times, channel.reference_delay, xp),
+            photon_flux=_delay_trace(boundary_flux, times, channel.reference_delay, xp),
+            raw_amplitude=field,
+            raw_photon_flux=boundary_flux,
+        )
     return traces
 
 

--- a/quchip/engine/partitioned.py
+++ b/quchip/engine/partitioned.py
@@ -13,13 +13,13 @@ from typing import Any
 def _uses_field_boundary(drive_ops: list, e_ops: dict | None) -> bool:
     """Whether a solve needs the unsplit PortNetwork reference plane."""
     from quchip.engine.ir import CoherentOp
-    from quchip.observables import is_output_observable
+    from quchip.observables import is_output_field
 
     if any(isinstance(operation, CoherentOp) for operation in drive_ops):
         return True
     if not e_ops:
         return False
-    return any(is_output_observable(value) for value in e_ops.values())
+    return any(is_output_field(value) for value in e_ops.values())
 
 
 def _scheduled_coupling_supports(chip: Any, drive_ops: list) -> tuple[tuple[str, ...], ...]:

--- a/quchip/observables.py
+++ b/quchip/observables.py
@@ -1,16 +1,16 @@
-"""Public solve-time observables for accessible SLH output fields."""
+"""Solve-time request for a complete accessible output field."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, TypeAlias
+from typing import Any
 
 from quchip.utils.labeling import resolve_label
 
 
 @dataclass(frozen=True)
-class OutputAmplitude:
-    r"""Mean output field ``<b_out>`` at one exposure reference plane."""
+class OutputField:
+    r"""Request ``<b_out>`` and ``<b_out dagger b_out>`` at one exposure."""
 
     exposure: str
 
@@ -18,34 +18,9 @@ class OutputAmplitude:
         object.__setattr__(self, "exposure", resolve_label(exposure))
 
 
-@dataclass(frozen=True)
-class OutputQuadrature:
-    r"""Mean field quadrature ``Re[exp(-i phase) <b_out>]``."""
-
-    exposure: str
-    phase: Any = 0.0
-
-    def __init__(self, exposure: str | Any, *, phase: Any = 0.0) -> None:
-        object.__setattr__(self, "exposure", resolve_label(exposure))
-        object.__setattr__(self, "phase", phase)
+def is_output_field(value: Any) -> bool:
+    """Return whether *value* requests a complete output-field trace."""
+    return isinstance(value, OutputField)
 
 
-@dataclass(frozen=True)
-class OutputPhotonFlux:
-    r"""Normally ordered output photon flux ``<b_out dagger b_out>``."""
-
-    exposure: str
-
-    def __init__(self, exposure: str | Any) -> None:
-        object.__setattr__(self, "exposure", resolve_label(exposure))
-
-
-OutputObservable: TypeAlias = OutputAmplitude | OutputQuadrature | OutputPhotonFlux
-
-
-def is_output_observable(value: Any) -> bool:
-    """Return whether *value* is a public output-field observable spec."""
-    return isinstance(value, (OutputAmplitude, OutputQuadrature, OutputPhotonFlux))
-
-
-__all__ = ["OutputAmplitude", "OutputPhotonFlux", "OutputQuadrature"]
+__all__ = ["OutputField"]

--- a/quchip/results/__init__.py
+++ b/quchip/results/__init__.py
@@ -2,15 +2,22 @@
 
 Whatever backend produced the solver output (QuTiP, dynamiqs/JAX, …), users
 interact only with :class:`SimulationResult` and
-:class:`SimulationBatchResult`. Named expectation-value traces are exposed
-as :class:`ObservableTrace`, and raw backend output is wrapped into a
+:class:`SimulationBatchResult`. Named expectation-value traces use
+:class:`ObservableTrace`; external-plane amplitude, quadrature, and photon
+flux use :class:`OutputFieldTrace`. Raw backend output is wrapped into a
 :class:`SimulationResult` via :func:`wrap_solver_result`. A partitioned
 solve (see :mod:`quchip.engine.partitioned`) combines its per-component
 results into a :class:`~quchip.results.partitioned.PartitionedSimulationResult`.
 """
 
 from quchip.results.partitioned import PartitionedSimulationResult
-from quchip.results.results import ObservableTrace, SimulationBatchResult, SimulationResult, wrap_solver_result
+from quchip.results.results import (
+    ObservableTrace,
+    OutputFieldTrace,
+    SimulationBatchResult,
+    SimulationResult,
+    wrap_solver_result,
+)
 from quchip.results.steady_state import SteadyStateBatchResult, SteadyStateResult
 from quchip.results.input_output import (
     OutputCorrelationResult,
@@ -20,6 +27,7 @@ from quchip.results.input_output import (
 
 __all__ = [
     "ObservableTrace",
+    "OutputFieldTrace",
     "SimulationBatchResult",
     "SimulationResult",
     "SteadyStateResult",

--- a/quchip/results/results.py
+++ b/quchip/results/results.py
@@ -56,6 +56,41 @@ class ObservableTrace:
     raw: Any
 
 
+@dataclass(frozen=True)
+class OutputFieldTrace:
+    """Complete transient field reported at one external reference plane.
+
+    ``amplitude`` is the complex mean field ``<b_out>`` and ``photon_flux``
+    is the normally ordered ``<b_out dagger b_out>`` in photons/ns.
+    ``raw_*`` retain the same moments at the Markov boundary before the
+    reciprocal reference-plane delay.
+    """
+
+    exposure: str
+    times: Any
+    amplitude: Any
+    photon_flux: Any
+    raw_amplitude: Any
+    raw_photon_flux: Any
+
+    def quadrature(self, phase: Any = 0.0) -> Any:
+        r"""Return ``Re[exp(-i phase) <b_out>]`` without another solve."""
+        from quchip.utils.jax_utils import array_namespace
+
+        xp = array_namespace(self.amplitude)
+        return xp.real(xp.exp(-1j * xp.asarray(phase)) * self.amplitude)
+
+    @property
+    def final_amplitude(self) -> Any:
+        """Return the final complex output amplitude."""
+        return self.amplitude[..., -1]
+
+    @property
+    def final_photon_flux(self) -> Any:
+        """Return the final normally ordered photon flux."""
+        return self.photon_flux[..., -1]
+
+
 _NO_STATES_MSG = "No states stored — pass options={'store_states': True} to the solver."
 
 
@@ -87,11 +122,13 @@ class SimulationResult:
         *,
         device_info: list[tuple[str, bool]] | None = None,
         observable_traces: dict[Any, ObservableTrace | list[ObservableTrace]] | None = None,
+        output_traces: dict[Any, OutputFieldTrace] | None = None,
     ) -> None:
         self._backend = backend
         self.times = backend.array_module.asarray(solver_result.times, dtype=float)
         self.states = solver_result.states
         self._expect_data: dict[Any, ObservableTrace | list[ObservableTrace]] | None = observable_traces
+        self._output_data = {} if output_traces is None else dict(output_traces)
         self.solver = solver_result.solver
         self.stats = dict(solver_result.stats) if solver_result.stats else {}
         self.dims = list(dims)
@@ -146,6 +183,25 @@ class SimulationResult:
 
     # Alias: reads nicely at call sites that say "give me the values array".
     expect_values = expect
+
+    # ------------------------------------------------------------------
+    # External fields
+    # ------------------------------------------------------------------
+
+    @property
+    def outputs(self) -> dict[Any, OutputFieldTrace]:
+        """Return complete output-field traces keyed by exposure label."""
+        return dict(self._output_data)
+
+    def output(self, exposure: Any) -> OutputFieldTrace:
+        """Return one field trace by exposure object or label."""
+        label = resolve_label(exposure)
+        try:
+            return self._output_data[label]
+        except KeyError as exc:
+            raise KeyError(
+                f"No output for {label!r}. Available exposures: {sorted(self._output_data)}"
+            ) from exc
 
     # ------------------------------------------------------------------
     # States, partial traces, overlaps
@@ -465,6 +521,8 @@ class SimulationResult:
         ]
         if self._expect_data is not None:
             parts.append(f"expect=dict({len(self._expect_data)} keys)")
+        if self._output_data:
+            parts.append(f"outputs=dict({len(self._output_data)} keys)")
         return ", ".join(parts) + ")"
 
 
@@ -503,6 +561,21 @@ class SimulationBatchResult(BatchResult[SimulationResult]):
         values = self._reshape([r.expect(key, index=index) for r in self._results])
         return self._reduce_time_axis(values, reduce)
 
+    def output(self, exposure: Any) -> OutputFieldTrace:
+        """Return one complete field trace reshaped to the natural sweep grid."""
+        traces = [result.output(exposure) for result in self._results]
+        if not traces:
+            raise RuntimeError("Empty batch has no output fields.")
+        first = traces[0]
+        return OutputFieldTrace(
+            exposure=first.exposure,
+            times=first.times,
+            amplitude=self._reshape([trace.amplitude for trace in traces]),
+            photon_flux=self._reshape([trace.photon_flux for trace in traces]),
+            raw_amplitude=self._reshape([trace.raw_amplitude for trace in traces]),
+            raw_photon_flux=self._reshape([trace.raw_photon_flux for trace in traces]),
+        )
+
     def population(self, device: str | BaseDevice, level: int = 0, *, reduce: str | None = None) -> Any:
         """Return population traces reshaped to the natural sweep grid."""
         values = self._reshape([r.population_array(device, level) for r in self._results])
@@ -534,10 +607,11 @@ def _wrap(
     engine_result: Any,
 ) -> SimulationResult:
     observable_traces = None
+    output_traces = None
     if e_ops_meta is not None:
         from quchip.engine.observables import build_observable_traces
 
-        observable_traces = build_observable_traces(
+        observable_traces, output_traces = build_observable_traces(
             solver_result,
             tlist,
             chip,
@@ -551,6 +625,7 @@ def _wrap(
         dims=chip.dims,
         device_info=[(d.label, d.computational) for d in chip.devices],
         observable_traces=observable_traces,
+        output_traces=output_traces,
     )
 
 

--- a/tests/test_coherent_input.py
+++ b/tests/test_coherent_input.py
@@ -8,8 +8,6 @@ import jax.numpy as jnp
 from quchip import (
     ChargeDrive,
     Chip,
-    CoherentInput,
-    ControlEndpoint,
     ControlEquipment,
     Delay,
     DuffingTransmon,
@@ -20,6 +18,7 @@ from quchip import (
 )
 from quchip import Crosstalk, Gain
 from quchip.control.drive import BaseDrive
+from quchip.control.field import CoherentInput, ControlEndpoint
 from quchip.engine.ir import CoherentOp, evaluate_signal_program
 
 

--- a/tests/test_eliminate_port_network.py
+++ b/tests/test_eliminate_port_network.py
@@ -34,7 +34,7 @@ def test_eliminate_retargets_port_without_double_counting_purcell() -> None:
     reduced = eliminate(chip, "r").chip
 
     assert reduced.port_network is not None
-    assert reduced.port_network.exposures == ()  # untouched ports retain implicit exposure
+    assert tuple(plane.label for plane in reduced.port_network.exposures) == ("readout",)
     assert reduced.port("readout").resolve_targets(reduced) == ("q",)
     assert reduced["q"].T1 is None
     channel = reduced.resolve().slh.external_channels[0]
@@ -51,7 +51,7 @@ def test_eliminate_preserves_scattering_and_explicit_exposure() -> None:
     after = reduced.resolve().slh
 
     assert reduced.port_network is not None
-    assert reduced.port_network.exposures == ("feedline",)
+    assert tuple(plane.label for plane in reduced.port_network.exposures) == ("feedline",)
     np.testing.assert_allclose(after.S, before.S)
     assert after.external_channels[0].key == "feedline"
     assert after.external_channels[0].reference_delay == before.external_channels[0].reference_delay

--- a/tests/test_output_correlations.py
+++ b/tests/test_output_correlations.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from quchip import Chip, Port, Resonator, VNA
+from quchip import Chip, Port, PortNetwork, Resonator, VNA
 
 
 def test_coherent_resonator_output_has_unit_g1_and_g2() -> None:
     resonator = Resonator(freq=6.0, levels=8, label="r")
     port = Port(resonator, rate=0.04, label="p")
-    vna = VNA(Chip([resonator], ports=[port]), input=port, outputs=[port])
+    vna = VNA(
+        Chip([resonator], port_network=PortNetwork.from_ports([port])),
+        input=port,
+        outputs=[port],
+    )
     vna.pump(port, freq=6.0, amplitude=0.02)
     delays = np.array([0.0, 2.0, 7.0])
 
@@ -30,7 +34,10 @@ def test_cross_port_correlations_retain_both_field_labels() -> None:
     input_port = Port(resonator, rate=0.03, label="in")
     output_port = Port(resonator, rate=0.04, label="out")
     vna = VNA(
-        Chip([resonator], ports=[input_port, output_port]),
+        Chip(
+            [resonator],
+            port_network=PortNetwork.from_ports([input_port, output_port]),
+        ),
         input=input_port,
         outputs=[input_port, output_port],
     )
@@ -49,7 +56,11 @@ def test_cross_port_correlations_retain_both_field_labels() -> None:
 def test_vacuum_output_has_zero_fluctuation_spectrum() -> None:
     resonator = Resonator(freq=6.0, levels=5, label="r")
     port = Port(resonator, rate=0.04, label="p")
-    vna = VNA(Chip([resonator], ports=[port]), input=port, outputs=[port])
+    vna = VNA(
+        Chip([resonator], port_network=PortNetwork.from_ports([port])),
+        input=port,
+        outputs=[port],
+    )
     frequencies = np.array([-0.1, 0.0, 0.1])
 
     result = vna.output_spectrum(port, frequencies=frequencies)
@@ -69,7 +80,11 @@ def test_thermal_output_has_g2_zero_near_two() -> None:
         thermal_population=0.2,
     )
     port = Port(resonator, rate=0.03, label="p")
-    vna = VNA(Chip([resonator], ports=[port]), input=port, outputs=[port])
+    vna = VNA(
+        Chip([resonator], port_network=PortNetwork.from_ports([port])),
+        input=port,
+        outputs=[port],
+    )
 
     result = vna.g2(port, [0.0])
 
@@ -89,7 +104,15 @@ def test_qutip_and_dynamiqs_stationary_output_analysis_agree() -> None:
             thermal_population=0.15,
         )
         port = Port(resonator, rate=0.03, label="p")
-        vna = VNA(Chip([resonator], ports=[port], backend=backend), input=port, outputs=[port])
+        vna = VNA(
+            Chip(
+                [resonator],
+                port_network=PortNetwork.from_ports([port]),
+                backend=backend,
+            ),
+            input=port,
+            outputs=[port],
+        )
         spectrum = vna.output_spectrum(port, frequencies=[-0.05, 0.0, 0.05])
         return spectrum.fluctuation_spectrum, vna.g1(port, [0.0, 2.0]).values, vna.g2(port, [0.0, 2.0]).values
 
@@ -104,7 +127,11 @@ def test_qutip_output_analysis_is_not_capped_by_engine_dense_dimension() -> None
     """QuTiP output analysis uses its native stationary lowering beyond the old dense cap."""
     resonator = Resonator(freq=6.0, levels=17, label="r", T1=20.0)
     port = Port(resonator, rate=0.04, label="p")
-    vna = VNA(Chip([resonator], ports=[port]), input=port, outputs=[port])
+    vna = VNA(
+        Chip([resonator], port_network=PortNetwork.from_ports([port])),
+        input=port,
+        outputs=[port],
+    )
 
     result = vna.output_spectrum(port, frequencies=[0.0])
 

--- a/tests/test_output_observables.py
+++ b/tests/test_output_observables.py
@@ -6,18 +6,23 @@ from dataclasses import FrozenInstanceError
 
 import numpy as np
 import pytest
+import quchip
 
-from quchip import (
-    Chip,
-    CoherentInput,
-    OutputAmplitude,
-    OutputPhotonFlux,
-    OutputQuadrature,
-    PortNetwork,
-    QuantumSequence,
-    Resonator,
-    Square,
-)
+from quchip import Chip, PortNetwork, QuantumSequence, Resonator, Square
+
+
+def test_package_root_keeps_one_input_output_concept() -> None:
+    """Implementation handles and per-moment request types stay off the package root."""
+    assert "PortNetwork" in quchip.__all__
+    assert {
+        "CoherentInput",
+        "ControlEndpoint",
+        "FieldTerminal",
+        "OutputAmplitude",
+        "OutputPhotonFlux",
+        "OutputQuadrature",
+        "SLHComponent",
+    }.isdisjoint(quchip.__all__)
 
 
 def _one_port_chip(
@@ -25,39 +30,27 @@ def _one_port_chip(
     rate: float = 0.04,
     delay: float = 0.0,
     backend: str = "qutip",
-) -> tuple[Chip, Resonator]:
+) -> tuple[Chip, Resonator, object]:
     resonator = Resonator(freq=0.2, levels=4, label="r")
     network = PortNetwork(label="line")
     port = network.port("coupler", target=resonator, rate=rate)
-    network.expose(
+    plane = network.expose(
         "readout",
         input=port.input,
         output=port.output,
         delay=delay,
     )
-    return Chip([resonator], port_network=network, frame="lab", backend=backend), resonator
+    chip = Chip([resonator], port_network=network, frame="lab", backend=backend)
+    return chip, resonator, plane
 
 
-def test_output_observable_specs_are_immutable_and_validate_the_exposure_label() -> None:
-    """Output specifications are immutable and require a valid exposure label."""
-    amplitude = OutputAmplitude("readout")
-    quadrature = OutputQuadrature("readout", phase=0.3)
-    flux = OutputPhotonFlux("readout")
-
-    assert amplitude.exposure == quadrature.exposure == flux.exposure == "readout"
-    assert quadrature.phase == pytest.approx(0.3)
-    with pytest.raises(FrozenInstanceError):
-        amplitude.exposure = "other"  # type: ignore[misc]
-
-
-def test_output_amplitude_is_s_beta_plus_l_expectation() -> None:
-    """Output amplitude evaluates the resolved S beta plus L relation."""
-    rate = 0.04
+def test_exposure_is_the_complete_transient_input_output_handle() -> None:
+    """One external-plane object schedules input and returns all output moments."""
     beta = 0.12 + 0.05j
-    chip, resonator = _one_port_chip(rate=rate)
+    chip, resonator, plane = _one_port_chip()
     sequence = QuantumSequence(chip)
     sequence.schedule(
-        CoherentInput("readout"),
+        plane.input,
         envelope=Square(duration=2.0, amplitude=abs(beta)),
         phase=np.angle(beta),
     )
@@ -65,42 +58,76 @@ def test_output_amplitude_is_s_beta_plus_l_expectation() -> None:
 
     result = sequence.simulate(
         tlist=times,
-        e_ops={
-            "field": OutputAmplitude("readout"),
-            resonator: resonator.lowering_operator(),
-        },
+        initial_state={resonator: 1},
+        e_ops={plane: plane.output},
+        partition=False,
+    )
+    field = result.output(plane)
+
+    assert plane.label == "readout"
+    assert chip.port_network is not None
+    assert chip.port_network.exposure(plane) == plane
+    assert chip.port_network.exposures == (plane,)
+    assert "_input_key" not in repr(plane)
+    assert "_output_key" not in repr(plane)
+    assert field.exposure == "readout"
+    assert set(result.outputs) == {"readout"}
+    np.testing.assert_allclose(field.times, times)
+    np.testing.assert_allclose(field.quadrature(), np.real(field.amplitude))
+    np.testing.assert_allclose(
+        field.quadrature(phase=np.pi / 2),
+        np.imag(field.amplitude),
+        atol=2e-8,
+    )
+    assert field.final_amplitude == field.amplitude[-1]
+    assert field.final_photon_flux == field.photon_flux[-1]
+    with pytest.raises(FrozenInstanceError):
+        plane.label = "other"  # type: ignore[misc]
+
+
+def test_output_amplitude_is_s_beta_plus_l_expectation() -> None:
+    """Output amplitude evaluates the resolved S beta plus L relation."""
+    rate = 0.04
+    beta = 0.12 + 0.05j
+    chip, resonator, plane = _one_port_chip(rate=rate)
+    sequence = QuantumSequence(chip)
+    sequence.schedule(
+        plane.input,
+        envelope=Square(duration=2.0, amplitude=abs(beta)),
+        phase=np.angle(beta),
+    )
+
+    result = sequence.simulate(
+        tlist=np.linspace(0.0, 2.0, 41),
+        e_ops={plane: plane.output, resonator: resonator.lowering_operator()},
         partition=False,
     )
 
     lowering = result.observable_traces["r"]
     assert not isinstance(lowering, list)
     expected = beta + np.sqrt(rate) * lowering.raw
-    np.testing.assert_allclose(result.expect("field"), expected, atol=2e-8)
+    np.testing.assert_allclose(result.output(plane).amplitude, expected, atol=2e-8)
 
 
-def test_output_quadrature_uses_half_sum_convention() -> None:
-    """Output quadrature uses the documented half-sum field convention."""
-    chip, _ = _one_port_chip()
-    phase = 0.37
+def test_output_quadrature_is_an_arbitrary_post_solve_projection() -> None:
+    """One complex field trace supports any quadrature phase after the solve."""
+    chip, _, plane = _one_port_chip()
     sequence = QuantumSequence(chip)
     sequence.schedule(
-        CoherentInput("readout"),
+        plane.input,
         envelope=Square(duration=1.0, amplitude=0.15),
         phase=0.21,
     )
-
-    result = sequence.simulate(
+    field = sequence.simulate(
         tlist=np.linspace(0.0, 1.0, 21),
-        e_ops={
-            "field": OutputAmplitude("readout"),
-            "quadrature": OutputQuadrature("readout", phase=phase),
-        },
+        e_ops={plane: plane.output},
         partition=False,
-    )
+    ).output(plane)
 
+    phase = 0.37
     np.testing.assert_allclose(
-        result.expect("quadrature"),
-        np.real(np.exp(-1j * phase) * result.expect("field")),
+        field.quadrature(phase),
+        np.real(np.exp(-1j * phase) * field.amplitude),
         atol=2e-8,
     )
 
@@ -108,168 +135,139 @@ def test_output_quadrature_uses_half_sum_convention() -> None:
 def test_output_photon_flux_includes_spontaneous_emission() -> None:
     """Normally ordered output flux includes spontaneous emission from L."""
     rate = 0.04
-    chip, resonator = _one_port_chip(rate=rate)
+    chip, resonator, plane = _one_port_chip(rate=rate)
     times = np.linspace(0.0, 4.0, 41)
 
-    result = QuantumSequence(chip).simulate(
+    field = QuantumSequence(chip).simulate(
         tlist=times,
         initial_state={resonator: 1},
-        e_ops={"flux": OutputPhotonFlux("readout")},
+        e_ops={plane: plane.output},
         partition=False,
-    )
+    ).output(plane)
 
-    np.testing.assert_allclose(
-        result.expect("flux"),
-        rate * np.exp(-rate * times),
-        atol=2e-7,
-    )
+    np.testing.assert_allclose(field.photon_flux, rate * np.exp(-rate * times), atol=2e-7)
 
 
 def test_scattering_routes_the_direct_coherent_background() -> None:
-    """Output fields include coherent background routed by scattering."""
+    """Complete output traces include coherent background routed by scattering."""
     left = Resonator(freq=0.2, levels=2, label="left")
     right = Resonator(freq=0.3, levels=2, label="right")
     network = PortNetwork(scattering=[[0.0, 1.0], [1.0, 0.0]], label="swap")
     network.port("left", target=left, rate=0.04)
     network.port("right", target=right, rate=0.09)
+    left_plane = network.exposure("left")
+    right_plane = network.exposure("right")
+    assert network.exposure("left") == left_plane
+    assert hash(network.exposure("left")) == hash(left_plane)
     chip = Chip([left, right], port_network=network, frame="lab")
     sequence = QuantumSequence(chip)
-    sequence.schedule(
-        CoherentInput("left"),
-        envelope=Square(duration=0.2, amplitude=0.2),
-    )
+    sequence.schedule(left_plane.input, envelope=Square(duration=0.2, amplitude=0.2))
 
     result = sequence.simulate(
         tlist=np.linspace(0.0, 0.2, 5),
-        e_ops={
-            "left_out": OutputAmplitude("left"),
-            "right_out": OutputAmplitude("right"),
-        },
+        e_ops={"right": left_plane.output, "other": right_plane.output},
         partition=False,
     )
 
-    assert result.expect("left_out")[0] == pytest.approx(0.0)
-    assert result.expect("right_out")[0] == pytest.approx(0.2)
+    assert result.output(left_plane).amplitude[0] == pytest.approx(0.0)
+    assert result.output(right_plane).amplitude[0] == pytest.approx(0.2)
 
 
-def test_reference_delay_is_applied_reciprocally_to_emitted_flux() -> None:
-    """Reference delay shifts emitted fields outward with the reciprocal convention."""
-    rate = 0.04
+def test_one_plane_cannot_be_requested_twice() -> None:
+    """A solve has one canonical trace for each external plane."""
+    chip, _, plane = _one_port_chip()
+
+    with pytest.raises(ValueError, match="readout.*only once"):
+        QuantumSequence(chip).simulate(
+            tlist=np.linspace(0.0, 0.2, 3),
+            e_ops={"first": plane.output, "second": plane.output},
+            partition=False,
+        )
+
+
+def test_output_field_retains_the_markov_boundary_before_reference_delay() -> None:
+    """Field traces expose both reported-plane and pre-delay boundary values."""
     delay = 0.2
-    chip, resonator = _one_port_chip(rate=rate, delay=delay)
+    chip, resonator, plane = _one_port_chip(delay=delay)
     times = np.linspace(0.0, 1.0, 11)
 
-    result = QuantumSequence(chip).simulate(
+    field = QuantumSequence(chip).simulate(
         tlist=times,
         initial_state={resonator: 1},
-        e_ops={"flux": OutputPhotonFlux("readout")},
+        e_ops={plane: plane.output},
         partition=False,
-    )
+    ).output("readout")
 
-    expected = np.where(
-        times < delay,
-        0.0,
-        rate * np.exp(-rate * (times - delay)),
+    assert field.photon_flux[0] == pytest.approx(0.0)
+    assert field.raw_photon_flux[0] == pytest.approx(0.04)
+    np.testing.assert_allclose(
+        field.photon_flux[times >= delay],
+        field.raw_photon_flux[:-2],
+        atol=2e-7,
     )
-    np.testing.assert_allclose(result.expect("flux"), expected, atol=2e-7)
 
 
 def test_reference_delay_applies_on_both_sides_of_direct_scattering() -> None:
     """Reference delay shifts incident and reported coherent fields reciprocally."""
     delay = 0.2
-    chip, _ = _one_port_chip(delay=delay)
+    chip, _, plane = _one_port_chip(delay=delay)
     sequence = QuantumSequence(chip)
-    sequence.schedule(
-        CoherentInput("readout"),
-        envelope=Square(duration=0.5, amplitude=0.2),
-    )
+    sequence.schedule(plane.input, envelope=Square(duration=0.5, amplitude=0.2))
     times = np.linspace(0.0, 0.8, 9)
 
-    result = sequence.simulate(
+    amplitude = sequence.simulate(
         tlist=times,
-        e_ops={"field": OutputAmplitude("readout")},
+        e_ops={plane: plane.output},
         partition=False,
-    )
+    ).output(plane).amplitude
 
-    np.testing.assert_allclose(result.expect("field")[times < 2 * delay], 0.0, atol=2e-8)
-    assert result.expect("field")[4] == pytest.approx(0.2, abs=2e-4)
+    np.testing.assert_allclose(amplitude[times < 2 * delay], 0.0, atol=2e-8)
+    assert amplitude[4] == pytest.approx(0.2, abs=2e-4)
 
 
-def test_multiple_coherent_inputs_on_one_exposure_add_before_output_evaluation() -> None:
-    """Incident fields on one exposure add before output evaluation."""
-    chip, _ = _one_port_chip(rate=0.04)
+def test_unknown_exposure_reports_the_available_boundary() -> None:
+    """Exposure lookup rejects unknown labels and reports valid choices."""
+    chip, _, _ = _one_port_chip()
+    assert chip.port_network is not None
+
+    with pytest.raises(KeyError, match="missing.*readout"):
+        chip.port_network.exposure("missing")
+
+
+def test_output_field_batch_preserves_grid_and_post_solve_analysis() -> None:
+    """Batched field extraction keeps sweep axes and arbitrary quadrature phase."""
+    chip, _, plane = _one_port_chip()
     sequence = QuantumSequence(chip)
-    sequence.schedule(CoherentInput("readout"), envelope=Square(duration=1.0, amplitude=0.1))
-    sequence.schedule(
-        CoherentInput("readout"),
-        envelope=Square(duration=1.0, amplitude=0.2),
-        phase=np.pi / 2,
-    )
-
-    result = sequence.simulate(
-        tlist=np.linspace(0.0, 1.0, 11),
-        e_ops={
-            "field": OutputAmplitude("readout"),
-            "flux": OutputPhotonFlux("readout"),
-        },
-        partition=False,
-    )
-
-    assert result.expect("field")[0] == pytest.approx(0.1 + 0.2j)
-    assert result.expect("flux")[0] == pytest.approx(0.1**2 + 0.2**2)
-
-
-def test_unknown_output_exposure_reports_the_available_boundary() -> None:
-    """Output evaluation rejects unknown exposures and reports valid choices."""
-    chip, _ = _one_port_chip()
-
-    with pytest.raises(ValueError, match="Unknown output exposure.*readout"):
-        QuantumSequence(chip).build_problem(
-            tlist=np.linspace(0.0, 1.0, 11),
-            e_ops={"field": OutputAmplitude("missing")},
-        )
-
-
-def test_output_observables_follow_sequence_batch_axes() -> None:
-    """Output observables preserve ordinary sequence batch axes."""
-    chip, _ = _one_port_chip()
-    sequence = QuantumSequence(chip)
-    handle = sequence.schedule(
-        CoherentInput("readout"),
-        envelope=Square(duration=0.5, amplitude=0.1),
-    )
+    pulse = sequence.schedule(plane.input, envelope=Square(duration=0.5, amplitude=0.1))
 
     result = sequence.simulate_batch(
-        handle.vary("amplitude", [0.1, 0.2]),
+        pulse.vary("amplitude", [0.1, 0.2]),
         tlist=np.linspace(0.0, 0.5, 6),
-        e_ops={"field": OutputAmplitude("readout")},
+        e_ops={plane: plane.output},
         progress=False,
     )
+    field = result.output(plane)
 
-    assert result.expect("field").shape == (2, 6)
-    np.testing.assert_allclose(result.expect("field")[:, 0], [0.1, 0.2], atol=2e-8)
+    assert field.amplitude.shape == (2, 6)
+    assert field.photon_flux.shape == (2, 6)
+    np.testing.assert_allclose(field.amplitude[:, 0], [0.1, 0.2], atol=2e-8)
+    np.testing.assert_allclose(field.quadrature(), np.real(field.amplitude))
 
 
-def test_qutip_and_dynamiqs_output_observables_agree() -> None:
+def test_qutip_and_dynamiqs_complete_output_fields_agree() -> None:
     """QuTiP and Dynamiqs agree on amplitude and photon-flux traces."""
     pytest.importorskip("dynamiqs")
 
     def traces(backend: str) -> tuple[np.ndarray, np.ndarray]:
-        chip, _ = _one_port_chip(backend=backend)
+        chip, _, plane = _one_port_chip(backend=backend)
         sequence = QuantumSequence(chip)
-        sequence.schedule(
-            CoherentInput("readout"),
-            envelope=Square(duration=1.0, amplitude=0.15),
-        )
-        result = sequence.simulate(
+        sequence.schedule(plane.input, envelope=Square(duration=1.0, amplitude=0.15))
+        field = sequence.simulate(
             tlist=np.linspace(0.0, 1.0, 21),
-            e_ops={
-                "field": OutputAmplitude("readout"),
-                "flux": OutputPhotonFlux("readout"),
-            },
+            e_ops={plane: plane.output},
             partition=False,
-        )
-        return np.asarray(result.expect("field")), np.asarray(result.expect("flux"))
+        ).output(plane)
+        return np.asarray(field.amplitude), np.asarray(field.photon_flux)
 
     qutip = traces("qutip")
     dynamiqs = traces("dynamiqs")
@@ -277,26 +275,23 @@ def test_qutip_and_dynamiqs_output_observables_agree() -> None:
     np.testing.assert_allclose(dynamiqs[1], qutip[1], atol=2e-7)
 
 
-def test_dynamiqs_output_quadrature_is_differentiable() -> None:
-    """Dynamiqs output quadrature remains differentiable through a solve."""
+def test_dynamiqs_output_quadrature_is_differentiable_after_the_solve() -> None:
+    """Post-solve field analysis stays differentiable through dynamiqs."""
     pytest.importorskip("dynamiqs")
     import jax
     import jax.numpy as jnp
 
-    chip, _ = _one_port_chip(backend="dynamiqs")
+    chip, _, plane = _one_port_chip(backend="dynamiqs")
 
     def final_quadrature(amplitude: object) -> object:
         sequence = QuantumSequence(chip)
-        sequence.schedule(
-            CoherentInput("readout"),
-            envelope=Square(duration=0.5, amplitude=amplitude),
-        )
-        result = sequence.simulate(
+        sequence.schedule(plane.input, envelope=Square(duration=0.5, amplitude=amplitude))
+        field = sequence.simulate(
             tlist=jnp.linspace(0.0, 0.5, 6),
-            e_ops={"I": OutputQuadrature("readout")},
+            e_ops={plane: plane.output},
             partition=False,
-        )
-        return result.expect("I")[-1]
+        ).output(plane)
+        return field.quadrature()[-1]
 
     value, gradient = jax.jit(jax.value_and_grad(final_quadrature))(jnp.asarray(0.1))
     assert jnp.isfinite(value)

--- a/tests/test_port_network.py
+++ b/tests/test_port_network.py
@@ -245,16 +245,25 @@ def test_network_dilation_precedes_stable_identity_hidden_baths() -> None:
     )
 
 
-def test_legacy_ports_form_an_explicit_identity_network() -> None:
-    """Legacy chip ports lower to the same explicit identity network boundary."""
+def test_from_ports_builds_an_explicit_identity_network() -> None:
+    """Existing port objects can seed the sole explicit network boundary."""
     resonator = Resonator(freq=6.0, levels=2, label="r")
     port = Port(resonator, rate=0.01, label="readout")
 
-    chip = Chip([resonator], ports=[port])
+    chip = Chip([resonator], port_network=PortNetwork.from_ports([port]))
 
     assert chip.port_network is not None
     assert chip.port_network.ports == (port,)
     np.testing.assert_allclose(chip.resolve().slh.S, [[1.0]])
+
+
+def test_chip_has_one_network_construction_path() -> None:
+    """Ports enter a chip through its sole network-owned boundary."""
+    resonator = Resonator(freq=6.0, levels=2, label="r")
+    port = Port(resonator, rate=0.01, label="readout")
+
+    with pytest.raises(TypeError, match="ports"):
+        Chip([resonator], ports=[port])  # type: ignore[call-arg]
 
 
 def test_second_network_cannot_silently_replace_the_first() -> None:

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -10,6 +10,7 @@ from quchip import (
     Chip,
     CollapseChannel,
     Port,
+    PortNetwork,
     Resonator,
 )
 
@@ -24,7 +25,7 @@ def test_internal_loss_and_ports_are_distinct_collapse_channels() -> None:
     )
     input_port = Port(resonator, external_quality_factor=15_000, label="in")
     output_port = Port(resonator, external_quality_factor=18_000, label="out")
-    chip = Chip([resonator], ports=[input_port, output_port])
+    chip = Chip([resonator], port_network=PortNetwork.from_ports([input_port, output_port]))
 
     terms = chip.resolve().collapse_terms
     port_terms = chip.resolve().port_terms
@@ -53,7 +54,7 @@ def test_collective_port_round_trips_and_connects_partition() -> None:
     lowering = np.array([[0.0, 1.0], [0.0, 0.0]], dtype=complex)
     operator = np.kron(lowering, np.eye(2)) + 0.5j * np.kron(np.eye(2), lowering)
     port = Port([first, second], rate=0.02, operator=operator, phase=0.3, label="feedline")
-    chip = Chip([first, second], ports=[port])
+    chip = Chip([first, second], port_network=PortNetwork.from_ports([port]))
 
     restored = Chip.from_dict(chip.to_dict())
 
@@ -67,7 +68,9 @@ def test_collective_port_round_trips_and_connects_partition() -> None:
 def test_port_parameters_rebind_without_mutating_source() -> None:
     """Port rate and phase use stable parameter paths and immutable chip rebinding."""
     resonator = Resonator(freq=6.8, levels=3, label="r")
-    chip = Chip([resonator], ports=[Port(resonator, rate=0.01, phase=0.2, label="readout")])
+    network = PortNetwork(label="line")
+    network.port("readout", target=resonator, rate=0.01, phase=0.2)
+    chip = Chip([resonator], port_network=network)
 
     shifted = chip.with_params({"port.readout.rate": 0.03, "port.readout.phase": -0.4})
 
@@ -86,7 +89,12 @@ def test_collective_port_can_span_more_than_two_devices() -> None:
         + np.kron(np.kron(np.eye(2), lowering), np.eye(2))
         + np.kron(np.kron(np.eye(2), np.eye(2)), lowering)
     )
-    chip = Chip(devices, ports=[Port(devices, rate=0.01, operator=operator, label="common")])
+    chip = Chip(
+        devices,
+        port_network=PortNetwork.from_ports(
+            [Port(devices, rate=0.01, operator=operator, label="common")]
+        ),
+    )
 
     resolved = chip.resolve(frame={device.label: 6.0 for device in devices})
     term = next(term for term in resolved.collapse_terms if term.source == "common")
@@ -124,14 +132,14 @@ def test_port_with_mixed_frame_bands_is_rejected_as_dynamic() -> None:
         dtype=complex,
     )
     port = Port(resonator, rate=0.02, operator=lowering + lowering.T, label="p")
-    chip = Chip([resonator], ports=[port])
+    chip = Chip([resonator], port_network=PortNetwork.from_ports([port]))
 
     assert chip.resolve(frame="lab").port_terms[0].frame_frequency == 0.0
     with pytest.raises(ValueError, match="different phases"):
         chip.resolve(frame={"r": 6.0})
 
     nearly_lowering = Port(resonator, rate=0.02, operator=lowering + 1e-11 * lowering.T, label="p")
-    near_chip = Chip([resonator], ports=[nearly_lowering])
+    near_chip = Chip([resonator], port_network=PortNetwork.from_ports([nearly_lowering]))
     assert near_chip.resolve(frame={"r": 6.0}).port_terms[0].frame_frequency == pytest.approx(6.0)
 
 
@@ -150,7 +158,10 @@ def test_explicit_port_uses_the_resolved_energy_frame_for_charge_basis_devices()
     lowering = np.outer(vectors[:, 0], vectors[:, 1].conj())
     port = Port(transmon, rate=0.02, operator=lowering, label="drive")
 
-    term = Chip([transmon], ports=[port]).resolve(frame={"q": transmon.freq}).port_terms[0]
+    term = Chip(
+        [transmon],
+        port_network=PortNetwork.from_ports([port]),
+    ).resolve(frame={"q": transmon.freq}).port_terms[0]
 
     assert term.frame_frequency == pytest.approx(transmon.freq)
 
@@ -159,7 +170,12 @@ def test_in_place_port_operator_mutation_invalidates_resolution_cache() -> None:
     """Mutating a public dense port operator cannot return stale resolved physics."""
     resonator = Resonator(freq=6.0, levels=2, label="r")
     operator = np.array([[0.0, 1.0], [0.0, 0.0]], dtype=complex)
-    chip = Chip([resonator], ports=[Port(resonator, rate=0.02, operator=operator, label="p")])
+    chip = Chip(
+        [resonator],
+        port_network=PortNetwork.from_ports(
+            [Port(resonator, rate=0.02, operator=operator, label="p")]
+        ),
+    )
     first = chip.resolve(frame="lab")
 
     operator[0, 1] = 0.5
@@ -181,7 +197,10 @@ def test_port_collapse_ownership_does_not_depend_on_display_labels() -> None:
     resonator = CollidingResonator(freq=6.0, levels=3, label="shared")
     port = Port(resonator, rate=0.02, label="shared")
 
-    resolved = Chip([resonator], ports=[port]).resolve(frame="lab")
+    resolved = Chip(
+        [resonator],
+        port_network=PortNetwork.from_ports([port]),
+    ).resolve(frame="lab")
 
     assert len(resolved.collapse_terms) == 2
     assert resolved.port_terms[0].rate == pytest.approx(0.02)

--- a/tests/test_resolved_partition.py
+++ b/tests/test_resolved_partition.py
@@ -8,11 +8,9 @@ import pytest
 from quchip import (
     Capacitive,
     Chip,
-    CoherentInput,
     CollapseChannel,
     Coupling,
     Exact,
-    OutputAmplitude,
     PortNetwork,
     QuantumSequence,
     RWA,
@@ -142,17 +140,19 @@ def test_field_io_declines_component_solve_but_keeps_automatic_simulation() -> N
     network = PortNetwork(scattering=np.asarray([[0.0, 1.0], [1.0, 0.0]]), label="swap")
     network.port("left", target=first, rate=0.02)
     network.port("right", target=second, rate=0.03)
+    left_plane = network.exposure("left")
+    right_plane = network.exposure("right")
     chip = Chip([first, second], port_network=network, frame={"a": 5.0, "b": 5.4})
     sequence = QuantumSequence(chip)
     sequence.schedule(
-        CoherentInput("left"),
+        left_plane.input,
         envelope=Square(duration=0.2, amplitude=0.01),
     )
 
     result = sequence.simulate(
         tlist=np.linspace(0.0, 0.2, 3),
-        e_ops={"right_out": OutputAmplitude("right")},
+        e_ops={right_plane: right_plane.output},
     )
 
     assert not isinstance(result, PartitionedSimulationResult)
-    assert result.expect("right_out").shape == (3,)
+    assert result.output(right_plane).amplitude.shape == (3,)

--- a/tests/test_vna.py
+++ b/tests/test_vna.py
@@ -21,6 +21,11 @@ from quchip import (
 )
 
 
+def _network(*ports: Port) -> PortNetwork:
+    """Return the explicit identity boundary for the supplied ports."""
+    return PortNetwork.from_ports(ports)
+
+
 def _linear_resonator(*, kappa_in: float, kappa_out: float = 0.0):
     resonator = Resonator(freq=6.0, levels=8, label="r")
     input_port = Port(resonator, rate=kappa_in, label="in")
@@ -29,7 +34,7 @@ def _linear_resonator(*, kappa_in: float, kappa_out: float = 0.0):
     if kappa_out:
         output_port = Port(resonator, rate=kappa_out, label="out")
         ports.append(output_port)
-    return resonator, input_port, output_port, Chip([resonator], ports=ports)
+    return resonator, input_port, output_port, Chip([resonator], port_network=_network(*ports))
 
 
 def test_coherent_port_input_uses_standard_slh_hamiltonian_sign() -> None:
@@ -153,14 +158,18 @@ def test_resonance_distinguishes_undercritical_and_overcoupling(
 ) -> None:
     resonator = Resonator(freq=6.0, levels=5, label="r", T1=1.0 / internal_rate)
     port = Port(resonator, rate=external_rate, label="p")
-    result = VNA(Chip([resonator], ports=[port]), input=port, outputs=[port]).sweep([6.0])
+    result = VNA(
+        Chip([resonator], port_network=_network(port)),
+        input=port,
+        outputs=[port],
+    ).sweep([6.0])
 
     expected = (internal_rate - external_rate) / (internal_rate + external_rate)
     np.testing.assert_allclose(result.s11, [expected], atol=2e-8)
 
 
 def test_vna_probe_has_no_finite_amplitude_mode() -> None:
-    """Finite-power spectroscopy belongs to CoherentInput simulations."""
+    """Finite-power spectroscopy belongs to external-plane input simulations."""
     assert "amplitude" not in inspect.signature(VNA.sweep).parameters
 
 
@@ -178,7 +187,7 @@ def test_vna_result_does_not_depend_on_chip_default_frame() -> None:
     def response(frame):
         resonator = Resonator(freq=6.0, levels=5, label="r")
         port = Port(resonator, rate=0.04, label="p")
-        chip = Chip([resonator], ports=[port], frame=frame)
+        chip = Chip([resonator], port_network=_network(port), frame=frame)
         return VNA(chip, input=port, outputs=[port]).sweep([5.98, 6.0, 6.02]).s11
 
     np.testing.assert_allclose(response("lab"), response("rotating"), atol=2e-8)
@@ -192,7 +201,7 @@ def test_one_carrier_probes_passive_modes_behind_the_port() -> None:
     chip = Chip(
         [purcell_filter, readout],
         couplings=[Capacitive(purcell_filter, readout, g=0.01)],
-        ports=[feedline],
+        port_network=_network(feedline),
     )
 
     result = VNA(chip, input=feedline, outputs=[feedline]).sweep([5.99, 6.0, 6.02])
@@ -206,7 +215,7 @@ def test_fixed_tone_variation_uses_pump_axes_without_new_drive_physics() -> None
     auxiliary = Resonator(freq=5.0, levels=3, label="aux")
     readout_port = Port(readout, rate=0.03, label="readout_port")
     pump_port = Port(auxiliary, rate=0.04, label="pump_port")
-    chip = Chip([readout, auxiliary], ports=[readout_port, pump_port])
+    chip = Chip([readout, auxiliary], port_network=_network(readout_port, pump_port))
     vna = VNA(chip, input=readout_port, outputs=[readout_port])
     pump = vna.pump(pump_port, freq=5.0, amplitude=0.02)
 
@@ -223,7 +232,7 @@ def test_distinct_stationary_tones_on_one_mode_require_time_evolution() -> None:
     resonator = Resonator(freq=6.0, levels=4, label="r")
     probe = Port(resonator, rate=0.02, label="probe")
     pump_port = Port(resonator, rate=0.02, label="pump")
-    chip = Chip([resonator], ports=[probe, pump_port])
+    chip = Chip([resonator], port_network=_network(probe, pump_port))
     vna = VNA(chip, input=probe, outputs=[probe])
     vna.pump(pump_port, freq=5.9, amplitude=0.01)
 
@@ -238,7 +247,11 @@ def test_qutip_and_dynamiqs_vna_response_agree() -> None:
         resonator = Resonator(freq=6.0, levels=5, label="r")
         input_port = Port(resonator, rate=0.02, label="in")
         output_port = Port(resonator, rate=0.03, label="out")
-        chip = Chip([resonator], ports=[input_port, output_port], backend=backend)
+        chip = Chip(
+            [resonator],
+            port_network=_network(input_port, output_port),
+            backend=backend,
+        )
         return VNA(chip, input=input_port, outputs=[output_port]).sweep([5.98, 6.0, 6.02]).s21
 
     np.testing.assert_allclose(np.asarray(response("dynamiqs")), response("qutip"), atol=2e-8)
@@ -252,7 +265,7 @@ def test_dynamiqs_pumped_small_signal_response_is_jittable_and_differentiable() 
 
     resonator = Resonator(freq=6.0, levels=3, label="r")
     port = Port(resonator, rate=0.04, label="p")
-    chip = Chip([resonator], ports=[port], backend="dynamiqs")
+    chip = Chip([resonator], port_network=_network(port), backend="dynamiqs")
 
     def reflection(amplitude):
         vna = VNA(chip, input=port, outputs=[port])
@@ -276,7 +289,11 @@ def test_dynamiqs_explicit_port_frequency_is_jittable_and_differentiable(
     resonator = Resonator(freq=6.0, levels=3, label="r")
     lowering = np.diag(np.sqrt(np.arange(1, 3)), k=1).astype(complex)
     port = Port(resonator, rate=0.04, operator=lowering, label="p")
-    vna = VNA(Chip([resonator], ports=[port], backend="dynamiqs"), input=port, outputs=[port])
+    vna = VNA(
+        Chip([resonator], port_network=_network(port), backend="dynamiqs"),
+        input=port,
+        outputs=[port],
+    )
 
     def reflection(frequency):
         return jnp.real(vna.sweep(jnp.asarray([frequency])).s11[0])
@@ -292,7 +309,7 @@ def test_resonantly_driven_two_level_population_matches_optical_bloch_solution()
     amplitude = 0.03
     qubit = DuffingTransmon(freq=5.0, anharmonicity=-0.2, levels=2, label="q")
     port = Port(qubit, rate=decay_rate, label="drive")
-    chip = Chip([qubit], ports=[port])
+    chip = Chip([qubit], port_network=_network(port))
 
     vna = VNA(chip, input=port, outputs=[port])
     vna.pump(port, freq=5.0, amplitude=amplitude)
@@ -312,7 +329,7 @@ def test_two_tone_cross_kerr_model_produces_a_pump_frequency_axis() -> None:
     chip = Chip(
         [qubit, resonator],
         [CrossKerr(qubit, resonator, chi=-0.03)],
-        ports=[qubit_port, readout_port],
+        port_network=_network(qubit_port, readout_port),
     )
     vna = VNA(chip, input=readout_port, outputs=[readout_port])
     pump = vna.pump(qubit_port, freq=5.0, amplitude=0.04)
@@ -339,7 +356,7 @@ def test_two_tone_probe_frame_propagates_through_passive_filter_network() -> Non
             CrossKerr(qubit, resonator, chi=-0.003),
             Capacitive(purcell_filter, resonator, g=0.010),
         ],
-        ports=[qubit_port, feedline],
+        port_network=_network(qubit_port, feedline),
     )
     vna = VNA(chip, input=feedline, outputs=[feedline])
     pump = vna.pump(qubit_port, freq=5.0, amplitude=0.02)
@@ -360,7 +377,7 @@ def test_nonlinear_stationary_state_matches_long_time_master_equation() -> None:
     amplitude = 0.05
     cavity = KerrCavity(freq=6.0, kerr=0.03, levels=8, label="c")
     port = Port(cavity, rate=0.05, label="p")
-    chip = Chip([cavity], ports=[port], backend="qutip")
+    chip = Chip([cavity], port_network=_network(port), backend="qutip")
     vna = VNA(chip, input=port, outputs=[port])
     vna.pump(port, freq=6.0, amplitude=amplitude)
     stationary = vna.sweep([6.0])


### PR DESCRIPTION
## Summary

The SLH stack had the right physics but too many user-facing handles: separate input, terminal, component, amplitude, quadrature, and photon-flux concepts. This PR contracts that surface around one external reference plane:

```python
plane = network.expose("readout", input=port.input, output=cable.output)

sequence.schedule(plane.input, envelope=probe, freq=6.8)
result = sequence.simulate(tlist=times, e_ops={plane: plane.output})

field = result.output(plane)
b_out = field.amplitude
i_trace = field.quadrature(phase=0.0)
flux = field.photon_flux
```

`plane.output` requests the complete field once. `result.output(plane)` then provides complex amplitude, arbitrary post-solve quadratures, normally ordered photon flux, final-value conveniences, and the pre-delay Markov-boundary traces. The same result shape works for batches and remains native to NumPy/JAX.

This keeps `PortNetwork` as the single public routing concept, removes seven package-root exports and the redundant `Chip(ports=...)` path, and replaces three per-moment output request classes with one output request and one analyzable trace. It also gives implicit port planes stable equality and prevents duplicate requests or alias/exposure collisions.

The resolved physics is unchanged: `b_out = S b_in + L`, coherent-input Hamiltonian construction, normal ordering, reciprocal reference-plane delay, and the input-free `ResolvedSLH` boundary remain owned where they were.

This language directly supports finite-power reflection/transmission, resonator ring-up and ring-down, emitted wave packets, phase-selectable homodyne traces without re-solving, photon-flux analysis, swept output maps, and differentiable output objectives.

## Diff scope

- package-root exports: 135 to 128, with no new root names
- production Python: +267 / -158, net +109 lines
- tests: +262 / -196, net +66 lines
- documentation: +61 / -59, net +2 lines

## Verification

- `python -m pytest`: 1,766 passed
- focused input-output/network/backend suite: 172 passed
- QuTiP/dynamiqs output parity and JAX gradient coverage passed
- `ruff check .`
- `python -m mypy quchip tests/typing/external_declarative_models.py`: 119 source files clean
- `python -m compileall -q quchip tests`
- `python tools/sync_example_outputs.py --check`
- repository Sphinx HTML build
- wheel and source distribution build; `twine check` passed
- built-wheel import/API smoke test and package membership audit passed
- `git diff --check`

## Checklist

- [x] This pull request is focused and contains no unrelated changes.
- [x] Changed behavior is covered by tests.
- [x] Relevant documentation and examples are updated.
- [x] Generated files and paired notebooks are synchronized where applicable.
- [x] `PHYSICS.md` documents the external-plane input/output contract.

## AI assistance

Codex was used to inspect the stacked implementation, develop and simplify the API change, update tests and documentation, and run the verification listed above. The resulting behavior and claims were reviewed against quchip's physics and ownership contracts.
