### PR TITLE
Simplify network noise declarations to quanta

### DIFF
--- a/PHYSICS.md
+++ b/PHYSICS.md
@@ -771,21 +771,14 @@ and active physics and the declared truncation. These queries use captured
 arrays; receiver processing does not change internal occupation.
 
 An attenuator, isolator load, or `network.termination()` can declare
-`occupation=n` or `temperature=T, noise_frequency=f`. Temperature is mK and
-`f` is a positive physical frequency in GHz. The Markov occupation is evaluated
-at this declared frequency and held constant over the simulated band. It is
-never evaluated at a rotating-frame offset. Vacuum remains the default.
-
-Attenuators also accept positive `loss_db` instead of `eta`.
-Amplifiers accept `gain_db` instead of linear power gain and either equivalent
-input `noise_temperature` in mK or `noise_figure_db` referenced to 290 K,
-with a positive `noise_frequency` in GHz. The conversion is
-`n_add = k_B T_e/(h f)` and `T_e = 290 K (10^(NF/10)-1)`. This is an
-equivalent symmetrized noise temperature, not a physical Planck occupation.
-The phase-preserving quantum floor still applies. Authored dB/temperature
-parameters remain the rebinding and serialization paths; conversion has one
-owner at resolution. As with direct added quanta, these values are flat at
-their declared noise reference over the modeled band.
+`thermal_occupation=n`: a finite, non-negative mean thermal population in
+quanta. Vacuum remains the default. Amplifiers require input-referred
+symmetrized `added_noise` in quanta, subject to the phase-preserving quantum
+floor. Both noise values are constant across the modeled band, including
+frequency sweeps; no temperature or reference frequency is inferred.
+Attenuators accept positive `loss_db` instead of `eta`; amplifiers accept
+`gain_db` instead of linear power gain. Authored parameters remain the
+rebinding and serialization paths.
 
 For a full unitary scattering matrix S, input j couples through
 `K_j = (S† L)_j`. In addition to vacuum `sum_i D[L_i]`, its thermal population
@@ -811,7 +804,7 @@ detuned-fluorescence spectrum in 0.3.0.
 Physical source budgets separate directly propagated fields from
 `device.correlations`. The latter includes nonlinear response and interference,
 so it need not be positive or independently sampleable. A matched absorptive
-filter declares `loss_occupation` or `loss_temperature` and emits
+filter declares `thermal_occupation` and emits
 `(1-|H(f)|²)n` in each direction. A scalar H(f) without that declaration does
 not imply an absorptive thermal model. Colored emission may propagate to
 external outputs, but colored noise that feeds a quantum coupling is rejected:

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -121,6 +121,26 @@ Prepare coupled eigenstates with `chip.state()`. Use `chip.bare_state()` for
 bare product states. `result.population(q, level=1)` measures a local isolated
 energy-state population; `overlap()` tests a particular joint state.
 
+## Declare network noise
+
+```python
+from quchip import PortNetwork
+
+network = PortNetwork()
+attenuator = network.attenuator("cold", loss_db=20, thermal_occupation=0.01)
+twpa = network.amplifier("twpa", gain_db=20, added_noise=0.5)
+```
+
+`thermal_occupation` is the passive load's mean thermal population in quanta;
+omitting it gives vacuum. `added_noise` is required, input-referred symmetrized
+noise in quanta, at least `(1 - 1/G) / 2` for power gain `G`. Both are constant
+across frequency sweeps. The TWPA model describes linear phase-preserving gain.
+
+For existing network declarations, rename `occupation` or `loss_occupation`
+to `thermal_occupation`. Temperature, noise figure, and `noise_frequency`
+arguments have been removed; supply noise quanta directly, including in saved
+component parameters.
+
 ## Reuse a measurement
 
 With the model and ports from the {doc}`fridge guide <guides/steady-state-and-vna>`:

--- a/docs/guides/steady-state-and-vna.md
+++ b/docs/guides/steady-state-and-vna.md
@@ -65,36 +65,36 @@ def passband(frequency):
 fridge = PortNetwork(label="thermal_fridge")
 port = fridge.port("bus_coupler", target=bus, external_quality_factor=bus_qe)
 input_filter = fridge.filter("input_4_8GHz", transfer=passband)
-att_4k = fridge.attenuator("att_4K", loss_db=20, temperature=4000, noise_frequency=6.5)
-att_cp = fridge.attenuator("att_CP", loss_db=20, temperature=100, noise_frequency=6.5)
-att_mxc = fridge.attenuator("att_MXC", loss_db=20, temperature=20, noise_frequency=6.5)
+n_4k, n_cp, n_mxc = 12.329033161427, 0.046220887106121, 1.6829628323748e-07
+att_4k = fridge.attenuator("att_4K", loss_db=20, thermal_occupation=n_4k)
+att_cp = fridge.attenuator("att_CP", loss_db=20, thermal_occupation=n_cp)
+att_mxc = fridge.attenuator("att_MXC", loss_db=20, thermal_occupation=n_mxc)
 circ = fridge.circulator("circ")
