### PR TITLE
docs: add section tabs and a scoped sidebar to the site navigation

### DIFF
--- a/docs/_ext/section_navigation.py
+++ b/docs/_ext/section_navigation.py
@@ -1,0 +1,53 @@
+"""Use the root toctree as section tabs and show one section in Furo's sidebar."""
+
+from bs4 import BeautifulSoup
+
+
+def section_navigation(app, pagename, templatename, context, doctree):
+    env = app.env
+    roots = env.toctree_includes.get(env.config.root_doc, [])
+
+    def contains(root, page):
+        return root == page or any(
+            contains(child, page) for child in env.toctree_includes.get(root, [])
+        )
+
+    active = next((root for root in roots if contains(root, pagename)), None)
+    if pagename == env.config.root_doc:
+        active = roots[0] if roots else None
+    context["docs_sections"] = [
+        {"doc": root, "title": env.titles[root].astext(), "active": root == active}
+        for root in roots
+    ]
+    context["docs_section"] = env.titles[active].astext() if active else "Documentation"
+    context["docs_section_root"] = active
+
+    # Furo has added accessible disclosure controls and current-page markers.
+    # Keep those, selecting only the active section's children.
+    soup = BeautifulSoup(context.get("furo_navigation_tree", ""), "html.parser")
+    link = soup.find("a", href=context["pathto"](active)) if active else None
+    tree = link.parent.find("ul", recursive=False) if link else None
+    if tree:
+        # Deep subtrees (the API module listing) stay collapsed to their entry
+        # unless the current page lives inside them.
+        for item in tree.select(":scope > li.has-children"):
+            if "current" in item.get("class", []):
+                continue
+            for child in list(item.children):
+                if getattr(child, "name", None) in {"ul", "input", "label"}:
+                    child.decompose()
+            item["class"] = ["toctree-l2"]
+        for item in tree.select("li.current-page > a"):
+            item["aria-current"] = "page"
+    if tree:
+        context["docs_section_tree"] = str(tree)
+    elif active:
+        context["docs_section_tree"] = ""
+    else:
+        # Pages outside every section keep the full tree rather than none.
+        context["docs_section_tree"] = context.get("furo_navigation_tree", "")
+
+
+def setup(app):
+    app.connect("html-page-context", section_navigation, priority=800)
+    return {"version": "1", "parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/_static/navigation.css
+++ b/docs/_static/navigation.css
@@ -1,0 +1,83 @@
+/* Global sections above Furo's reading layout. */
+:root { --docs-header-height: 76px; }
+/* Furo sizes body to the viewport (height: 100%); a sticky header can only
+   stick within its parent's box, so let the body grow with the document and
+   give the page its full-height guarantee in viewport units instead. */
+body { height: auto; min-height: 100%; }
+.page { min-height: calc(100vh - var(--docs-header-height)); }
+.docs-header {
+  height: var(--docs-header-height); box-sizing: border-box;
+  display: flex; align-items: center; gap: 3rem; padding: 0 2rem;
+  border-bottom: 1px solid var(--color-background-border);
+  background: var(--color-background-primary);
+  /* Furo's .page is a flex container; its drawers are flex items with
+     z-index 30 (sidebar) and 50 (contents), so the header must clear both. */
+  position: sticky; top: 0; z-index: 60;
+}
+.skip-to-content { z-index: 70; }
+.back-to-top { top: calc(var(--docs-header-height) + 1rem); }
+.docs-header ~ .skip-to-content { display: none; }
+@media print { .docs-header { display: none; } }
+.docs-brand { display: flex; align-items: center; gap: 1rem; flex-shrink: 0; }
+.docs-brand img { width: 114px; height: 32px; object-fit: contain; }
+.docs-brand > span { color: var(--color-foreground-muted); font-size: .875rem; }
+.docs-version { margin-left: .35rem; font-variant-numeric: tabular-nums; }
+.docs-tabs { display: flex; height: 100%; align-items: stretch; gap: 2rem; }
+.docs-tabs a {
+  display: flex; align-items: center; border-bottom: 2px solid transparent;
+  padding: 2px 0 0; color: var(--color-foreground-secondary);
+  font-size: .925rem; white-space: nowrap;
+}
+.docs-tabs a.active { border-bottom-color: var(--color-brand-primary); color: var(--color-foreground-primary); font-weight: 600; }
+.docs-header a { text-decoration: none; }
+.docs-header a:hover { color: var(--color-brand-primary); }
+.docs-repository { margin-left: auto; color: var(--color-foreground-muted); font-size: .875rem; }
+.docs-sidebar-heading { padding: 2rem 1.5rem 1rem; font-size: .8rem; font-weight: 650; letter-spacing: .035em; }
+.docs-sidebar-heading a { color: var(--color-foreground-primary); text-decoration: none; }
+.docs-section-tree > ul { padding-left: 0; }
+.docs-section-tree > ul > li > a { padding-left: 1.5rem; }
+/* Keep the theme's native disclosures reachable by keyboard. */
+.docs-section-tree .toctree-checkbox {
+  display: block; position: absolute; width: 1px; height: 1px;
+  padding: 0; margin: -1px; overflow: hidden; clip-path: inset(50%);
+  white-space: nowrap; border: 0;
+}
+.docs-section-tree .toctree-checkbox:focus-visible + label {
+  outline: 2px solid var(--color-brand-primary); outline-offset: 2px;
+}
+.sidebar-sticky, .toc-sticky { top: var(--docs-header-height); height: calc(100vh - var(--docs-header-height)); }
+.toc-sticky { max-height: calc(100vh - var(--docs-header-height)); }
+.sidebar-container { width: 100%; }
+.sidebar-search-container { margin-bottom: 1rem; }
+article h1 { letter-spacing: -.035em; }
+article :is(h1,h2,h3,h4,[id]) { scroll-margin-top: calc(var(--docs-header-height) + 2rem); }
+a:focus-visible, button:focus-visible, input:focus-visible, summary:focus-visible { outline: 2px solid var(--color-brand-primary); outline-offset: 4px; }
+.docs-eyebrow { color: var(--color-brand-primary); font-size: .875rem; font-weight: 600; margin-bottom: .65rem; }
+.docs-intro { font-size: 1.15rem; line-height: 1.65; max-width: 37em; color: var(--color-foreground-secondary); }
+.docs-paths { margin: 1.5rem 0 2rem; }
+.docs-paths a { display: grid; grid-template-columns: 1fr auto; gap: .2rem 1rem; padding: 1rem 0; border-top: 1px solid var(--color-background-border); text-decoration: none; }
+.docs-paths a:last-child { border-bottom: 1px solid var(--color-background-border); }
+.docs-paths strong { color: var(--color-foreground-primary); font-weight: 600; }
+.docs-paths span { color: var(--color-foreground-secondary); font-size: .925rem; grid-column: 1; }
+.docs-paths b { grid-column: 2; grid-row: 1 / 3; align-self: center; font-weight: 400; }
+.docs-paths a:hover strong { color: var(--color-brand-primary); }
+@media (max-width: 67em) {
+  /* Narrow screens: the global header scrolls away and Furo's own mobile bar
+     (menu, title, theme, contents) stays sticky as the theme intends. */
+  :root { --docs-header-height: 0px; }
+  .docs-header {
+    position: static; height: auto; flex-wrap: wrap; gap: 0;
+    padding: .75rem 1rem 0; justify-content: space-between;
+  }
+  .docs-repository { margin-left: 0; }
+  .docs-tabs {
+    order: 3; width: 100%; height: 44px; gap: 1.5rem; justify-content: flex-start;
+    overflow-x: auto; scrollbar-width: none; -webkit-overflow-scrolling: touch;
+  }
+  .docs-tabs::-webkit-scrollbar { display: none; }
+  .docs-tabs a { font-size: .85rem; flex-shrink: 0; }
+  .sidebar-sticky, .toc-sticky { top: 0; height: 100vh; }
+  .toc-sticky { max-height: 100vh; }
+  article :is(h1,h2,h3,h4,[id]) { scroll-margin-top: 5rem; }
+}
+@media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }

