### PR TITLE
Release 0.3.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
 repository-code: "https://github.com/quchip/quchip"
 url: "https://quchip.org"
 license: Apache-2.0
-version: "0.2.0"
-date-released: "2026-08-14"
+version: "0.3.1"
+date-released: "2026-09-08"
 preferred-citation:
   type: article
   title: "quchip: A Differentiable Toolkit for Modeling Quantum Devices"

--- a/RELEASE_NOTES_0.3.1.md
+++ b/RELEASE_NOTES_0.3.1.md
@@ -1,0 +1,42 @@
+# quchip 0.3.1
+
+Changes since [v0.3.0](https://github.com/quchip/quchip/compare/v0.3.0...v0.3.1).
+
+## Measurements and fridge noise
+
+- `VNA.measure()` captures the driven steady-state response, internal mode amplitudes and photon numbers, and output noise spectra. Receiver bandwidth, integration time, calibration and repeated IQ sampling reuse those results without another physical solve.
+- Fridge noise propagates through declared attenuators, isolators, circulators, filters and amplifiers. Measurements report output noise density and contributions by source, including cross-output IQ covariance.
+- `result.measure()` samples saved quantum states after either Schrödinger or master-equation evolution. Joint measurements preserve correlations and support assignment errors and calibrated conditional IQ distributions.
+- `result.iq_readout()` uses captured downstream wiring; `IQReadout.from_wiring()` uses a supplied wired model. Both transform supplied conditional coherent fields and accumulate receiver noise without requiring a readout pulse. These detector models do not infer IQ signals from qubit populations or add measurement backaction to the simulated evolution.
+
+## Documentation
+
+- Added section navigation and aligned page titles across headings, sidebars and the README.
+- Extended the fridge guide with steady-state versus sampled resonator responses and Rabi counts and IQ using the same wiring.
+- Moved the Purcell calculation into Focused studies, retaining its existing URL.
+- Shortened the cookbook to practical API choices and common pitfalls; example-authoring guidance now lives under Contribute.
+
+## Public names and compatibility
+
+Public names now distinguish bath occupation, jump rates and network ports:
+
+| Previous name | Preferred name |
+|---|---|
+| `thermal_population` | `thermal_occupation` |
+| `result.collapse_flux(...)` | `result.jump_rate(...)` |
+| `component.side(...)`, `block.side(...)` | `component.port(...)`, `block.port(...)` |
+| `network.exposure(...)`, `network.exposures` | `network.external_port(...)`, `network.external_ports` |
+| `FieldExposure`, `FieldSide` | `NetworkPort`, `ComponentPort` |
+
+The previous names remain compatibility aliases through 0.4 and are scheduled
+for removal in 0.5. Old thermal constructor arguments, parameter bindings,
+noise configurations and saved device dictionaries are accepted. Parameter
+discovery and new serialized dictionaries use `thermal_occupation` only;
+supplying both spellings in one update raises an error. The value is the bath's
+mean occupation, not an initial qubit population. Jump rates include absorption
+and dephasing channels and are not generally emitted photon fluxes.
+
+The new measurement results are named `StateMeasurement` and `StateSamples`
+for saved quantum states, and `VNAMeasurement`, `VNAMeasurementStatistics` and
+`VNAMeasurementSamples` for VNA calculations. `result.measure(...)` and
+`VNA.measure(...)` keep their existing call syntax. `fit_a_dress` is unchanged.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,29 +1,9 @@
 # Release notes
 
-## Unreleased
-
-Public names now distinguish bath occupation, jump rates and network ports:
-
-| Previous name | Preferred name |
-|---|---|
-| `thermal_population` | `thermal_occupation` |
-| `result.collapse_flux(...)` | `result.jump_rate(...)` |
-| `component.side(...)`, `block.side(...)` | `component.port(...)`, `block.port(...)` |
-| `network.exposure(...)`, `network.exposures` | `network.external_port(...)`, `network.external_ports` |
-| `FieldExposure`, `FieldSide` | `NetworkPort`, `ComponentPort` |
-
-The previous names remain compatibility aliases through 0.4 and are scheduled
-for removal in 0.5. Old thermal constructor arguments, parameter bindings,
-noise configurations and saved device dictionaries are accepted. Parameter
-discovery and new serialized dictionaries use `thermal_occupation` only;
-supplying both spellings in one update raises an error. The value is the bath's
-mean occupation, not an initial qubit population. Jump rates include absorption
-and dephasing channels and are not generally emitted photon fluxes.
-
-The new measurement results are named `StateMeasurement` and `StateSamples`
-for saved quantum states, and `VNAMeasurement`, `VNAMeasurementStatistics` and
-`VNAMeasurementSamples` for VNA calculations. `result.measure(...)` and
-`VNA.measure(...)` keep their existing call syntax. `fit_a_dress` is unchanged.
+```{include} ../RELEASE_NOTES_0.3.1.md
+:relative-docs: docs/
+:heading-offset: 1
+```
 
 ```{include} ../RELEASE_NOTES_0.3.0.md
 :relative-docs: docs/

--- a/quchip/__init__.py
+++ b/quchip/__init__.py
@@ -23,7 +23,7 @@ del _jax
 import os  # noqa: E402
 from importlib import import_module  # noqa: E402
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 from quchip.analysis import (  # noqa: E402
     CRHamiltonianResult,


### PR DESCRIPTION
Release the VNA measurement, saved-state readout, fridge noise and documentation additions from #35–#37 as quchip 0.3.1.

This PR changes only release metadata: the package version, citation version/date, and consolidated 0.3.1 release notes including the supported naming aliases. After integration into main, tag the merged commit as v0.3.1 and publish the same notes on GitHub.

Validation: the feature tip passed 1,957 tests; this release change passes Ruff, strict Sphinx, wheel/sdist builds and Twine metadata checks. Required GitHub checks run on the release PR before merging.

Prepared with AI assistance.