-iso_1 = fridge.isolator("iso_1", temperature=20, noise_frequency=6.5)
-iso_2 = fridge.isolator("iso_2", temperature=20, noise_frequency=6.5)
-iso_loss = fridge.attenuator("iso_insertion", loss_db=1, temperature=20, noise_frequency=6.5)
+iso_1 = fridge.isolator("iso_1", thermal_occupation=n_mxc)
+iso_2 = fridge.isolator("iso_2", thermal_occupation=n_mxc)
+iso_loss = fridge.attenuator("iso_insertion", loss_db=1, thermal_occupation=n_mxc)
 output_filter = fridge.filter("output_4_8GHz", transfer=passband,
-                              loss_temperature=20, noise_frequency=6.5)
-coax = fridge.attenuator("output_coax", loss_db=2, temperature=4000, noise_frequency=6.5)
-hemt = fridge.amplifier("HEMT_4K", gain_db=40, noise_temperature=2500, noise_frequency=6.5)
-room_amp = fridge.amplifier("amp_RT", gain_db=20, noise_figure_db=3, noise_frequency=6.5)
+                              thermal_occupation=n_mxc)
+coax = fridge.attenuator("output_coax", loss_db=2, thermal_occupation=n_4k)
+hemt = fridge.amplifier("HEMT_4K", gain_db=40, added_noise=8.0140842782029)
+room_amp = fridge.amplifier("amp_RT", gain_db=20, added_noise=925.22946424527)
 ```
 
-`loss_db` is the power loss in dB. An attenuator's `temperature` sets the
-occupation of its dissipative load at `noise_frequency`. The isolator loads
-are at 20 mK; their combined insertion loss is represented by `iso_loss`.
-The circulator routes fields ideally and adds no noise of its own.
+`loss_db` is the power loss in dB. `thermal_occupation` is the mean thermal
+population of a passive load in quanta. The values above correspond to
+4 K, 100 mK, and 20 mK at 6.5 GHz and stay fixed throughout this sweep.
+The isolators use the coldest load; `iso_loss` represents their combined
+insertion loss. The ideal circulator adds no noise of its own.
 
-For the HEMT, `noise_temperature=2500` is a 2.5 K equivalent input noise
-temperature. It specifies the added noise, independently of the physical
-4 K stage. The room amplifier instead uses a 3 dB noise figure relative to
-290 K. These match the [noise-temperature](https://lownoisefactory.com/wp-content/uploads/2026/02/lnf-lnc4_8sg.pdf)
-and [noise-figure](https://helpfiles.keysight.com/csg/pxivna/Applications/Noise_Figure.htm)
-conventions used for amplifier specifications.
+Amplifier `added_noise` is input-referred symmetrized noise in quanta.
+The HEMT and room amplifier values correspond, at 6.5 GHz, to a 2.5 K
+equivalent noise temperature and a 3 dB noise figure referenced to 290 K.
+These are fixed model inputs, independent of the amplifiers' physical stages.
 
-The filters have half-power edges at 4 and 8 GHz. `loss_temperature` describes
-the noise emitted by absorbed power in the output filter. Here the input
-filter sees a vacuum source, with the thermal attenuators downstream of it.
-The resonators' intrinsic loss baths are also vacuum.
+The filters have half-power edges at 4 and 8 GHz. The output filter's
+`thermal_occupation` declares a matched absorptive load. The input filter
+sees a vacuum source, with thermal attenuators downstream. The resonators'
+intrinsic loss baths are also vacuum.
 
 Connect the input chain to circulator port 1, the bus to port 2, and the
 receiver chain to port 3. Name the external network ports `drive` for the source and `readout` for the
@@ -407,12 +407,10 @@ covariance in photons/ns. The trace is the complex field variance. The sum
 includes detector vacuum. `device.correlations` contains interference between
 the input and the device field and may be negative.
 
-Passive load temperatures give Planck occupations. Amplifier noise temperature
-uses $n_\mathrm{add}=k_B T_e/(hf)$, while noise figure uses
-$T_e=290\,\mathrm{K}\,(10^{\mathrm{NF}/10}-1)$.
-`noise_frequency` fixes these occupations over the model's Markov band.
-Linear `eta`, linear power `gain`, and input-referred symmetrized `added_noise`
-remain available as alternative declarations.
+Passive `thermal_occupation` and amplifier `added_noise` are constant quanta
+across the modeled band. Frequency sweeps still evaluate filter transmission
+and the device response at each frequency. Linear `eta` and power `gain`
+may replace `loss_db` and `gain_db`.
 
 The default offset grid spans ±0.1 GHz down to 1 Hz. Supply
 `noise_frequencies=` if a narrower spectral feature needs more points.

--- a/quchip/chip/port_network.py
+++ b/quchip/chip/port_network.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 
 from quchip.chip.ports import Port
-from quchip.engine.field_noise import amplifier_values, attenuation_value, noise_parameters, occupation_value
+from quchip.engine.field_noise import amplifier_values, attenuation_value, noise_parameters, thermal_occupation_value
 from quchip.engine.reference import (
     FieldChannel,
     ReferenceAmplifier,
@@ -562,15 +562,14 @@ class PortNetwork:
         return self._permutation_component(label, names, order, kind="permutation", sided=False)
 
     def attenuator(
-        self, label: str, *, eta: Any = None, loss_db: Any = None, occupation: Any = None,
-        temperature: Any = None, noise_frequency: Any = None,
+        self, label: str, *, eta: Any = None, loss_db: Any = None, thermal_occupation: Any = None,
     ) -> SLHComponent:
         """Add a reciprocal two-sided attenuator with power transmission ``eta``.
 
         Each direction has amplitude transmission ``sqrt(eta)`` and couples to
         one of two hidden loss channels with amplitude ``sqrt(1-eta)``.
-        They default to vacuum. Declare occupation, or temperature in mK with
-        noise_frequency in GHz, to give both loads a thermal state.
+        They default to vacuum. ``thermal_occupation`` gives both loads a mean
+        thermal population in quanta, constant across the modeled band.
         Specify either power transmission ``eta`` or positive ``loss_db``.
         """
         power = {key: value for key, value in (("eta", eta), ("loss_db", loss_db)) if value is not None}
@@ -588,8 +587,7 @@ class PortNetwork:
             ),
             _row_inputs=((1, 3), (0, 2), (0, 2), (1, 3)),
             _kind="attenuator",
-            _parameters={**power, **noise_parameters(
-                occupation=occupation, temperature=temperature, noise_frequency=noise_frequency)},
+            _parameters={**power, **noise_parameters(thermal_occupation)},
         )
         return self._add_component(component)
 
@@ -609,8 +607,8 @@ class PortNetwork:
         return self._reference_component(label, kind="delay", parameters={"duration": duration})
 
     def filter(
-        self, label: str, *, transfer: Callable[..., Any], loss_occupation: Any = None,
-        loss_temperature: Any = None, noise_frequency: Any = None, **parameters: Any,
+        self, label: str, *, transfer: Callable[..., Any], thermal_occupation: Any = None,
+        **parameters: Any,
     ) -> SLHComponent:
         """Add a two-sided passive filter reference section.
 
@@ -627,21 +625,17 @@ class PortNetwork:
         serialized with :meth:`to_dict`; ``Chip.clone()`` and ``Chip.with_params()``
         preserve the callable.
 
-        Declare loss_occupation, or loss_temperature in mK with noise_frequency
-        in GHz, for a matched absorptive realization emitting (1-|H|²)n.
+        Declare ``thermal_occupation`` in quanta, constant across the modeled
+        band, for a matched absorptive realization emitting (1-|H|²)n.
         A scalar transfer alone does not distinguish absorption from reflection.
         Colored thermal emission cannot feed a quantum coupling through a
         reference section; use a dynamical filter/bath model for that case.
         """
-        noise = noise_parameters(occupation=loss_occupation, temperature=loss_temperature,
-                                 noise_frequency=noise_frequency)
-        parameters.update({f"loss_{name}" if name != "noise_frequency" else name: value
-                           for name, value in noise.items()})
+        parameters.update(noise_parameters(thermal_occupation))
         return self._reference_component(label, kind="filter", parameters=dict(parameters), transfer=transfer)
 
     def amplifier(
-        self, label: str, *, gain: Any = None, gain_db: Any = None, added_noise: Any = None,
-        noise_temperature: Any = None, noise_figure_db: Any = None, noise_frequency: Any = None,
+        self, label: str, *, added_noise: Any, gain: Any = None, gain_db: Any = None,
     ) -> SLHComponent:
         """Add a phase-preserving amplifier reference section to an output line.
 
@@ -658,17 +652,11 @@ class PortNetwork:
         noise. The section remains outside Markovian ``S``, ``L``, and
         ``H`` and serializes normally.
 
-        Alternatively specify ``gain_db`` and either ``noise_temperature``
-        (equivalent input noise temperature in mK) or ``noise_figure_db``
-        (290 K reference). Both require ``noise_frequency`` in GHz to convert
-        to added quanta. Equivalent temperature uses kT/hf, not the Planck
-        occupation of a physical thermal load. Authored conventions remain
-        parameter paths for rebinding and serialization.
+        ``gain_db`` may replace linear ``gain``. Added quanta are constant
+        across the modeled band and exclude the input's own noise.
         """
         parameters = {key: value for key, value in (
-            ("gain", gain), ("gain_db", gain_db), ("added_noise", added_noise),
-            ("noise_temperature", noise_temperature), ("noise_figure_db", noise_figure_db),
-            ("noise_frequency", noise_frequency)) if value is not None}
+            ("gain", gain), ("gain_db", gain_db), ("added_noise", added_noise)) if value is not None}
         ReferenceAmplifier(label, *amplifier_values(parameters))
         return self._reference_component(
             label, kind="amplifier", parameters=parameters,
@@ -703,13 +691,13 @@ class PortNetwork:
         return self._permutation_component(label, names, sources, kind="circulator")
 
     def isolator(
-        self, label: str, *, occupation: Any = None,
-        temperature: Any = None, noise_frequency: Any = None,
+        self, label: str, *, thermal_occupation: Any = None,
     ) -> SLHComponent:
         """Add an ideal isolator routing side 1 to side 2.
 
-        The reverse field is dumped into ``hidden.<label>.load``, whose vacuum
-        travels back toward side 1.
+        The reverse field is dumped into ``hidden.<label>.load``. Its thermal
+        population travels back toward side 1. ``thermal_occupation`` is in
+        quanta, constant across the modeled band; the default is vacuum.
         """
         component = self._permutation_component(
             label,
@@ -718,25 +706,22 @@ class PortNetwork:
             kind="isolator",
             hidden_pairs=(("load", "load", f"hidden.{label}.load"),),
         )
-        component._parameters.update(noise_parameters(
-            occupation=occupation, temperature=temperature, noise_frequency=noise_frequency))
+        component._parameters.update(noise_parameters(thermal_occupation))
         return component
 
     def termination(
-        self, label: str, *, occupation: Any = None,
-        temperature: Any = None, noise_frequency: Any = None,
+        self, label: str, *, thermal_occupation: Any = None,
     ) -> SLHComponent:
         """Add a matched one-sided load with an optional thermal input state.
 
-        Specify occupation directly, or temperature in mK and the positive
-        physical noise_frequency in GHz defining the Markov occupation.
+        ``thermal_occupation`` is the mean thermal population in quanta,
+        constant across the modeled band. The default is vacuum.
         """
         component = self._permutation_component(
             label, ("1", "load"), (1, 0), kind="termination",
             hidden_pairs=(("load", "load", f"hidden.{label}.load"),),
         )
-        component._parameters.update(noise_parameters(
-            occupation=occupation, temperature=temperature, noise_frequency=noise_frequency))
+        component._parameters.update(noise_parameters(thermal_occupation))
         return component
 
     def _permutation_component(
@@ -972,7 +957,7 @@ class PortNetwork:
         fields = []
         for index, entry in enumerate(compiled.channels):
             exposure = entry.exposure
-            occupation = (occupation_value(self._components[exposure._input_key[0]]._parameters)
+            occupation = (thermal_occupation_value(self._components[exposure._input_key[0]]._parameters)
                           if exposure._hidden else None)
             inbound = entry.reference.inbound
             if has_colored_noise(inbound):
@@ -1524,13 +1509,11 @@ class PortNetwork:
         if kind in {"attenuator", "isolator"}:
             assert output_side is not None
             eta = attenuation_value(parameters) if kind == "attenuator" else float(output_side == "2")
-            return ReferenceLoss(label, eta, occupation_value(parameters))
+            return ReferenceLoss(label, eta, thermal_occupation_value(parameters))
         assert component._transfer is not None
-        noise = occupation_value({name: parameters[key] for name, key in
-                                  (("occupation", "loss_occupation"), ("temperature", "loss_temperature"),
-                                   ("noise_frequency", "noise_frequency")) if key in parameters})
+        noise = thermal_occupation_value(parameters)
         transfer_parameters = {name: value for name, value in parameters.items()
-                               if name not in {"loss_occupation", "loss_temperature", "noise_frequency"}}
+                               if name != "thermal_occupation"}
         return ReferenceFilter(label, component._transfer, MappingProxyType(transfer_parameters),
                                noise)
 

--- a/quchip/engine/field_noise.py
+++ b/quchip/engine/field_noise.py
@@ -4,8 +4,7 @@ from typing import Any, Mapping
 
 import numpy as np
 
-from quchip.utils.constants import k_B
-from quchip.utils.jax_utils import contains_tracer, select_array_module
+from quchip.utils.jax_utils import contains_tracer
 
 
 def _choice(parameters: Mapping[str, Any], names: tuple[str, ...]) -> tuple[str, Any]:
@@ -31,65 +30,28 @@ def attenuation_value(parameters: Mapping[str, Any]) -> Any:
 
 
 def amplifier_values(parameters: Mapping[str, Any]) -> tuple[Any, Any]:
-    """Convert gain and equivalent input noise to symmetrized added quanta.
-
-    Equivalent noise temperature is mK, not a Planck bath temperature.
-    Noise figure uses the standard 290 K reference: Te = 290 K (F - 1).
-    """
+    """Resolve power gain and input-referred symmetrized added quanta."""
     name, value = _choice(parameters, ("gain", "gain_db"))
     gain = value if name == "gain" else 10 ** (value / 10)
-    name, noise = _choice(parameters, ("added_noise", "noise_temperature", "noise_figure_db"))
-    if name == "added_noise":
-        if parameters.get("noise_frequency") is not None:
-            raise ValueError("noise_frequency is used with noise_temperature or noise_figure_db.")
-    else:
-        _, frequency = _choice(parameters, ("noise_frequency",))
-        if not contains_tracer(frequency) and frequency <= 0:
-            raise ValueError("noise_frequency must be positive GHz.")
-        temperature = noise if name == "noise_temperature" else 290_000 * (10 ** (noise / 10) - 1)
-        noise = k_B * temperature / frequency
+    _, noise = _choice(parameters, ("added_noise",))
     return gain, noise
 
 
-def noise_parameters(*, occupation: Any = None, temperature: Any = None, noise_frequency: Any = None) -> dict[str, Any]:
-    """Validate one Markov field state; temperature is mK and frequency is GHz."""
-    if temperature is not None:
-        if occupation is not None or noise_frequency is None:
-            raise ValueError("Specify occupation, or temperature with noise_frequency in GHz.")
-        values = {"temperature": temperature, "noise_frequency": noise_frequency}
-    elif occupation is not None:
-        if noise_frequency is not None:
-            raise ValueError("noise_frequency is used only with temperature.")
-        values = {"occupation": occupation}
-    elif noise_frequency is not None:
-        raise ValueError("noise_frequency requires temperature.")
-    else:
-        return {}
-    for key, value in values.items():
-        if not contains_tracer(value):
-            number = np.asarray(value)
-            if number.ndim or not np.isrealobj(number) or not np.isfinite(number):
-                raise ValueError(f"{key} must be a finite real scalar.")
-            if number < 0 or (key == "noise_frequency" and number == 0):
-                raise ValueError(f"{key} must be {'positive' if key == 'noise_frequency' else 'non-negative'}.")
+def noise_parameters(thermal_occupation: Any = None) -> dict[str, Any]:
+    """Validate a constant thermal population in quanta; None means implicit vacuum."""
+    values = {} if thermal_occupation is None else {"thermal_occupation": thermal_occupation}
+    thermal_occupation_value(values)
     return values
 
 
-def occupation_value(parameters: Mapping[str, Any]) -> Any | None:
-    """Return a declared input occupation, or None for an implicit vacuum field."""
-    values = noise_parameters(**{key: parameters[key] for key in
-                                ("occupation", "temperature", "noise_frequency") if key in parameters})
-    if not values:
+def thermal_occupation_value(parameters: Mapping[str, Any]) -> Any | None:
+    """Return the declared thermal quanta, preserving an explicit zero."""
+    if parameters.get("thermal_occupation") is None:
         return None
-    if "occupation" in values:
-        return values["occupation"]
-    xp = select_array_module(contains_tracer(tuple(values.values())))
-    temperature = xp.asarray(values["temperature"])
-    safe_temperature = xp.where(temperature > 0, temperature, 1.0)
-    exponent = values["noise_frequency"] / (k_B * safe_temperature)
-    # exp(-x)/(1-exp(-x)) is stable at low temperature and at T=0 under JAX.
-    occupation = xp.exp(-exponent) / (-xp.expm1(-exponent))
-    return xp.where(temperature > 0, occupation, 0.0)
+    _, value = _choice(parameters, ("thermal_occupation",))
+    if not contains_tracer(value) and value < 0:
+        raise ValueError("thermal_occupation must be non-negative.")
+    return value
 
 
 def input_noise_matrix(slh: Any, xp: Any) -> Any:

--- a/tests/test_field_noise.py
+++ b/tests/test_field_noise.py
@@ -12,7 +12,7 @@ def test_warm_isolator_load_thermalizes_only_the_protected_device() -> None:
     r = Resonator(freq=6.0, levels=12, label="r")
     net = PortNetwork(label="line")
     port = net.port("port", target=r, rate=0.03)
-    iso = net.isolator("iso", occupation=0.3)
+    iso = net.isolator("iso", thermal_occupation=0.3)
     net.link(port, iso)
     net.expose("readout", at=iso.port(2))
     chip = Chip([r], port_network=net)
@@ -23,33 +23,31 @@ def test_warm_isolator_load_thermalizes_only_the_protected_device() -> None:
     np.testing.assert_allclose(diagonal, expected, atol=1e-10)
     restored = Chip.from_dict(json.loads(json.dumps(chip.to_dict())))
     np.testing.assert_allclose(restored.steadystate().state.full(), steady.state.full(), atol=1e-10)
-    cold = chip.with_params({"network.component.iso.occupation": 0.0})
+    cold = chip.with_params({"network.component.iso.thermal_occupation": 0.0})
     assert np.real(cold.steadystate().state.full()[0, 0]) == pytest.approx(1.0)
 
 
-def test_matched_thermal_loss_and_temperature_agree() -> None:
+def test_matched_thermal_loss_sets_device_population() -> None:
     """A lossy line mixes a vacuum input with its thermal load occupation."""
     r = Resonator(freq=6.0, levels=12, label="r")
     net = PortNetwork(label="line")
     port = net.port("port", target=r, rate=0.03)
-    att = net.attenuator("att", eta=0.25, temperature=300.0, noise_frequency=6.0)
+    att = net.attenuator("att", eta=0.25, thermal_occupation=0.6)
     net.link(port, att)
     net.expose("readout", at=att.port(2))
     chip = Chip([r], port_network=net)
     state = chip.steadystate().state.full()
-    # SI constants provide an independent occupation in the physical carrier frame.
-    n = 0.75 / np.expm1(6.62607015e-34 * 6e9 / (1.380649e-23 * 0.300))
+    n = (1 - 0.25) * 0.6
     expected = (n / (n + 1)) ** np.arange(12)
     expected /= expected.sum()
     np.testing.assert_allclose(np.diag(state), expected, atol=1e-10)
 
 
-def test_thermal_state_declarations_reject_ambiguous_or_invalid_values() -> None:
-    """Temperature needs a physical frequency and cannot accompany occupation."""
-    for kwargs in ({"temperature": 20}, {"temperature": 20, "noise_frequency": 6, "occupation": 1},
-                   {"occupation": -1}, {"temperature": -2, "noise_frequency": 6}):
-        with pytest.raises(ValueError):
-            PortNetwork().termination("load", **kwargs)
+@pytest.mark.parametrize("value", [-1, np.nan, np.inf, 1j, [0.2]])
+def test_thermal_state_declarations_reject_invalid_values(value) -> None:
+    """Thermal quanta must be a finite non-negative real scalar."""
+    with pytest.raises(ValueError):
+        PortNetwork().termination("load", thermal_occupation=value)
 
 
 def test_thermal_equilibrium_output_is_flat_without_double_counting() -> None:
@@ -59,7 +57,7 @@ def test_thermal_equilibrium_output_is_flat_without_double_counting() -> None:
     net = PortNetwork()
     port = net.port("p", target=r, rate=0.04)
     circ = net.circulator("circ")
-    load = net.termination("warm", occupation=0.3)
+    load = net.termination("warm", thermal_occupation=0.3)
     net.link(port, circ.port(2))
     net.link(load.port(1), circ.port(1))
     out = net.expose("out", at=circ.port(3))
@@ -80,8 +78,8 @@ def test_nonideal_unitary_component_uses_declared_thermal_loss_ports() -> None:
     device = net.component("nonideal", scattering=[[0,t,loss,0], [t,0,0,loss],
                                                     [-loss,0,0,t], [0,-loss,t,0]],
                            terminals=("in", "out", "loss1", "loss2"))
-    cold = net.termination("cold", occupation=0.0)
-    warm = net.termination("warm", occupation=0.2)
+    cold = net.termination("cold", thermal_occupation=0.0)
+    warm = net.termination("warm", thermal_occupation=0.2)
     for output, input_, name in ((port.output, port.input, "in"),
                                  (cold.output_terminal("1"), cold.input_terminal("1"), "loss1"),
                                  (warm.output_terminal("1"), warm.input_terminal("1"), "loss2")):
@@ -101,7 +99,7 @@ def test_thermal_collapse_coupling_rate_gradient() -> None:
     mode = Resonator(freq=6.0, levels=8, label="r")
     net = PortNetwork()
     port = net.port("p", target=mode, rate=0.03)
-    load = net.isolator("iso", occupation=0.3)
+    load = net.isolator("iso", thermal_occupation=0.3)
     net.link(port, load)
     net.expose("out", at=load.port(2))
     chip = Chip([mode], port_network=net, backend="dynamiqs")
@@ -119,7 +117,7 @@ def test_declared_reverse_source_is_blocked_by_an_ideal_isolator() -> None:
     port = net.port("p", target=mode, rate=0.03)
     net.port("probe", target=mode, rate=0.01)
     iso = net.isolator("iso")
-    warm = net.termination("reverse", occupation=1.0)
+    warm = net.termination("reverse", thermal_occupation=1.0)
     net.link(port, iso, warm.port(1))
     chip = Chip([mode], port_network=net)
     np.testing.assert_allclose(np.diag(chip.steadystate().state.full()), [1,0,0,0,0,0,0,0], atol=1e-10)

--- a/tests/test_linear_measurement.py
+++ b/tests/test_linear_measurement.py
@@ -1,4 +1,4 @@
-"""Compact acquisition preserves physical noise and datasheet conventions."""
+"""Compact acquisition preserves noise quanta and power gain conventions."""
 
 import numpy as np
 import pytest
@@ -11,9 +11,9 @@ def thermal_fridge(*, backend="qutip", filter_first=True):
     net = PortNetwork(label="fridge")
     port = net.port("p", target=r, rate=.04)
     filt = net.filter("filter", transfer=lambda f: 1/(1-1j*(f-6)/.1))
-    att = net.attenuator("att", loss_db=10., occupation=.02)
+    att = net.attenuator("att", loss_db=10., thermal_occupation=.02)
     circ = net.circulator("circ")
-    amp = net.amplifier("amp", gain_db=20., noise_temperature=2000., noise_frequency=6.)
+    amp = net.amplifier("amp", gain_db=20., added_noise=7.)
     chain = (filt, att) if filter_first else (att, filt)
     lead = net.delay("lead", duration=0.)
     net.link(lead, *chain, circ.port(1))
@@ -51,7 +51,7 @@ def test_filter_after_thermal_source_still_rejects_colored_backaction():
 
 
 def test_lossless_thermal_attenuator_before_filter_emits_no_colored_noise():
-    """A zero-loss endpoint is valid even when its physical temperature is nonzero."""
+    """A zero-loss endpoint is valid even when its load has thermal quanta."""
     chip, drive, readout = thermal_fridge(filter_first=False)
     chip = chip.with_params({"network.component.att.loss_db": 0.})
     for options in (None, {}):
@@ -66,7 +66,7 @@ def test_filtered_auxiliary_field_mixed_after_device_does_not_create_backaction(
     net = PortNetwork()
     port = net.port("p", target=r, rate=.04)
     split = net.hybrid90("split")
-    filt = net.filter("aux", transfer=lambda f: np.sqrt(.6)/(1-1j*(f-6.)/.02), loss_occupation=.2)
+    filt = net.filter("aux", transfer=lambda f: np.sqrt(.6)/(1-1j*(f-6.)/.02), thermal_occupation=.2)
     net.connect(port.output, split.input_terminal("left"))
     net.connect(filt.output_terminal("2"), split.input_terminal("right"))
     net.connect(split.output_terminal("right"), filt.input_terminal("2"))
@@ -119,23 +119,22 @@ def test_nine_mode_measurement_matches_independent_star_response_without_density
     np.testing.assert_allclose(covariance, np.broadcast_to(np.eye(2)*(85000.5/2e6), covariance.shape), atol=1e-10)
 
 
-def test_datasheet_noise_parameters_rebind_and_roundtrip():
-    """dB and temperature remain authored parameters after capture and serialization."""
+def test_noise_quanta_and_db_parameters_rebind_and_roundtrip():
+    """dB and noise quanta remain authored parameters after capture and serialization."""
     r = Resonator(freq=6., levels=4, label="r")
     net = PortNetwork()
     port = net.port("p", target=r, rate=.04)
     loss = net.attenuator("loss", loss_db=10.)
-    amp = net.amplifier("amp", gain_db=20., noise_figure_db=1., noise_frequency=6.)
+    amp = net.amplifier("amp", gain_db=20., added_noise=2.)
     net.link(port, loss, amp)
     net.expose("out", at=amp.port(2))
     chip = Chip([r], port_network=net)
     restored = Chip.from_dict(chip.to_dict())
-    changed = restored.with_params({"network.component.amp.gain_db": 30., "network.component.loss.loss_db": 20.})
+    changed = restored.with_params({"network.component.amp.gain_db": 30., "network.component.loss.loss_db": 20.,
+                                    "network.component.amp.added_noise": 3.})
     point = VNA(changed).measure(6., .001, input="out", outputs=["out"])
     assert point.parameters[0]["network.component.amp.gain_db"] == 30.
-    # Independent SI conversion: Te = 290*(10**(NF/10)-1), nadd = kTe/(hf).
-    nadd = 1.380649e-23 * 290*(10**.1-1)/(6.62607015e-34*6e9)
-    expected = (1000*nadd+(1000-1)/2+1)/2e6
+    expected = (1000*3.+(1000-1)/2+1)/2e6
     np.testing.assert_allclose(point.statistics(receiver=IQReceiver(integration_time=1e6)).covariance("out"),
                                np.eye(2)*expected, atol=1e-10)
     physical = 2e6*expected-1
@@ -146,28 +145,28 @@ def test_datasheet_noise_parameters_rebind_and_roundtrip():
 
 
 @pytest.mark.parametrize("kwargs", [dict(gain=100., gain_db=20., added_noise=1.),
-    dict(gain_db=20., noise_temperature=2000.), dict(gain_db=20., noise_temperature=2000., added_noise=1.),
-    dict(gain_db=20., noise_figure_db=-1., noise_frequency=6.)])
-def test_ambiguous_or_incomplete_amplifier_conventions_fail(kwargs):
-    """Noise conventions cannot be mixed or silently supplied a reference frequency."""
+    dict(gain_db=20., added_noise=.1), dict(gain=.5, added_noise=1.),
+    dict(gain_db=20., added_noise=np.nan), dict(gain_db=20., added_noise=np.inf)])
+def test_invalid_amplifier_declarations_fail(kwargs):
+    """Gain is unambiguous and finite added quanta satisfy the quantum floor."""
     with pytest.raises(ValueError):
         PortNetwork().amplifier("amp", **kwargs)
 
 
 @pytest.mark.optional_backend
-def test_linear_measurement_datasheet_noise_gradient():
-    """Equivalent temperature differentiates through harmonic acquisition and receiver."""
+def test_linear_measurement_added_noise_gradient():
+    """Added quanta differentiate through harmonic acquisition and receiver."""
     jax = pytest.importorskip("jax")
     pytest.importorskip("dynamiqs")
     chip, drive, readout = thermal_fridge(backend="dynamiqs")
     offsets = np.array([-.1, -.01, 0., .01, .1])
-    def variance(temperature):
-        changed = chip.with_params({"network.component.amp.noise_temperature": temperature})
+    def variance(added_noise):
+        changed = chip.with_params({"network.component.amp.added_noise": added_noise})
         result = VNA(changed).measure(6., .002, input=drive, outputs=[readout],
                                      noise_frequencies=offsets)
         return result.statistics(receiver=IQReceiver(integration_time=1e6)).covariance(readout)[0, 0]
-    gradient = jax.jit(jax.grad(variance))(2000.)
-    expected = 100*1.380649e-26/(6.62607015e-34*6e9)/(2e6)
+    gradient = jax.jit(jax.grad(variance))(7.)
+    expected = 100/(2e6)
     np.testing.assert_allclose(gradient, expected, rtol=1e-9)
 
 
@@ -206,7 +205,7 @@ def test_coupled_modes_share_thermal_noise_and_match_general_solver():
     r = Resonator(freq=6.01, levels=5, internal_quality_factor=6000, label="r")
     net = PortNetwork()
     port = net.port("p", target=bus, rate=.04)
-    att = net.attenuator("att", loss_db=10., occupation=.01)
+    att = net.attenuator("att", loss_db=10., thermal_occupation=.01)
     net.link(att, port)
     drive = net.expose("drive", at=att.port(1))
     chip = Chip([bus, r], [Capacitive(bus, r, g=.005)], port_network=net, approximation=RWA())
@@ -227,7 +226,7 @@ def test_internal_photon_number_jit_gradients_follow_drive_and_thermal_balance()
     pytest.importorskip("dynamiqs")
     chip, drive, readout = thermal_fridge(backend="dynamiqs")
     def occupation(amplitude, bath):
-        changed = chip.with_params({"network.component.att.occupation": bath})
+        changed = chip.with_params({"network.component.att.thermal_occupation": bath})
         result = VNA(changed).measure(6., amplitude, input=drive, outputs=[readout],
                                      noise_frequencies=[-.04, -.004, 0., .004, .04])
         return result.photon_number("r")

--- a/tests/test_measurement.py
+++ b/tests/test_measurement.py
@@ -5,16 +5,16 @@ import pytest
 from quchip import Chip, IQReceiver, PortNetwork, Resonator, VNA
 
 
-def line(*, occupation=None, backend="qutip", mixed=False):
+def line(*, thermal_occupation=None, backend="qutip", mixed=False):
     r = Resonator(freq=6.0, levels=8, label="r")
     net = PortNetwork(label="line")
     port = net.port("coupler", target=r, rate=0.04)
     circ = net.circulator("circ")
-    iso = net.isolator("iso", occupation=occupation)
+    iso = net.isolator("iso", thermal_occupation=thermal_occupation)
     amp = net.amplifier("hemt", gain=100.0, added_noise=1.0)
     net.link(port, circ.port(2))
     if mixed:
-        loss = net.attenuator("loss", eta=0.25, occupation=0.2)
+        loss = net.attenuator("loss", eta=0.25, thermal_occupation=0.2)
         second = net.amplifier("second", gain=10.0, added_noise=2.0)
         net.link(circ.port(3), amp, iso, loss, second)
         tail = second
@@ -168,7 +168,7 @@ def split_thermal(*, delay=0.0, backend="qutip"):
     net = PortNetwork()
     net.port("quiet", target=mode, rate=0.01)
     split = net.beam_splitter("split", eta=0.25)
-    load = net.termination("warm", occupation=2.0)
+    load = net.termination("warm", thermal_occupation=2.0)
     cable = net.delay("cable", duration=delay)
     net.connect(load.output_terminal("1"), split.input_terminal("right"))
     net.connect(split.output_terminal("right"), cable.input_terminal("1"))
@@ -248,7 +248,7 @@ def test_branched_chain_preserves_independently_peeled_reverse_leg(kind) -> None
         section = net.delay("section", duration=0.123)
         transmission = np.exp(2j*np.pi*6.0*0.123)
     elif kind == "attenuator":
-        section = net.attenuator("section", eta=0.25, occupation=0.0)
+        section = net.attenuator("section", eta=0.25, thermal_occupation=0.0)
         transmission = 0.5
     else:
         section = net.filter("section", transfer=lambda f: 0.5+np.zeros_like(f))

--- a/tests/test_terminal_measurement.py
+++ b/tests/test_terminal_measurement.py
@@ -160,7 +160,7 @@ def wired_result(*, backend="qutip", gain=100., noise=1., loss=.25):
     port = net.port("p", target=r, rate=.04)
     circ = net.circulator("circ")
     amp = net.amplifier("hemt", gain=gain, added_noise=noise)
-    attenuator = net.attenuator("cable", eta=loss, occupation=.2)
+    attenuator = net.attenuator("cable", eta=loss, thermal_occupation=.2)
     net.link(port, circ.port(2))
     net.link(circ.port(3), amp, attenuator)
     drive = net.expose("drive", at=circ.port(1))
@@ -297,7 +297,7 @@ def test_bandpass_noise_and_partitioned_wiring_forwarding():
     p = net.port("p", target=r, rate=.04)
     circ = net.circulator("circ")
     filt = net.filter("bandpass", transfer=lambda f: np.where((f >= 4) & (f <= 8), 1., 0.),
-                      loss_occupation=.2)
+                      thermal_occupation=.2)
     amp = net.amplifier("hemt", gain=100., added_noise=1.)
     net.link(p, circ.port(2))
     net.link(circ.port(3), filt, amp)


### PR DESCRIPTION
## Summary

Network noise declarations currently require users to choose between several conventions and supply a frequency for temperature or noise-figure conversion. This change accepts noise directly in quanta: passive components use `thermal_occupation`, and amplifiers require input-referred symmetrized `added_noise`. Both are constant across the modeled band, including frequency sweeps; gain and attenuation still accept linear values or dB.

This intentionally removes `temperature`, `loss_temperature`, `noise_temperature`, `noise_figure_db`, and `noise_frequency` from the noise API. Existing network `occupation` and filter `loss_occupation` parameters become `thermal_occupation`, including saved component parameters. Vacuum defaults, explicit zero, the amplifier quantum floor, noise propagation, parameter rebinding, and JAX differentiation are preserved.

The fridge guide supplies equivalent quanta and reproduces its saved results. The cumulative diff is 143 additions and 190 deletions across nine files (net −47 lines).

## Verification

- Full pytest suite from a clean source archive matching this commit: **1962 passed, 180 warnings** in 16m23s.
- 228 focused tests passed, including analytical thermal/noise checks, both backends, serialization, JAX gradients, and fresh execution of the fridge guide.
- Ruff, mypy (140 source files), compilation, generated example output freshness, and `git diff --check` passed.
- Strict Sphinx build from clean source and wheel/sdist builds passed; package contents exclude private control files.
- Independent read-only review found no actionable defects.

## Checklist

- [x] This pull request is focused and contains no unrelated changes.
- [x] Changed behavior is covered by tests, or no behavior changed.
- [x] Relevant documentation and examples are updated.
- [x] Generated files and paired notebooks are synchronized, if applicable.
- [x] `PHYSICS.md` is updated, or is not relevant: updated the noise conventions and filter declaration.

## AI assistance

Codex implemented the API simplification, updated tests and documentation, ran validation, and prepared this pull request. A separate read-only AI review checked the changes.