--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -1,0 +1,20 @@
+{% extends "!page.html" %}
+
+{% block body %}
+{#- Keep the skip link first in tab order; the theme's own copy is hidden in CSS. -#}
+<a class="skip-to-content muted-link" href="#furo-main-content">{{ _("Skip to content") }}</a>
+<header class="docs-header">
+  <a class="docs-brand" href="{{ pathto(master_doc) }}" aria-label="quchip documentation home">
+    <img class="only-light" src="{{ pathto('_static/' + theme_light_logo, 1) }}" alt="quchip" width="114" height="32">
+    <img class="only-dark" src="{{ pathto('_static/' + theme_dark_logo, 1) }}" alt="quchip" width="114" height="32">
+    <span>docs <span class="docs-version">{{ version }}</span></span>
+  </a>
+  <nav class="docs-tabs" aria-label="Documentation sections">
+    {% for section in docs_sections %}
+    <a href="{{ pathto(section.doc) }}"{% if section.active %} class="active" aria-current="{{ 'page' if pagename == section.doc else 'location' }}"{% endif %}>{{ section.title }}</a>
+    {% endfor %}
+  </nav>
+  <a class="docs-repository" href="https://github.com/quchip/quchip">GitHub <span aria-hidden="true">↗</span></a>
+</header>
+{{ super() }}
+{% endblock %}

--- a/docs/_templates/sidebar/brand.html
+++ b/docs/_templates/sidebar/brand.html
@@ -1,0 +1,7 @@
+<div class="docs-sidebar-heading">
+  {% if docs_section_root %}
+  <a href="{{ pathto(docs_section_root) }}"{% if pagename == docs_section_root %} aria-current="page"{% endif %}>{{ docs_section }}</a>
+  {% else %}
+  <span>{{ docs_section }}</span>
+  {% endif %}
+</div>

--- a/docs/_templates/sidebar/navigation.html
+++ b/docs/_templates/sidebar/navigation.html
@@ -1,0 +1,12 @@
+<nav class="sidebar-tree docs-section-tree" aria-label="{{ docs_section }} pages">
+  {% if docs_section_tree %}
+  {{ docs_section_tree }}
+  {% else %}
+  {# Pages outside every section still get somewhere to go. #}
+  <ul>
+    {% for section in docs_sections %}
+    <li class="toctree-l1"><a class="reference internal" href="{{ pathto(section.doc) }}">{{ section.title }}</a></li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+</nav>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,7 @@ extensions = [
     "myst_parser",
     "sphinx_copybutton",
     "themed_images",
+    "section_navigation",
 ]
 
 templates_path = ["_templates"]
@@ -63,7 +64,7 @@ suppress_warnings = ["docutils", "ref.python", "myst.xref_missing", "ref.ref", "
 html_theme = "furo"
 html_title = f"quchip {version}"
 html_static_path = ["_static"]
-html_css_files = ["figures.css"]
+html_css_files = ["figures.css", "navigation.css"]
 html_favicon = "_static/favicon.png"
 # Colors come from the quchip identity system (see the wordmark assets):
 # ink #16181c / paper #fafbfc, #f2f4f6 / accent #c92f33 in light mode;

--- a/docs/contribute/index.md
+++ b/docs/contribute/index.md
@@ -1,0 +1,25 @@
+# Contribute
+
+Extend quchip with a model, improve the documentation, or contribute a fix.
+
+- {doc}`Extend quchip <../extensions>` with devices, couplings, drives,
+  envelopes, dissipation, and interoperability mappings.
+- Read the {doc}`contributing guide <../contributing>` for development and validation.
+- Check the {doc}`release notes <../release-notes>` for changes and migration notes.
+- Follow the {doc}`code of conduct <../conduct>` when participating.
+
+Report bugs and model requests through [GitHub Issues](https://github.com/quchip/quchip/issues).
+Use [Discussions](https://github.com/quchip/quchip/discussions) for questions and proposals.
+
+The accompanying paper is [quchip: A Differentiable Toolkit for Modeling Quantum Devices](https://arxiv.org/abs/2607.17081).
+Software citation metadata is in [CITATION.cff](https://github.com/quchip/quchip/blob/main/CITATION.cff).
+
+```{toctree}
+:hidden:
+:maxdepth: 1
+
+Extend quchip <../extensions>
+Contributing <../contributing>
+Release notes <../release-notes>
+Code of conduct <../conduct>
+```

--- a/docs/get-started/first-simulation.md
+++ b/docs/get-started/first-simulation.md
@@ -1,0 +1,50 @@
+# Your first simulation
+
+How much population does a Gaussian pulse leave in a transmon's first excited
+state? Declare a four-level transmon, wire a charge drive, and apply a 20 ns pulse.
+Frequencies are in GHz and times are in ns.
+
+## Declare the chip and drive
+
+```python
+import numpy as np
+from quchip import RWA, ChargeDrive, Chip, DuffingTransmon, Gaussian, QuantumSequence
+
+q = DuffingTransmon(freq=5.0, anharmonicity=-0.25, levels=4, label="q")
+chip = Chip([q], frame="rotating", approximation=RWA())
+line = ChargeDrive(q, label="xy")
+chip.wire(line)
+```
+
+The model uses a rotating frame and the rotating-wave approximation. No loss
+channels are declared, so this calculation describes coherent evolution.
+
+## Schedule and simulate
+
+```python
+sequence = QuantumSequence(chip)
+sequence.schedule(
+    line,
+    envelope=Gaussian(duration=20.0, sigmas=3.0, amplitude=0.04),
+    freq=chip.freq(q),
+)
+result = sequence.simulate(
+    tlist=np.linspace(0.0, 30.0, 121),
+    initial_state=chip.state({q: 0}),
+)
+print(f"Final excited-state population: {result.population(q, 1)[-1]:.3f}")
+```
+
+```text
+Final excited-state population: 0.745
+```
+
+The pulse transfers about 75% of the population into |1⟩. It has not been
+calibrated as a π pulse. The higher levels allow population to leak into |2⟩;
+read it with `result.population(q, 2)`.
+
+Increasing the model from four to five levels changes the final |1⟩ population
+by less than one part in a million for this pulse.
+
+Continue with {doc}`pulses, leakage, and readout <../guides/dynamics-pulses-and-readout>`
+to compare short and long pulses on a coupled transmon–resonator model.

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -1,0 +1,22 @@
+# Get started
+
+Go from installation to a coupled chip and a pulse simulation.
+quchip uses GHz for frequencies, ns for time, and mK for temperature.
+
+1. {doc}`Install quchip <installation>` and choose any optional integrations.
+2. {doc}`Build your first chip <../guides/defining-and-inspecting-a-chip>`:
+   couple a transmon to a resonator and inspect the dressed frequencies.
+3. {doc}`Run your first simulation <first-simulation>`:
+   drive a transmon and read its excited-state population.
+
+Continue to the {doc}`guides <../guides/index>` for spectra, readout,
+microwave networks, reductions, and gradients.
+
+```{toctree}
+:hidden:
+:maxdepth: 1
+
+Installation <installation>
+Your first chip <../guides/defining-and-inspecting-a-chip>
+Your first simulation <first-simulation>
+```

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -1,0 +1,35 @@
+# Installation
+
+quchip requires Python 3.11 or newer. Install it in a virtual environment:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install quchip
+```
+
+On Windows, activate with `.venv\Scripts\activate` instead.
+
+## Optional integrations
+
+QuTiP is the default simulation backend. Add integrations as needed:
+
+```bash
+python -m pip install 'quchip[dynamiqs]'  # JAX-native simulations
+python -m pip install 'quchip[viz]'       # Chip and control graphs
+python -m pip install 'quchip[scqubits]'  # scqubits interoperability
+```
+
+Extras can be combined, for example `quchip[dynamiqs,viz]`.
+See {doc}`backend and solver options <../guides/choosing-a-backend>` for numerical settings.
+
+## Check the installation
+
+```bash
+python -c "import quchip; print(quchip.__version__)"
+```
+
+quchip is a 0.x project. Pin the version for a reproducible calculation,
+for example `quchip==0.3.0`.
+
+Next, {doc}`declare your first chip <../guides/defining-and-inspecting-a-chip>`.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,45 @@
+# Guides
+
+Choose a physical question. Each guide starts with a runnable calculation,
+then develops the model and interprets its observables.
+
+New to quchip? Start with {doc}`your first chip <defining-and-inspecting-a-chip>`.
+
+## Spectra and dynamics
+
+- {doc}`Spectra and parameter sweeps <statics-and-parameter-studies>`:
+  compare dressed observables and track states through avoided crossings.
+- {doc}`Pulses and readout <dynamics-pulses-and-readout>`:
+  compare pulse bandwidth, leakage, and conditional resonator response.
+
+## Microwave networks
+
+- {doc}`Resonator reflection <steady-state-and-vna>`:
+  follow the measured signal through the fridge wiring.
+- {doc}`Purcell filtering and T1 <slh-networks>`:
+  compare circuits and identify where an excitation is lost.
+
+## Reduction and inference
+
+- {doc}`Chip transformations <chip-transformations>`:
+  reduce a model and replay its controls.
+- {doc}`Gradients and fitting <differentiability>`:
+  differentiate observables and fit shared model parameters.
+
+## From the talk
+
+The {doc}`SQA 2026 companion <from-sqa-2026>` collects five short calculations
+from the presentation. The guides above stand on their own.
+
+```{toctree}
+:hidden:
+:maxdepth: 1
+
+Spectra and sweeps <statics-and-parameter-studies>
+Pulses and readout <dynamics-pulses-and-readout>
+Resonator reflection <steady-state-and-vna>
+Purcell filtering and T1 <slh-networks>
+Chip transformations <chip-transformations>
+Gradients and fitting <differentiability>
+SQA 2026 companion <from-sqa-2026>
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,92 +1,71 @@
-```{image} _static/quchip-wordmark-light.png
-:class: only-light
-:width: 380px
-:align: center
-:alt: quchip
+```{raw} html
+<p class="docs-eyebrow">quchip documentation</p>
 ```
 
-```{image} _static/quchip-wordmark-dark.png
-:class: only-dark
-:width: 380px
-:align: center
-:alt: quchip
+# Start with a chip.
+
+```{container} docs-intro
+Model superconducting quantum devices in Python. Declare devices, couplings,
+controls, and losses, then calculate spectra, simulate pulses, or fit parameters.
 ```
-
-# Documentation
-
-`quchip` is an open-source Python toolkit for modelling superconducting quantum chips.
-
-Declare devices, couplings, controls, and losses once. Use the same chip for
-dressed spectra, pulse experiments, model reduction, and JAX gradients.
 
 ## Install
 
-quchip requires Python 3.11 or newer.
+Requires Python 3.11 or newer.
 
 ```bash
-pip install quchip
+python -m pip install quchip
 ```
 
-Optional extras: `quchip[dynamiqs]` for the JAX-native backend, `quchip[viz]` for graph visualization, `quchip[scqubits]` for scqubits interoperability.
+See {doc}`installation <get-started/installation>` for optional backends and integrations.
 
-The {doc}`backend guide <guides/choosing-a-backend>` shows how to select QuTiP
-or dynamiqs, choose an integration method, and set tolerances, step controls,
-batching, and gradients.
+## Your first calculation
 
-## Learn quchip
+Couple a transmon to a resonator and read their dressed frequencies.
+Frequencies and couplings are in GHz; this model uses the rotating-wave approximation.
 
-1. {doc}`Declare and inspect a chip <guides/defining-and-inspecting-a-chip>`
-2. {doc}`Sweep spectra and compare measurements <guides/statics-and-parameter-studies>`
-3. {doc}`Schedule pulses and read observables <guides/dynamics-pulses-and-readout>`
-4. {doc}`Measure resonator reflection through a fridge <guides/steady-state-and-vna>`
-5. {doc}`Compare Purcell filtering and T1 <guides/slh-networks>`
-6. {doc}`Reduce a chip and replay its controls <guides/chip-transformations>`
-7. {doc}`Differentiate observables and fit parameters <guides/differentiability>`
+```python
+from quchip import RWA, Capacitive, Chip, DuffingTransmon, Resonator
 
-The {doc}`cookbook` defines the conventions used by executable quchip examples.
+q = DuffingTransmon(freq=5.0, anharmonicity=-0.25, levels=4, label="q")
+r = Resonator(freq=7.0, levels=5, label="r")
+chip = Chip(
+    [q, r], [Capacitive(q, r, g=0.05, label="qr")], approximation=RWA()
+)
 
-```{figure} images/hello_qubit_drive_leakage.svg
-:width: 760px
-:alt: Short and long Gaussian pulses with multilevel qubit populations
+print(f"Qubit: {chip.freq(q):.6f} GHz")
+print(f"Resonator: {chip.freq(r):.6f} GHz")
 ```
 
-```{figure} images/hello_dispersive_readout_iq.svg
-:width: 560px
-:alt: Conditional resonator IQ paths with emphasized final points
+```text
+Qubit: 4.998533 GHz
+Resonator: 7.001041 GHz
 ```
 
-`quchip` uses GHz for ordinary frequencies, ns for time, and mK for temperature. The implemented conventions and approximations are recorded in the {doc}`physics reference <physics>`.
+The coupling shifts each frequency from its bare value. Continue with
+{doc}`your first chip <guides/defining-and-inspecting-a-chip>` to inspect the
+Hamiltonian and change a parameter.
 
-## Start from the SQA 2026 talk
+## What would you like to calculate?
 
-The {doc}`post-talk page <guides/from-sqa-2026>` collects five runnable entry points.
+```{raw} html
+<div class="docs-paths">
+  <a href="guides/statics-and-parameter-studies.html"><strong>Spectra and interactions</strong><span>Sweep parameters and follow dressed states.</span><b aria-hidden="true">→</b></a>
+  <a href="guides/dynamics-pulses-and-readout.html"><strong>Pulses and readout</strong><span>Schedule drives, compare leakage, and read observables.</span><b aria-hidden="true">→</b></a>
+  <a href="guides/steady-state-and-vna.html"><strong>Microwave response and loss</strong><span>Measure reflection through a fridge and explore Purcell filtering.</span><b aria-hidden="true">→</b></a>
+  <a href="guides/differentiability.html"><strong>Gradients and fitting</strong><span>Differentiate observables and infer model parameters.</span><b aria-hidden="true">→</b></a>
+</div>
+```
 
-The accompanying paper is [quchip: A Differentiable Toolkit for Modeling Quantum Devices](https://arxiv.org/abs/2607.17081) (arXiv:2607.17081); citation metadata is in the repository's [CITATION.cff](https://github.com/quchip/quchip/blob/main/CITATION.cff).
+Browse all {doc}`guides <guides/index>` or look up the
+{doc}`API and physics conventions <reference/index>`.
 
 ```{toctree}
 :maxdepth: 1
 :hidden:
 
-guides/defining-and-inspecting-a-chip
-guides/statics-and-parameter-studies
-guides/dynamics-pulses-and-readout
-guides/steady-state-and-vna
-guides/slh-networks
-guides/chip-transformations
-guides/differentiability
-guides/choosing-a-backend
-guides/from-sqa-2026
-release-notes
-cookbook
-extensions
-physics
-api
-contributing
-conduct
+get-started/index
+guides/index
+reference/index
+contribute/index
 ```
-
-## Project
-
-- [GitHub](https://github.com/quchip/quchip)
-- [PyPI](https://pypi.org/project/quchip/)
-- License: Apache-2.0

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,20 @@
+# Reference
+
+Look up an API, check a physics convention, or configure a solver.
+
+- {doc}`API reference <../api>` — objects, methods, and their parameters.
+- {doc}`Physics reference <../physics>` — units, Hamiltonians, frames,
+  approximations, and dissipative models.
+- {doc}`Backend and solver options <../guides/choosing-a-backend>` —
+  QuTiP and dynamiqs, integration, batching, and stationary states.
+- {doc}`Cookbook <../cookbook>` — conventions for writing and checking quchip calculations.
+
+```{toctree}
+:hidden:
+:maxdepth: 1
+
+API reference <../api>
+Physics conventions <../physics>
+Backends and solvers <../guides/choosing-a-backend>
+Cookbook <../cookbook>
+```


### PR DESCRIPTION
## Summary

Groups the documentation into **Get started**, **Guides**, **Reference**, and **Contribute**. A sticky header carries the section tabs; the sidebar shows only the active section's pages and falls back to the full tree for pages outside every section.

## Robustness

- The header stacks above Furo's sidebar and contents drawers (flex items with z-index 30/50) and keeps sticking past the first viewport. Furo sizes `body` to `100%`, which pins a sticky child to one screen, so the body now grows with the document and `.page` keeps its full-height guarantee in viewport units.
- The skip link stays first in tab order; the back-to-top control clears the header; the header is hidden in print.
- Narrow screens hand the sticky role back to Furo's mobile bar, with a horizontally scrollable tab row.
- Deep sidebar subtrees (the API module listing) stay collapsed unless the current page lives inside them.

Verified with a local build at 1440, 1000, 390, and 320 px widths, in dark mode, and after long scrolls (header at top 0, tabs and GitHub link topmost under the cursor).
