### PR TITLE
Prepare quchip 0.3.2: API documentation and leaner CI

### DIFF
--- a/.github/actions/classify-pr/action.yml
+++ b/.github/actions/classify-pr/action.yml
@@ -16,21 +16,4 @@ runs:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
-        if [[ "$EVENT_NAME" != "pull_request" ]]; then
-          echo "full_ci=true" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        full_ci=false
-        while IFS= read -r -d '' changed_file; do
-          case "$changed_file" in
-            docs/*|*.md|CITATION.cff|LICENSE|.gitignore|.github/workflows/release.yml)
-              ;;
-            *)
-              full_ci=true
-              break
-              ;;
-          esac
-        done < <(git diff --name-only -z "$BASE_SHA" "$HEAD_SHA")
-
-        echo "full_ci=$full_ci" >> "$GITHUB_OUTPUT"
+        bash "$GITHUB_ACTION_PATH/classify.sh" >> "$GITHUB_OUTPUT"

--- a/.github/actions/classify-pr/classify.sh
+++ b/.github/actions/classify-pr/classify.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Fail closed if the compared commits cannot be read.
+set -euo pipefail
+
+if [[ "${EVENT_NAME:?}" != "pull_request" ]]; then
+  echo "full_ci=true"
+  exit 0
+fi
+
+changed_files=$(mktemp)
+trap 'rm -f "$changed_files"' EXIT
+git diff --no-renames --name-only -z "${BASE_SHA:?}" "${HEAD_SHA:?}" > "$changed_files"
+
+full_ci=false
+while IFS= read -r -d '' changed_file; do
+  case "$changed_file" in
+    examples/*|tests/*|quchip/*|tools/*|.github/actions/*|.github/rulesets/*)
+      full_ci=true
+      break
+      ;;
+    docs/*|*.md|CITATION.cff|LICENSE|.gitignore|.github/workflows/release.yml)
+      ;;
+    *)
+      full_ci=true
+      break
+      ;;
+  esac
+done < "$changed_files"
+
+echo "full_ci=$full_ci"

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,54 @@
+{
+  "name": "Protect main with on-demand full CI",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/main"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "required_reviewers": [],
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "require_extra_approval_for_unattributed_changes": true,
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "lint"
+          },
+          {
+            "context": "test-fast (3.11)"
+          },
+          {
+            "context": "test-fast (3.12)"
+          },
+          {
+            "context": "pre-merge full suite"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,14 +1,10 @@
 name: benchmark
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, edited]
-  push:
-    branches: [main]
   workflow_dispatch:
     inputs:
       base_ref:
-        description: Comparison commit or ref (defaults to the preceding commit)
+        description: Comparison commit or ref (relative to the selected branch)
         type: string
         default: HEAD^
 
@@ -16,8 +12,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: benchmark-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: benchmark-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   closed-system:
@@ -25,9 +21,9 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     env:
-      BENCHMARK_RUNGS: ${{ github.event_name == 'push' && '1,2,3,4,5,6,7' || '1,3,5,7' }}
-      BUILD_REPEAT: ${{ github.event_name == 'push' && '5' || '3' }}
-      SOLVE_REPEAT: ${{ github.event_name == 'push' && '7' || '5' }}
+      BENCHMARK_RUNGS: "1,2,3,4,5,6,7"
+      BUILD_REPEAT: "5"
+      SOLVE_REPEAT: "7"
       OMP_NUM_THREADS: "1"
       OPENBLAS_NUM_THREADS: "1"
       MKL_NUM_THREADS: "1"
@@ -38,7 +34,7 @@ jobs:
       - name: Check out exact head
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Set up uv
@@ -57,7 +53,7 @@ jobs:
       - name: Resolve comparison commit
         id: comparison
         env:
-          BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before || inputs.base_ref }}
+          BASE_REF: ${{ inputs.base_ref }}
         run: |
           base_sha=$(git rev-parse --verify "${BASE_REF}^{commit}")
           echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,6 @@ name: ci
 # Changes to this policy or its workflows always run the full lanes.
 
 on:
-  push:
-    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,10 @@ on:
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
+concurrency:
+  group: docs-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,8 @@ on:
       - "CONTRIBUTING.md"
       - "CODE_OF_CONDUCT.md"
       - "pyproject.toml"
+      - "tools/check_api_docs.py"
+      - "tests/test_api_doc_coverage.py"
       - ".github/workflows/docs.yml"
   pull_request:
     paths:
@@ -21,6 +23,8 @@ on:
       - "CONTRIBUTING.md"
       - "CODE_OF_CONDUCT.md"
       - "pyproject.toml"
+      - "tools/check_api_docs.py"
+      - "tests/test_api_doc_coverage.py"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
@@ -34,8 +38,12 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
       - run: uv venv --python 3.11
-      - run: uv pip install -e '.[docs]'
-      - run: uv run sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
+      - run: uv pip install -e '.[docs,dynamiqs]'
+      - name: Check public parameter documentation
+        run: |
+          uv run python -m unittest discover -s tests -p test_api_doc_coverage.py
+          uv run python tools/check_api_docs.py
+      - run: uv run sphinx-build -b html -W --keep-going -d docs/_build/doctrees docs docs/_build/html
       - name: Deploy to docs.quchip.org
         if: github.event_name != 'pull_request'
         uses: cloudflare/wrangler-action@v3

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -1,8 +1,7 @@
 name: pre-merge
 
-# This required check is skipped for explicitly classified documentation,
-# Markdown metadata, and release-workflow-only pull requests. Other changes
-# fail cheaply until a maintainer adds ready-to-merge to the current PR commit.
+# Completes the suite after the required fast lanes. Documentation-only PRs
+# skip it; other changes require ready-to-merge on the current PR commit.
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
@@ -47,4 +46,9 @@ jobs:
             ci-constraints-*.txt
       - run: uv venv --python 3.11
       - run: uv pip install -e '.[test,dynamiqs]' -c ci-constraints-3.11.txt
-      - run: uv run --no-sync pytest
+      # The separately required fast lanes already cover core + physics_sentinel.
+      # Use the complement so new markers cannot silently fall out of CI.
+      - if: github.event_name == 'pull_request'
+        run: uv run --no-sync pytest -m "not (core or physics_sentinel)"
+      - if: github.event_name == 'workflow_dispatch'
+        run: uv run --no-sync pytest

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
 repository-code: "https://github.com/quchip/quchip"
 url: "https://quchip.org"
 license: Apache-2.0
-version: "0.3.1"
-date-released: "2026-09-08"
+version: "0.3.2"
+date-released: "2026-09-10"
 preferred-citation:
   type: article
   title: "quchip: A Differentiable Toolkit for Modeling Quantum Devices"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,11 +31,38 @@ The suite is also divided into lanes:
 python -m pytest -m core
 python -m pytest -m physics_sentinel
 python -m pytest -m extended
+python -m pytest -m "not (core or physics_sentinel)"
 ```
 
 - `core` covers analytical behavior and public API contracts.
 - `physics_sentinel` checks simulation-backed physics invariants.
 - `extended` contains slower and long-tail coverage.
+- `not (core or physics_sentinel)` runs the remainder, including example tests.
+
+### CI and merging
+
+| Event | Checks |
+| --- | --- |
+| PR opened or updated | Lint/types and `core or physics_sentinel` on Python 3.11 and 3.12 |
+| `ready-to-merge` added to the current PR commit | Remaining tests on Python 3.11 |
+| Push to `main` | Relevant docs build/deployment; no repeated test or benchmark run |
+| Manual pre-merge run | Full test suite |
+| Manual benchmark run | Full benchmark ladder against the selected comparison ref |
+| Weekly dependency canary | Full suite on Python 3.11 and 3.12 with fresh dependencies |
+
+The required fast and pre-merge checks together cover the full suite without
+repeating the fast tests on Python 3.11. Re-add `ready-to-merge` after updating
+a PR; a label on an older commit does not approve the new one. Documentation
+and release metadata use lightweight validation. Source, tests, executable
+examples (including Markdown), tooling, and CI policy require the test lanes.
+An unreadable change list fails classification.
+
+The `main` ruleset requires the PR branch to include current `main` before
+merging. Its configuration is recorded in
+[`.github/rulesets/main.json`](.github/rulesets/main.json); changing this file
+does not update GitHub automatically. An administrator must apply it to
+ruleset `21738854` before merging the workflow changes that remove post-merge
+test runs. Required check names are preserved for existing PRs.
 
 Tests that require dynamiqs use the `optional_backend` marker and call `pytest.importorskip("dynamiqs")`, so they skip cleanly when dynamiqs is unavailable.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,22 @@ python -m mypy quchip tests/typing/external_declarative_models.py
 
 Ruff uses a 120-character line limit. Public API docstrings use NumPy-style sections and imperative summaries ending with periods. Every test has a one-line docstring stating the invariant under test.
 
+Document every public constructor, function, and method parameter, including
+keyword-only and inherited arguments. Give accepted forms, defaults, units,
+allowed choices or ranges, and the meaning of `None` where applicable. Expand
+forwarded options or link to their precise contract. Keep descriptions short;
+put equations and derivations in `Notes`, with primary physics references.
+Describe result attributes and return values with shapes, axis order, and units.
+
+With the docs extra installed, run `python tools/check_api_docs.py` to detect
+missing descriptions and obsolete parameter names on package exports and the
+returned types listed in that tool. This checks structure; review numerical
+conventions and references against the implementation, then inspect rendered
+API pages. A successful Sphinx build alone does not establish completeness.
+The check includes the dynamiqs backend when that extra is installed. The docs
+job installs `.[docs,dynamiqs]` so both backend implementations are inspected
+and the complete reference can be built with warnings treated as errors.
+
 ## Examples and notebooks
 
 The [guides](docs/guides/index.md) and [cookbook](docs/cookbook.md) explain how to use quchip, including model construction, parameter changes, sweeps and result interpretation. Follow the same workflows in contributed examples. [Writing examples](docs/contribute/writing-examples.md) covers organization, figures and numerical checks.

--- a/RELEASE_NOTES_0.3.2.md
+++ b/RELEASE_NOTES_0.3.2.md
@@ -1,0 +1,29 @@
+# quchip 0.3.2
+
+Changes since [v0.3.1](https://github.com/quchip/quchip/compare/v0.3.1...v0.3.2).
+
+## Network noise API
+
+- Passive network components now use `thermal_occupation`; replace previous
+  `occupation` and `loss_occupation` arguments and saved parameter keys.
+- Amplifiers require explicit `added_noise`. Temperature, noise-figure, and
+  `noise_frequency` constructor arguments have been removed; convert these
+  inputs to noise quanta before declaring components. See the
+  [network-noise migration guidance](docs/cookbook.md#declare-network-noise).
+
+## API documentation
+
+- Added parameter options, defaults, units, `None` behavior, result shapes,
+  and physics references across public constructors and methods.
+- Reuse inherited backend contracts and suppress empty type-only parameter
+  tables. A coverage check detects missing descriptions and stale names.
+- Serve README images from the documentation site for consistent rendering.
+
+## Development and releases
+
+- PR fast and pre-merge test selections cover the suite without repeating the
+  fast tests on Python 3.11. Merges require checks against current `main`.
+- Remove post-merge test reruns, make benchmarks manual, and fail change
+  classification when Git cannot read the compared revisions.
+- Tagged releases verify package metadata and release notes, publish to PyPI,
+  and create the corresponding GitHub Release after publication.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,9 @@ autodoc_default_options = {
 }
 autodoc_member_order = "bysource"
 autodoc_typehints = "description"
+# Add types to authored entries without inventing empty parameter tables for
+# result records whose public fields are documented as attributes.
+autodoc_typehints_description_target = "documented"
 
 napoleon_google_docstring = False
 napoleon_numpy_docstring = True

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -30,6 +30,6 @@ python -c "import quchip; print(quchip.__version__)"
 ```
 
 quchip is a 0.x project. Pin the version for a reproducible calculation,
-for example `quchip==0.3.1`.
+for example `quchip==0.3.2`.
 
 Next, {doc}`declare your first chip <../guides/defining-and-inspecting-a-chip>`.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,10 @@
 # Release notes
 
+```{include} ../RELEASE_NOTES_0.3.2.md
+:relative-docs: docs/
+:heading-offset: 1
+```
+
 ```{include} ../RELEASE_NOTES_0.3.1.md
 :relative-docs: docs/
 :heading-offset: 1

--- a/quchip/__init__.py
+++ b/quchip/__init__.py
@@ -23,7 +23,7 @@ del _jax
 import os  # noqa: E402
 from importlib import import_module  # noqa: E402
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 from quchip.analysis import (  # noqa: E402
     CRHamiltonianResult,

--- a/quchip/analysis/cross_resonance.py
+++ b/quchip/analysis/cross_resonance.py
@@ -310,6 +310,23 @@ class CRHamiltonianResult:
     ``params_ctrl0`` / ``params_ctrl1`` hold the raw per-control-state fit
     output ``[px, py, pz, td, bx, by, bz]`` and are diagnostics only: they are
     in the fit's internal units (px/py/pz in Hz, td in seconds), not converted.
+
+    Attributes
+    ----------
+    IX, IY, IZ, ZX, ZY, ZZ : float
+        Fitted ordinary-frequency coefficients in GHz.
+    IX_err, IY_err, IZ_err, ZX_err, ZY_err, ZZ_err : float or None
+        Local residual-scaled uncertainty estimates in GHz.
+    params_ctrl0, params_ctrl1 : ndarray or None
+        Raw fit parameters for the two control states.
+    cov_ctrl0, cov_ctrl1 : ndarray or None
+        Raw local covariance matrices.
+    cost_ctrl0, cost_ctrl1 : float or None
+        Least-squares costs.
+    converged : bool or None
+        Fit convergence status.
+    message : str
+        Solver status message.
     """
 
     IX: float

--- a/quchip/analysis/effective_hamiltonian.py
+++ b/quchip/analysis/effective_hamiltonian.py
@@ -137,6 +137,7 @@ def analyze_static_zz(chip: "Chip", device_a: str | BaseDevice, device_b: str | 
     Parameters
     ----------
     chip : Chip
+        Chip whose dressed spectrum and couplings define the static model.
     device_a, device_b : str or BaseDevice
         The two devices whose static ZZ is analyzed.
 
@@ -297,6 +298,7 @@ def effective_hamiltonian(
     Parameters
     ----------
     chip : Chip
+        Chip whose dressed spectrum defines the effective subspace.
     subspace : mapping or sequence
         ``{device: levels}`` keeps ``range(levels)`` of each named device
         (spectators grounded); a bare sequence of devices keeps each one's
@@ -343,6 +345,7 @@ def effective_hamiltonian_between_states(
     Parameters
     ----------
     chip : Chip
+        Chip whose dressed spectrum defines the effective Hamiltonian.
     state_a, state_b : tuple[int, ...]
         Full chip-length bare-occupation tuples (one entry per device, in
         :attr:`~quchip.chip.chip.Chip.devices` order).

--- a/quchip/analysis/vna.py
+++ b/quchip/analysis/vna.py
@@ -62,7 +62,17 @@ class _OperatingPoint:
 
 @dataclass(frozen=True)
 class PortTone:
-    """A fixed coherent input field entering through one declared port."""
+    """A fixed coherent input field entering through one declared port.
+
+    Attributes
+    ----------
+    port : str
+        Resolved external network-port label.
+    freq : scalar
+        Carrier frequency in GHz.
+    amplitude : scalar
+        Complex incident field amplitude in ``1/sqrt(ns)``.
+    """
 
     port: str
     freq: Any
@@ -71,7 +81,24 @@ class PortTone:
     _owner: "VNA"
 
     def vary(self, field: str, values: Any, *, name: str | None = None) -> Sweep:
-        """Create a sweep axis for this tone's ``freq`` or ``amplitude``."""
+        """Create a sweep axis for this tone's frequency or amplitude.
+
+        Parameters
+        ----------
+        field : {"freq", "amplitude"}
+            Tone attribute to vary. Frequency is in GHz and amplitude is in
+            ``1/sqrt(ns)``.
+        values : array_like
+            Values in sweep order.
+        name : str or None, optional
+            Public result-axis name; defaults to ``"<port>.<field>"``.
+
+        Returns
+        -------
+        Sweep
+            Axis for :meth:`VNA.sweep`, :meth:`VNA.finite_power`, or
+            :meth:`VNA.measure`.
+        """
         if field not in {"freq", "amplitude"}:
             raise ValueError(f"A port tone can vary only 'freq' or 'amplitude', got {field!r}.")
         return _ToneAxis(
@@ -97,6 +124,13 @@ class VNA:
     ``VNA(chip)`` selects every exposed instrument port in the chip's ``PortNetwork``.
     Pass exposed port objects or their labels as ``ports`` to select a subset;
     a bare label string is rejected.
+
+    Parameters
+    ----------
+    chip : Chip
+        Chip with a ``PortNetwork``.
+    ports : sequence of port objects or str, optional
+        Selected external ports; ``None`` selects all external ports.
     """
 
     def __init__(self, chip: Any, *, ports: Sequence[Any] | None = None) -> None:
@@ -115,14 +149,40 @@ class VNA:
         self._tones: list[PortTone] = []
 
     def pump(self, port: Any, *, freq: Any, amplitude: Any) -> PortTone:
-        """Add a fixed background tone and return its variation handle."""
+        """Add a fixed coherent pump and return its sweep handle.
+
+        Parameters
+        ----------
+        port : port object or str
+            External port receiving the pump.
+        freq : scalar
+            Pump frequency in GHz.
+        amplitude : scalar
+            Complex incident field in ``1/sqrt(ns)``.
+
+        Returns
+        -------
+        PortTone
+            Handle for varying pump frequency or amplitude.
+        """
         tone = PortTone(_resolve_exposure(self.chip, port), freq, amplitude, len(self._tones), self)
         self._tones.append(tone)
         return tone
 
     @staticmethod
     def zip(*variations: Sweep) -> ZippedSweep:
-        """Pair tone variations element by element."""
+        """Pair sweep axes element by element instead of taking a product.
+
+        Parameters
+        ----------
+        *variations : Sweep
+            Axes with equal lengths.
+
+        Returns
+        -------
+        ZippedSweep
+            Composite sweep evaluated at corresponding points.
+        """
         return Sweep.zip(*variations)
 
     def sweep(
@@ -142,6 +202,23 @@ class VNA:
         uses one multi-right-hand-side mode-space solve. The stationary route solves
         one pumped operating point, then uses one shifted-Liouvillian factorization
         for every input port.
+
+        Parameters
+        ----------
+        frequencies : scalar or array_like
+            Probe frequencies in GHz.
+        *variations : Sweep or ZippedSweep
+            Chip and pump axes; Cartesian axes combine and zipped axes vary together.
+        options : dict or None, optional
+            Stationary solver options; ``None`` permits the passive-linear path.
+        progress : bool, default=False
+            Show a progress bar for stationary solves.
+
+        Returns
+        -------
+        SParameterResult
+            Matrix with shape ``(*shape, n_ports, n_ports)`` and indexing
+            ``[..., output, input]``.
         """
         freq_values, freq_is_axis = _axis_values(frequencies)
         self._validate_variations(variations, reserved=("frequency",) if freq_is_axis else ())
@@ -220,6 +297,25 @@ class VNA:
         This method always uses the stationary Liouvillian route. It does not use the
         passive-linear mode-space shortcut or follow sweep-rate hysteresis and
         metastable branches.
+
+        Parameters
+        ----------
+        frequencies, amplitudes : scalar or array_like
+            Probe frequencies in GHz and incident fields in ``1/sqrt(ns)``.
+        *variations : Sweep or ZippedSweep
+            Chip and pump axes.
+        input : port object or str, optional
+            Probe input; required when multiple ports are selected.
+        options : dict or None, optional
+            Stationary solver options.
+        progress : bool, default=False
+            Show a progress bar.
+
+        Returns
+        -------
+        MeanFieldResponseResult
+            Complex means with shape ``(*shape, n_ports)`` and incident fields
+            with shape ``shape``.
         """
         if input is None:
             if len(self.ports) != 1:
@@ -327,6 +423,28 @@ class VNA:
         without another solve; it is not a quantum-trajectory distribution.
         Internal Fock-mode amplitudes and occupations are captured as well;
         query them with mode_amplitude(device) and photon_number(device).
+
+        Parameters
+        ----------
+        frequencies, amplitudes : scalar or array_like
+            Probe frequencies in GHz and incident fields in ``1/sqrt(ns)``.
+        *variations : Sweep or ZippedSweep
+            Chip and pump axes.
+        input : port object or str, optional
+            Probe input; required when multiple ports are selected.
+        outputs : sequence of port objects or str, optional
+            Captured outputs; ``None`` selects all selected ports.
+        noise_frequencies : array_like or None, optional
+            Symmetric increasing offset grid in GHz, including zero.
+        options : dict or None, optional
+            Stationary solver options.
+        progress : bool, default=False
+            Show a progress bar.
+
+        Returns
+        -------
+        VNAMeasurement
+            Means and physical noise spectra reusable by receiver processing.
         """
         from quchip.analysis.measurement import measure
         return measure(self, frequencies, amplitudes, variations, input=input, outputs=outputs,
@@ -344,6 +462,15 @@ class VNA:
         Frequencies are offsets in GHz from the stationary tone frame. The
         coherent carrier is reported separately because it is a delta peak,
         not a finite sampled spectral density.
+
+        Parameters
+        ----------
+        output : port object or str
+            Output plane.
+        frequencies : scalar or array_like
+            Offset frequencies in GHz.
+        options : dict or None, optional
+            Stationary solver options.
         """
         output_port = _resolve_exposure(self.chip, output)
         frequency_values, _ = _axis_values(frequencies)
@@ -396,7 +523,24 @@ class VNA:
         input: Any | None = None,
         options: dict | None = None,
     ) -> OutputCorrelationResult:
-        """Return normalized first-order output coherence."""
+        """Return normalized first-order output coherence ``g1``.
+
+        Parameters
+        ----------
+        output : port object or str
+            Delayed output plane.
+        delays : scalar or array_like
+            Non-negative delays in ns.
+        input : port object or str, optional
+            Cross-correlation input; defaults to ``output``.
+        options : dict or None, optional
+            Stationary solver options.
+
+        Returns
+        -------
+        OutputCorrelationResult
+            Normalized and raw correlations on the delay grid.
+        """
         return self._correlation(output, delays, input=input, order=1, options=options)
 
     def g2(
@@ -407,7 +551,24 @@ class VNA:
         input: Any | None = None,
         options: dict | None = None,
     ) -> OutputCorrelationResult:
-        """Return normalized second-order output intensity correlation."""
+        """Return normalized second-order output intensity correlation ``g2``.
+
+        Parameters
+        ----------
+        output : port object or str
+            Delayed output plane.
+        delays : scalar or array_like
+            Non-negative delays in ns.
+        input : port object or str, optional
+            Cross-correlation input; defaults to ``output``.
+        options : dict or None, optional
+            Stationary solver options.
+
+        Returns
+        -------
+        OutputCorrelationResult
+            Normalized and raw second-order correlations on the delay grid.
+        """
         return self._correlation(output, delays, input=input, order=2, options=options)
 
     def _correlation(

--- a/quchip/approximations.py
+++ b/quchip/approximations.py
@@ -34,7 +34,13 @@ class Approximation(ABC):
     filters_terms: bool = False
 
     def keeps_operator_band(self, weights: tuple[int, ...]) -> bool:
-        """Return whether a structural operator band survives reduction."""
+        """Return whether a structural operator band survives reduction.
+
+        Parameters
+        ----------
+        weights : tuple[int, ...]
+            Creation-minus-annihilation weight per endpoint.
+        """
         del weights
         return True
 
@@ -51,7 +57,13 @@ class Approximation(ABC):
 
     @staticmethod
     def from_dict(data: Any) -> "Approximation":
-        """Restore one explicit strategy and reject retired schemas."""
+        """Restore one explicit strategy and reject retired schemas.
+
+        Parameters
+        ----------
+        data : mapping
+            Serialized ``Exact`` or ``RWA`` record.
+        """
         if not isinstance(data, dict):
             raise TypeError(
                 "approximation must be a serialized Exact or RWA strategy, "
@@ -79,6 +91,17 @@ class RWA(Approximation):
     """First-order structural rotating-wave selection.
 
     ``keep_bands`` replaces, rather than extends, total-excitation conservation.
+
+    Parameters
+    ----------
+    keep_bands : iterable of tuple[int, ...] or None, default None
+        Operator-band weights to retain. ``None`` keeps only bands whose
+        weights sum to zero. Supplied tuples must be non-empty and integral.
+
+    References
+    ----------
+    Cohen-Tannoudji, Dupont-Roc & Grynberg, *Atom-Photon Interactions*
+    (Wiley, 1992), Ch. IV.
     """
 
     keep_bands: frozenset[tuple[int, ...]] | None
@@ -88,6 +111,13 @@ class RWA(Approximation):
         object.__setattr__(self, "keep_bands", _freeze_bands(keep_bands))
 
     def keeps_operator_band(self, weights: tuple[int, ...]) -> bool:
+        """Return whether ``weights`` is retained by this RWA policy.
+
+        Parameters
+        ----------
+        weights : tuple[int, ...]
+            Creation-minus-annihilation weight per endpoint.
+        """
         if self.keep_bands is not None:
             return weights in self.keep_bands
         return sum(weights) == 0

--- a/quchip/backend/__init__.py
+++ b/quchip/backend/__init__.py
@@ -159,7 +159,22 @@ def get_default_backend() -> Backend:
 
 
 def set_default_backend(backend: str | Backend) -> None:
-    """Set the active default backend by name (``"qutip"``/``"dynamiqs"``) or instance."""
+    """Set the default backend for subsequent calculations.
+
+    Parameters
+    ----------
+    backend : {"qutip", "dynamiqs"} or Backend
+        Backend name or instance. A chip-specific backend or a scoped
+        calculation override takes precedence. ``"dynamiqs"`` requires
+        the optional ``quchip[dynamiqs]`` dependencies.
+
+    Raises
+    ------
+    ValueError
+        The backend name is unknown.
+    TypeError
+        The value is neither a name nor a Backend instance.
+    """
     global _default_backend
     _default_backend = _coerce_backend(backend)
 

--- a/quchip/backend/_dims.py
+++ b/quchip/backend/_dims.py
@@ -17,7 +17,15 @@ import numpy as np
 
 
 def validate_two_body_indices(index_a: int, index_b: int, dims: Sequence[int]) -> None:
-    """Raise ``ValueError`` when two-body device indices are equal or out of range."""
+    r"""Raise ``ValueError`` when two-body device indices are equal or out of range.
+
+    Parameters
+    ----------
+    index_a, index_b : int
+        Distinct zero-based subsystem positions.
+    dims : sequence of int
+        Subsystem dimensions; indices must be smaller than len(dims).
+    """
     n_devices = len(dims)
     if index_a == index_b:
         raise ValueError("index_a and index_b must be different")

--- a/quchip/backend/containers.py
+++ b/quchip/backend/containers.py
@@ -28,7 +28,17 @@ from quchip.utils.values import DeferredValue
 
 
 class BatchSolveError(RuntimeError):
-    """A numerical or configuration failure at one batch point, safe across workers."""
+    r"""A numerical or configuration failure at one batch point, safe across workers.
+
+    Parameters
+    ----------
+    index : int
+        Zero-based flat batch index that failed.
+    detail : str
+        Underlying numerical or configuration failure.
+    parameters : dict or None, default None
+        Parameter values at the failing point; None stores an empty mapping.
+    """
 
     def __init__(self, index: int, detail: str, parameters: dict[str, Any] | None = None) -> None:
         self.index = index
@@ -76,7 +86,21 @@ class SolverResult:
 
 @dataclass(frozen=True)
 class SteadyStateSolverResult:
-    """Backend payload for one stationary Lindblad solve."""
+    r"""Backend payload for one stationary Lindblad solve.
+
+    Attributes
+    ----------
+    state : State
+        Stationary density matrix in the native backend basis.
+    expect : list or None
+        Expectations in the requested observable order; None when not evaluated.
+    stats : dict
+        Backend diagnostics, including whether uniqueness was checked.
+    residual : scalar or None
+        Norm of the stationary Liouvillian residual, or None if not computed.
+    nullity : int or None
+        Estimated Liouvillian null-space dimension, or None when unchecked.
+    """
 
     state: Any
     expect: list[Any] | None = None
@@ -92,7 +116,17 @@ class SteadyStateSolverResult:
 
 @dataclass(frozen=True)
 class LinearResponseSolverResult:
-    """Backend payload for one batched passive-linear scattering solve."""
+    r"""Backend payload for one batched passive-linear scattering solve.
+
+    Attributes
+    ----------
+    responses : array_like, shape (n_freq, n_ports, n_ports)
+        Complex scattering matrix indexed by frequency, output, then input.
+    mode_amplitudes : array_like, shape (n_freq, n_modes, n_ports)
+        Internal mode response to unit incident amplitude at each input port.
+    residuals : array_like, shape (n_freq,)
+        Linear-system residual norms at each probe frequency.
+    """
 
     responses: Any
     mode_amplitudes: Any
@@ -112,12 +146,19 @@ class LinearResponseSolverResult:
 
 @dataclass
 class PreparedHamiltonian:
-    """Backend-native Hamiltonian produced by :meth:`Backend.prepare_hamiltonian`.
+    r"""Backend-native Hamiltonian produced by :meth:`Backend.prepare_hamiltonian`.
 
     ``rhs`` is whatever the backend's solver accepts directly — a ``Qobj`` /
     ``QobjEvo`` for QuTiP, a dynamiqs ``TimeQArray`` / sum of them for
     dynamiqs. ``metadata`` passes engine-level hints (e.g.
     ``spectral_bound_ghz`` for integrator step heuristics) through opaquely.
+
+    Attributes
+    ----------
+    rhs : object
+        Native Hamiltonian consumed by the solver, already in angular-frequency units.
+    metadata : dict
+        Integration hints, including spectral/carrier bounds when available.
     """
 
     rhs: Any
@@ -126,7 +167,17 @@ class PreparedHamiltonian:
 
 @dataclass(frozen=True)
 class PreparedStationary:
-    """Temporary native generator shared by one stationary operating point."""
+    r"""Temporary native generator shared by one stationary operating point.
+
+    Attributes
+    ----------
+    backend : Backend
+        Backend instance that owns this preparation.
+    engine_result : EngineResult
+        Exact captured operating point associated with the generator.
+    liouvillian : object
+        Native stationary generator, with rates in 1/ns.
+    """
 
     backend: Any = field(repr=False, compare=False)
     engine_result: Any = field(repr=False, compare=False)
@@ -135,10 +186,21 @@ class PreparedStationary:
 
 @dataclass
 class EagerBatch:
-    """Batched-solve payload with one native RHS per element.
+    r"""Batched-solve payload with one native RHS per element.
 
     The default :meth:`Backend.solve_batch` dispatches each element's RHS
     through :meth:`Backend.batched_sesolve` / :meth:`Backend.batched_mesolve`.
+
+    Attributes
+    ----------
+    rhs_list : list
+        One native right-hand side per batch element.
+    batch_size : int
+        Number of batch elements.
+    metadata : dict
+        Shared lowering and integration hints.
+    tlist : array_like or None
+        Common save-time grid in ns, or None when unspecified.
     """
 
     rhs_list: list[Any]
@@ -149,11 +211,22 @@ class EagerBatch:
 
 @dataclass
 class VmappedBatch:
-    """Batched-solve payload with a single natively batched RHS.
+    r"""Batched-solve payload with a single natively batched RHS.
 
     ``rhs`` covers every element at once — the dynamiqs path, where the
     per-element signals are stacked along a leading batch axis and the
     solver runs one vmapped call.
+
+    Attributes
+    ----------
+    rhs : object
+        Native right-hand side including the batch axis.
+    batch_size : int
+        Number of batch elements.
+    metadata : dict
+        Shared lowering and integration hints.
+    tlist : array_like or None
+        Common save-time grid in ns, or None when unspecified.
     """
 
     rhs: Any
@@ -164,12 +237,23 @@ class VmappedBatch:
 
 @dataclass
 class DeferredBatch:
-    """Batched-solve payload whose RHS construction is deferred.
+    r"""Batched-solve payload whose RHS construction is deferred.
 
     ``shared`` carries backend-private state; the producing backend must
     override :meth:`Backend.solve_batch` to consume it. QuTiP assembles final
     ``QobjEvo`` objects inside its workers; Dynamiqs assembles a vmapped RHS
     inside its cached JIT.
+
+    Attributes
+    ----------
+    shared : object
+        Backend-private lowering payload consumed by solve_batch.
+    batch_size : int
+        Number of batch elements.
+    metadata : dict
+        Shared lowering and integration hints.
+    tlist : array_like or None
+        Common save-time grid in ns, or None when unspecified.
     """
 
     shared: Any
@@ -185,7 +269,7 @@ PreparedBatch: TypeAlias = EagerBatch | VmappedBatch | DeferredBatch
 
 @dataclass
 class EigensystemData:
-    """Hermitian eigensystem returned in a single diagonalization call.
+    r"""Hermitian eigensystem returned in a single diagonalization call.
 
     ``eigenvalues`` is ascending. ``eigenvector_matrix`` stacks the
     eigenvectors as columns in the bare-product basis used for the
@@ -198,6 +282,13 @@ class EigensystemData:
     Backends populate either ``_states_builder`` (a callable that materializes
     the ket list on demand) or prime ``_states_cache`` directly (when the
     diagonalizer already produced the kets, e.g. QuTiP's ``Qobj.eigenstates``).
+
+    Attributes
+    ----------
+    eigenvalues : array_like, shape (D,)
+        Ascending eigenvalues in the input operator's units.
+    eigenvector_matrix : array_like, shape (D, D)
+        Eigenvectors as columns in the input operator basis.
     """
 
     eigenvalues: Any

--- a/quchip/backend/dynamiqs.py
+++ b/quchip/backend/dynamiqs.py
@@ -117,11 +117,9 @@ class DynamiqsBackend(Backend):
 
     @property
     def array_module(self) -> Any:
-        """Return the array module for JAX-traceable numeric code (``jax.numpy``)."""
         return jnp
 
     def to_array(self, op: Operator) -> Any:
-        """Return a dense ``jax.numpy`` array for *op*."""
         if hasattr(op, "to_jax"):
             return jnp.asarray(op.to_jax(), dtype=jnp.complex128)
         if hasattr(op, "full"):
@@ -129,26 +127,26 @@ class DynamiqsBackend(Backend):
         return jnp.asarray(op, dtype=jnp.complex128)
 
     def overlap(self, a: State, b: State) -> complex:
-        """Return the complex inner product ⟨a|b⟩ for two kets, via ``dynamiqs.braket``.
-
-        ``dynamiqs.overlap`` returns the real-valued :math:`|\\langle a|b
-        \\rangle|^2` (or a density-matrix fidelity), not the protocol's
-        phase-sensitive complex inner product — ``dq.braket`` is the
-        matching primitive.
-        """
         return dq.braket(a, b)
 
     def norm(self, state_or_op: State | Operator) -> Any:
-        """Return the norm of a state or operator via ``dynamiqs.norm``.
+        r"""Return the native dynamiqs norm with its default PSD assumption.
 
-        Returns the backend-native (possibly traced) scalar rather than a
-        concrete ``float`` — the protocol allows a 0-d array here so a
-        traced amplitude stays traceable under ``jax.jit``/``grad``.
+        Parameters
+        ----------
+        state_or_op : QArray
+            Ket or bra for the Euclidean norm, or a positive-semidefinite matrix
+            for its real trace. General indefinite operators are outside this hook's
+            matrix convention.
+
+        Returns
+        -------
+        jax.Array
+            Native scalar; traced inputs retain their gradients.
         """
         return dq.norm(state_or_op)
 
     def trace(self, op: Operator) -> complex:
-        """Return the scalar trace ``Tr(op)`` via ``dynamiqs.trace``."""
         return dq.trace(op)
 
     # ------------------------------------------------------------------
@@ -156,12 +154,7 @@ class DynamiqsBackend(Backend):
     # ------------------------------------------------------------------
 
     def eager_operators(self) -> Any:
-        """Use dense dynamiqs operators during JAX compile-time evaluation.
-
-        Sparse-diagonal validation cannot run inside
-        ``jax.ensure_compile_time_eval``. This context restores the previous
-        global layout on exit.
-        """
+        """Temporarily use dense Dynamiqs operators, then restore the global layout."""
         from contextlib import contextmanager
 
         from dynamiqs.qarrays.layout import get_layout, set_global_layout
@@ -178,23 +171,19 @@ class DynamiqsBackend(Backend):
         return dense_layout()
 
     def destroy(self, n: int) -> Operator:
-        """Return the annihilation operator for an *n*-level Fock space (``dynamiqs.destroy``)."""
         return dq.destroy(n)
 
     def create(self, n: int) -> Operator:
-        """Return the creation operator for an *n*-level Fock space (``dynamiqs.create``)."""
         return dq.create(n)
 
     def number(self, n: int) -> Operator:
-        """Return the number operator for an *n*-level Fock space (``dynamiqs.number``)."""
         return dq.number(n)
 
     def identity(self, n: int) -> Operator:
-        """Return the identity operator for an *n*-level space (``dynamiqs.eye``)."""
         return dq.eye(n)
 
     def diag(self, values: Any, dims: list[list[int]] | None = None) -> Operator:
-        """Build a backend-native sparse-DIA diagonal operator from main-diagonal *values*.
+        r"""Build a backend-native sparse-DIA diagonal operator from main-diagonal *values*.
 
         Overrides the protocol default to keep the operator in sparse-DIA
         layout even when *values* is a JAX tracer — the offsets ``(0,)`` are
@@ -203,6 +192,17 @@ class DynamiqsBackend(Backend):
         ``from_canonical_operator`` densifies any traced DIA payload, which
         forces a dense ``H₀`` for circuit-style devices and triggers the
         sparse→dense warning during static-Hamiltonian assembly.
+
+        Parameters
+        ----------
+        values : array_like
+            Main-diagonal entries, flattened in input order.
+        dims : list or None, default None
+            Subsystem dimensions as in from_array; None uses one subsystem.
+
+        See Also
+        --------
+        quchip.backend.protocol.Backend.diag
         """
         v = jnp.asarray(values, dtype=jnp.complex128).reshape(-1)
         n = v.shape[0]
@@ -212,7 +212,6 @@ class DynamiqsBackend(Backend):
         return SparseDIAQArray(dim_tuple, False, (0,), v[None, :])
 
     def from_array(self, data: Any, dims: list[list[int]] | None = None) -> Operator:
-        """Construct a native operator, preserving native sparse storage."""
         if isinstance(data, (DenseQArray, SparseDIAQArray)):
             dims_tuple = self._coerce_dims(dims, data.shape)
             if dims_tuple is None or dims_tuple == data.dims:
@@ -231,7 +230,6 @@ class DynamiqsBackend(Backend):
         return dq.asqarray(array, dims=dims_tuple)
 
     def to_canonical_operator(self, op: Operator) -> Any:
-        """Serialize a ``QArray`` into the backend-agnostic canonical IR."""
         from quchip.engine.ir import CanonicalOperator
 
         # getattr's default must stay lazy: to_array densifies a SparseDIA
@@ -258,7 +256,6 @@ class DynamiqsBackend(Backend):
         )
 
     def from_canonical_operator(self, canonical: Any) -> Operator:
-        """Reconstruct a ``QArray`` from the canonical IR payload (dense/DIA/COO)."""
         dims = tuple(canonical.dims)
         if canonical.layout == "dense":
             return dq.asqarray(jnp.asarray(canonical.values, dtype=jnp.complex128), dims=dims)
@@ -283,19 +280,15 @@ class DynamiqsBackend(Backend):
         return self._sparse_qarray_from_coo(rows, cols, values, dims)
 
     def coerce_operator(self, op: Operator) -> Operator:
-        """Pass *op* through unchanged (trace-safe): native operators are (JAX) arrays already."""
         return self.to_array(op)
 
     def dag(self, op: Operator) -> Operator:
-        """Return the Hermitian conjugate ``op†`` via ``dynamiqs.dag``."""
         return dq.dag(op)
 
     def eigenenergies(self, op: Operator) -> Any:
-        """Return the ascending eigenvalues of a Hermitian operator (``jax.numpy.linalg.eigvalsh``)."""
         return jnp.linalg.eigvalsh(self.to_array(op))
 
     def eigensystem_data(self, op: Operator) -> EigensystemData:
-        """Return ascending eigenvalues, eigenvector matrix, and lazily built eigenstate kets."""
         dense = self.to_array(op)
         evals, evecs = jnp.linalg.eigh(dense)
         dims = getattr(op, "dims", (dense.shape[0],))
@@ -314,11 +307,9 @@ class DynamiqsBackend(Backend):
         )
 
     def expect(self, op: Operator, state: State) -> complex:
-        """Return the expectation value ⟨op⟩ for a ket or density matrix via ``dynamiqs.expect``."""
         return dq.expect(op, state)
 
     def ptrace(self, state: State, keep: int | list[int], dims: list[int]) -> State:
-        """Reduce onto subsystem(s) *keep* via ``dynamiqs.ptrace`` (partial trace)."""
         keep_arg = tuple(keep) if isinstance(keep, list) else keep
         return dq.ptrace(state, keep_arg, dims=tuple(dims))
 
@@ -333,13 +324,11 @@ class DynamiqsBackend(Backend):
     # a single jnp pytree (strictly more traceable than a list of tracers).
 
     def stack_states(self, states: Any) -> Any:
-        """Pass the native stacked ``QArray`` through; restack a list if needed."""
         if hasattr(states, "shape") and not isinstance(states, (list, tuple)):
             return states
         return self._stack_qarray_batch(list(states))
 
     def expect_over_time(self, op: Operator, stacked_states: Any) -> Any:
-        """Return ⟨op⟩(t) at every save point via a single batched ``dynamiqs.expect`` call."""
         # Native dq.expect fast path; the generic protocol overlap/populations
         # extractors are already array-namespace-parameterized (jnp here), so
         # they need no dynamiqs override — and overlap stays the complex
@@ -347,13 +336,11 @@ class DynamiqsBackend(Backend):
         return jnp.asarray(dq.expect(op, stacked_states))
 
     def ptrace_over_time(self, stacked_states: Any, keep: int | list[int], dims: list[int]) -> Any:
-        """Reduce onto subsystem(s) *keep* at every save point (partial trace, batched ``dynamiqs.ptrace``)."""
         keep_arg = tuple(keep) if isinstance(keep, list) else keep
         reduced = dq.ptrace(stacked_states, keep_arg, dims=tuple(dims))
         return jnp.asarray(reduced.to_jax(), dtype=jnp.complex128)
 
     def tensor(self, *operators: Operator) -> Operator:
-        """Return the tensor product of operators via ``dynamiqs.tensor`` (pass-through for one factor)."""
         if len(operators) == 1:
             return operators[0]
         return dq.tensor(*operators)
@@ -369,11 +356,6 @@ class DynamiqsBackend(Backend):
         index_b: int,
         dims: Sequence[int],
     ) -> Operator:
-        """Embed a two-body operator on devices *index_a* ⊗ *index_b* into the full space.
-
-        Keeps a sparse operator sparse; a dense operator is reordered, padded
-        with identities, and permuted back to the original subsystem order.
-        """
         canonical = self.to_canonical_operator(op_ab)
         if canonical.is_sparse:
             return self._embed_two_body_sparse(canonical, index_a, index_b, dims)
@@ -398,33 +380,27 @@ class DynamiqsBackend(Backend):
         return dq.asqarray(restored, dims=tuple(dims))
 
     def basis(self, n: int, k: int) -> State:
-        """Return the Fock basis ket |k⟩ in an *n*-level space (``dynamiqs.basis``)."""
         return dq.basis(n, k)
 
     def tensor_states(self, *states: State) -> State:
-        """Return the tensor product of states via ``dynamiqs.tensor`` (pass-through for one state)."""
         if len(states) == 1:
             return states[0]
         return dq.tensor(*states)
 
     def coherent(self, n: int, alpha: complex) -> State:
-        """Return the coherent state |α⟩ truncated to *n* Fock levels (``dynamiqs.coherent``)."""
         return dq.coherent(n, alpha)
 
     def state_to_dm(self, state: State) -> State:
-        """Return a density matrix; pass through if *state* is already one."""
         if not self.is_ket(state):
             return state
         column = self.coerce_state(state)
         return column @ dq.dag(column)
 
     def is_ket(self, state: State) -> bool:
-        """Return whether *state* is a ket (flat or column vector) rather than a density matrix."""
         shape = tuple(state.shape)
         return len(shape) == 1 or (len(shape) == 2 and shape[1] == 1)
 
     def is_native_state(self, state: Any) -> bool:
-        """Return whether *state* is a Dynamiqs quantum array."""
         return isinstance(state, dq.QArray)
 
     # ------------------------------------------------------------------
@@ -438,20 +414,28 @@ class DynamiqsBackend(Backend):
         metadata: dict[str, Any],
         tlist: Any,
     ) -> dict[str, Any]:
-        """Normalize quchip aliases and fill in a ``max_steps`` budget.
+        r"""Validate dynamiqs integration options and fill the default step budget.
 
-        The quchip option aliases (``progress_bar`` → ``progress_meter``,
-        ``nsteps`` → ``max_steps``) are mapped onto dynamiqs' canonical names
-        by :meth:`_normalize_dq_options`. When ``max_steps`` is still unset,
-        it is derived by :func:`~quchip.backend._dims.default_solver_steps`
-        (see that function's docstring for the heuristic) — the same
-        heuristic the QuTiP backend uses.
+        Parameters
+        ----------
+        options : dict
+            Supported keys: ``method`` (native deterministic dynamiqs method),
+            ``gradient`` (native gradient configuration), ``max_steps`` (integer
+            ceiling), ``progress_meter``, ``store_states``, and ``store_final_state``.
+            ``nsteps`` aliases ``max_steps``; ``progress_bar`` aliases
+            ``progress_meter``. Do not supply an alias and its canonical key together.
+            Set tolerances on the native ``method`` object. With an explicit method,
+            set its step limit there instead of also passing ``max_steps`` here.
+            Monte Carlo methods and unrecognized keys are rejected.
+        metadata : dict
+            Lowering hints, including ordinary-GHz spectral/carrier bounds.
+        tlist : array_like
+            Save-time grid in ns used to estimate integration budgets.
 
-        ``max_steps`` limits the total internal step count. Pulse edges are
-        supplied separately through the native Hamiltonian's discontinuities,
-        so adaptive integration visits short pulses even inside long idles.
-        The deterministic adaptive methods expose no ``max_step`` option;
-        their tolerances and supported native method choices remain explicit.
+        Returns
+        -------
+        dict
+            Copied options with missing integration defaults filled.
         """
         resolved = self._normalize_dq_options(options)
         if "max_steps" not in resolved and resolved.get("method") is None:
@@ -496,13 +480,6 @@ class DynamiqsBackend(Backend):
         return resolved
 
     def coerce_state(self, state: State, dims: tuple[int, ...] | None = None) -> State:
-        """Convert a QuTiP ``Qobj`` state into a dimensioned dynamiqs qarray.
-
-        Used when a per-call ``backend="dynamiqs"`` override consumes initial
-        states built under the QuTiP backend (``chip.state(...)`` before the
-        call). Composite subsystem dimensions must survive the conversion:
-        dynamiqs checks them when multiplying the Hamiltonian by the state.
-        """
         if hasattr(state, "full"):  # qutip.Qobj duck-type; no qutip import needed
             return dq.asqarray(state, dims=dims)
         if len(tuple(state.shape)) == 1:  # flat native ket: dynamiqs solvers need a column
@@ -522,7 +499,6 @@ class DynamiqsBackend(Backend):
         e_ops: list[Operator] | None = None,
         options: dict[str, Any] | None = None,
     ) -> SolverResult:
-        """Solve the Schrödinger equation via ``dynamiqs.sesolve`` (JAX-traced)."""
         result = dq.sesolve(
             H, psi0, jnp.asarray(tlist, dtype=float),
             **self._solve_kwargs(e_ops, options),
@@ -538,7 +514,6 @@ class DynamiqsBackend(Backend):
         e_ops: list[Operator] | None = None,
         options: dict[str, Any] | None = None,
     ) -> SolverResult:
-        """Solve the Lindblad master equation via ``dynamiqs.mesolve`` (JAX-traced)."""
         result = dq.mesolve(
             H, [] if c_ops is None else c_ops, rho0, jnp.asarray(tlist, dtype=float),
             **self._solve_kwargs(e_ops, options),
@@ -554,7 +529,30 @@ class DynamiqsBackend(Backend):
         return self.to_array(dq.slindbladian(hamiltonian, collapse_ops))
 
     def steadystate(self, problem: Any, *, prepared: PreparedStationary | None = None) -> SteadyStateSolverResult:
-        """Solve a static Lindblad generator by a trace-constrained JAX solve."""
+        r"""Solve a static Lindblad generator by a trace-constrained JAX solve.
+
+        Parameters
+        ----------
+        problem : SteadyStateProblem
+            Captured static model, observables, and stationary solver options.
+        prepared : PreparedStationary or None, default None
+            Matching prepared generator; ``None`` builds it.
+
+        Returns
+        -------
+        SteadyStateSolverResult
+            Stationary density matrix and convergence diagnostics.
+
+        See Also
+        --------
+        quchip.backend.protocol.Backend.steadystate
+
+        Notes
+        -----
+        ``problem.options`` accepts only ``method="direct"`` and
+        ``rank_tolerance`` (singular-value cutoff, default automatic). A nonunique
+        stationary kernel produces a NaN state; inspect the returned nullity.
+        """
         options = dict(problem.options)
         method = options.pop("method", "direct")
         if method != "direct":
@@ -609,7 +607,6 @@ class DynamiqsBackend(Backend):
         return stationary_condition_number(liouvillian, math.prod(engine_result.dims), xp=jnp)
 
     def linear_response(self, problem: Any) -> LinearResponseSolverResult:
-        """Solve passive-linear scattering with batched JAX mode matrices."""
         return linear_response(problem, xp=jnp)
 
     def stationary_resolvent(
@@ -621,7 +618,6 @@ class DynamiqsBackend(Backend):
         *,
         prepared: PreparedStationary | None = None,
     ) -> dict[tuple[str, str], Any]:
-        """Evaluate stationary resolvents with Dynamiqs' JAX Liouvillian."""
         liouvillian = self.prepare_stationary(engine_result, prepared=prepared).liouvillian
         dimension = math.prod(engine_result.dims)
         targets = jnp.stack(
@@ -663,7 +659,6 @@ class DynamiqsBackend(Backend):
         *,
         prepared: PreparedStationary | None = None,
     ) -> dict[str, Any]:
-        """Propagate regression operators with Dynamiqs' JAX Liouvillian."""
         liouvillian = self.prepare_stationary(engine_result, prepared=prepared).liouvillian
         dimension = math.prod(engine_result.dims)
         initial_vector = jnp.asarray(initial.to_dense(), dtype=jnp.complex128).T.reshape(-1)
@@ -721,13 +716,6 @@ class DynamiqsBackend(Backend):
         return cache
 
     def solve_problem(self, problem: Any) -> SolverResult:
-        """Lower and solve a single :class:`SolveProblem` via a cached jitted solve.
-
-        Falls back to the protocol default (one-shot ``prepare_hamiltonian`` +
-        ``sesolve``/``mesolve``) whenever the engine result contains a dynamic
-        term that is not a :class:`ScalarModulation` (the cached path can only
-        rebuild ``ScalarModulation`` signals).
-        """
         engine_result = problem.engine_result
         if not self._engine_result_is_cacheable(engine_result):
             return super().solve_problem(problem)
@@ -907,13 +895,29 @@ class DynamiqsBackend(Backend):
         engine_result: Any,
         tlist: Any | None = None,
     ) -> PreparedHamiltonian:
-        """Convert a :class:`EngineResult` into a dynamiqs native RHS.
+        r"""Convert a :class:`EngineResult` into a dynamiqs native RHS.
 
         Static terms are summed as qarrays; dynamic terms with
         ``ScalarModulation`` time-dependence are wrapped via
         ``dynamiqs.modulated`` with a JAX-traceable :class:`_SignalCallable`.
         ``tlist`` is passed through in metadata but not used for sampling —
         dynamiqs evaluates callables on the integrator's adaptive grid.
+
+        Parameters
+        ----------
+        engine_result : EngineResult
+            Captured engine Hamiltonian and channels in solver units.
+        tlist : array_like
+            Requested save times in ns, used by native time-dependent lowering.
+
+        Returns
+        -------
+        PreparedHamiltonian
+            Native right-hand side and numerical integration hints.
+
+        See Also
+        --------
+        quchip.backend.protocol.Backend.prepare_hamiltonian
         """
         static_ops = [
             self.from_canonical_operator(term.operator)
@@ -958,7 +962,7 @@ class DynamiqsBackend(Backend):
         return rhs
 
     def prepare_batch(self, batch: Any) -> DeferredBatch:
-        """Lower compatible problems into stable leaves for one vmapped solve.
+        r"""Lower compatible problems into stable leaves for one vmapped solve.
 
         Shared operators (static + per-slot dynamic) are converted exactly
         once via an id-keyed cache. For each dynamic slot, the per-element
@@ -973,6 +977,20 @@ class DynamiqsBackend(Backend):
         ValueError
             If a slot contains heterogeneous pytree structures (cannot be
             stacked) or a non-``ScalarModulation`` time dependence.
+
+        Parameters
+        ----------
+        batch : SolveBatch
+            Batch of captured problems with compatible save grids.
+
+        Returns
+        -------
+        PreparedBatch
+            Eager, native-vectorized, or deferred representation selected by this backend.
+
+        See Also
+        --------
+        quchip.backend.protocol.Backend.prepare_batch
         """
         engine_results = tuple(problem.engine_result for problem in batch.problems)
         cached_native = self._make_op_cache()
@@ -1036,11 +1054,27 @@ class DynamiqsBackend(Backend):
         )
 
     def solve_batch(self, batch: Any, *, progress: bool = True) -> list[SolverResult]:
-        """Solve a :class:`SolveBatch` via a single native dynamiqs vmap.
+        r"""Solve a :class:`SolveBatch` via a single native dynamiqs vmap.
 
         Raises :class:`RuntimeError` when the batch is not structurally
         homogeneous — no silent fallback. Callers with heterogeneous inputs
         should regroup through :func:`quchip.engine.solve_many`.
+
+        Parameters
+        ----------
+        batch : SolveBatch
+            Captured problems and batch parameter values.
+        progress : bool, default True
+            Request a batch progress display.
+
+        Returns
+        -------
+        list of SolverResult
+            Results in batch order.
+
+        See Also
+        --------
+        quchip.backend.protocol.Backend.solve_batch
         """
         if batch.batch_size == 0:
             return []

--- a/quchip/backend/protocol.py
+++ b/quchip/backend/protocol.py
@@ -67,7 +67,7 @@ State = Any
 
 
 class Backend(ABC):
-    """Abstract contract implemented by every quchip operator backend.
+    r"""Abstract contract implemented by every quchip operator backend.
 
     A backend wraps a quantum-dynamics library (QuTiP, dynamiqs, ...) and
     exposes three orthogonal surfaces:
@@ -87,6 +87,11 @@ class Backend(ABC):
     Defaults provided here are NumPy-based and correct for any backend, so
     concrete subclasses only override where they can do better (e.g. QuTiP
     reuses ``Qobj.eigenstates``, dynamiqs reuses ``dq.expect``).
+
+    Solver Hamiltonians use angular frequencies; public device parameters use
+    ordinary GHz.
+    For operator and circuit-QED conventions, see Blais et al.,
+    `Rev. Mod. Phys. 93, 025005 (2021) <https://doi.org/10.1103/RevModPhys.93.025005>`_.
     """
 
     # ------------------------------------------------------------------
@@ -107,32 +112,61 @@ class Backend(ABC):
 
     @abstractmethod
     def to_array(self, op: Operator) -> Any:
-        """Return a dense array (native to :attr:`array_module`) for *op*."""
+        r"""Return a dense array (native to :attr:`array_module`) for *op*.
+
+        Parameters
+        ----------
+        op : Operator
+            Backend-native operator.
+        """
         ...
 
     def overlap(self, a: State, b: State) -> complex:
-        """Return the scalar inner product ⟨a|b⟩ for two kets."""
+        r"""Return the scalar inner product ⟨a|b⟩ for two kets.
+
+        Parameters
+        ----------
+        a, b : State
+            Kets in the same Hilbert space; the first is conjugated.
+        """
         a_arr = np.asarray(self.to_array(a), dtype=complex)
         b_arr = np.asarray(self.to_array(b), dtype=complex)
         return complex(np.conj(a_arr).T @ b_arr)
 
     def norm(self, state_or_op: State | Operator) -> Any:
-        """Return the Frobenius / ℓ²-norm of a state or operator.
+        r"""Return the Frobenius / ℓ²-norm of a state or operator.
 
         A concrete ``float`` for CPU-only backends; a JAX-traceable backend
         may return a native 0-d array instead so a traced amplitude stays
         differentiable — callers that need concreteness route through
         :func:`~quchip.utils.jax_utils.maybe_concrete_scalar`.
+
+        Parameters
+        ----------
+        state_or_op : State or Operator
+            Ket or matrix whose Euclidean/Frobenius norm is requested.
         """
         arr = np.asarray(self.to_array(state_or_op), dtype=complex)
         return float(np.linalg.norm(arr))
 
     def is_native_state(self, state: Any) -> bool:
-        """Return whether *state* is already represented by this backend."""
+        r"""Return whether *state* is already represented by this backend.
+
+        Parameters
+        ----------
+        state : State
+            Ket or density matrix to inspect or convert.
+        """
         return False
 
     def trace(self, op: Operator) -> complex:
-        """Return the scalar trace ``Tr(op)``."""
+        r"""Return the scalar trace ``Tr(op)``.
+
+        Parameters
+        ----------
+        op : Operator
+            Backend-native operator.
+        """
         arr = np.asarray(self.to_array(op), dtype=complex)
         return complex(np.trace(arr))
 
@@ -163,33 +197,68 @@ class Backend(ABC):
         return nullcontext()
 
     def destroy(self, n: int) -> Operator:
-        """Build the annihilation operator :math:`\\hat a` for an *n*-level Fock space."""
+        r"""Build the annihilation operator :math:`\hat a` for an *n*-level Fock space.
+
+        Parameters
+        ----------
+        n : int
+            Positive Hilbert-space dimension; number states run from 0 to n - 1.
+
+        """
         data = np.zeros((n, n), dtype=complex)
         for k in range(1, n):
             data[k - 1, k] = np.sqrt(k)
         return self._single_mode(data)
 
     def create(self, n: int) -> Operator:
-        """Build the creation operator :math:`\\hat a^\\dagger` for an *n*-level Fock space."""
+        r"""Build the creation operator :math:`\hat a^\dagger` for an *n*-level Fock space.
+
+        Parameters
+        ----------
+        n : int
+            Positive Hilbert-space dimension; number states run from 0 to n - 1.
+
+        """
         data = np.zeros((n, n), dtype=complex)
         for k in range(1, n):
             data[k, k - 1] = np.sqrt(k)
         return self._single_mode(data)
 
     def number(self, n: int) -> Operator:
-        """Build the number operator :math:`\\hat n = \\hat a^\\dagger \\hat a`."""
+        r"""Build the number operator :math:`\hat n = \hat a^\dagger \hat a`.
+
+        Parameters
+        ----------
+        n : int
+            Positive Hilbert-space dimension; number states run from 0 to n - 1.
+
+        """
         return self._single_mode(np.diag(np.arange(n, dtype=complex)))
 
     def identity(self, n: int) -> Operator:
-        """Build the identity operator for an *n*-level space."""
+        r"""Build the identity operator for an *n*-level space.
+
+        Parameters
+        ----------
+        n : int
+            Positive Hilbert-space dimension; number states run from 0 to n - 1.
+
+        """
         return self._single_mode(np.eye(n, dtype=complex))
 
     def from_array(self, data: Any, dims: list[list[int]] | None = None) -> Operator:
-        """Construct a native operator from a dense matrix.
+        r"""Construct a native operator from a dense matrix.
 
         *dims* accepts quchip's row/col layout (``[[row_dims], [col_dims]]``)
         or a flat list; ``None`` means a single subsystem of size
         ``data.shape[0]``.
+
+        Parameters
+        ----------
+        data : array_like
+            Dense matrix in the requested tensor-product basis.
+        dims : list or None, default None
+            Subsystem dimensions, flat or [[row_dims], [column_dims]]. None treats the row space as one subsystem.
         """
         from quchip.engine.ir import CanonicalOperator
 
@@ -201,12 +270,19 @@ class Backend(ABC):
         )
 
     def diag(self, values: Any, dims: list[list[int]] | None = None) -> Operator:
-        """Construct a backend-native diagonal operator from main-diagonal *values*.
+        r"""Construct a backend-native diagonal operator from main-diagonal *values*.
 
         Backends that distinguish layouts (e.g. dynamiqs sparse-DIA) should
         return their sparse representation so element-wise composition with
         other diagonal operators stays sparse. Default falls through to
         :meth:`from_array` after building a dense ``np.diag``.
+
+        Parameters
+        ----------
+        values : array_like
+            Main-diagonal entries, flattened in input order.
+        dims : list or None, default None
+            Subsystem dimensions as in from_array; None uses one subsystem.
         """
         from quchip.engine.ir import CanonicalOperator
 
@@ -226,12 +302,24 @@ class Backend(ABC):
 
     @abstractmethod
     def to_canonical_operator(self, op: Operator) -> "CanonicalOperator":
-        """Serialize a native operator into the backend-agnostic canonical IR."""
+        r"""Serialize a native operator into the backend-agnostic canonical IR.
+
+        Parameters
+        ----------
+        op : Operator
+            Backend-native operator.
+        """
         ...
 
     @abstractmethod
     def from_canonical_operator(self, canonical: "CanonicalOperator") -> Operator:
-        """Reconstruct a native operator from the canonical IR payload."""
+        r"""Reconstruct a native operator from the canonical IR payload.
+
+        Parameters
+        ----------
+        canonical : CanonicalOperator
+            Backend-neutral matrix payload including its tensor dimensions and basis metadata.
+        """
         ...
 
     # ------------------------------------------------------------------
@@ -239,7 +327,7 @@ class Backend(ABC):
     # ------------------------------------------------------------------
 
     def coerce_operator(self, op: Operator) -> Operator:
-        """Coerce an array-like local operator into backend-native form.
+        r"""Coerce an array-like local operator into backend-native form.
 
         The operator-side mirror of :meth:`coerce_state`. Device-side
         physical-coupling accessors (e.g.
@@ -249,30 +337,65 @@ class Backend(ABC):
         route their operands through this hook so both forms compose
         freely. Backends whose native operators are already arrays
         override with a trace-safe passthrough.
+
+        Parameters
+        ----------
+        op : Operator
+            Backend-native operator.
         """
         return self.from_array(self.to_array(op))
 
     def dag(self, op: Operator) -> Operator:
-        """Return the Hermitian conjugate ``op†``."""
+        r"""Return the Hermitian conjugate ``op†``.
+
+        Parameters
+        ----------
+        op : Operator
+            Backend-native operator.
+        """
         arr = np.asarray(self.to_array(op), dtype=complex)
         return self.from_array(np.conj(arr).T)
 
     def matmul(self, a: Operator, b: Operator) -> Operator:
-        """Return the matrix product ``a @ b``."""
+        r"""Return the matrix product ``a @ b``.
+
+        Parameters
+        ----------
+        a, b : Operator
+            Left and right matrix factors with compatible dimensions.
+        """
         return a @ b
 
     def eigenenergies(self, op: Operator) -> Any:
-        """Return the ascending eigenvalues of a Hermitian operator."""
+        r"""Return the ascending eigenvalues of a Hermitian operator.
+
+        Parameters
+        ----------
+        op : Operator
+            Hermitian operator to diagonalize.
+        """
         dense = np.asarray(self.to_array(op), dtype=complex)
         return np.linalg.eigvalsh(dense)
 
     def eigenstates(self, op: Operator) -> tuple[Any, Any]:
-        """Return ``(eigenvalues, eigenstates)`` of a Hermitian operator, ascending."""
+        r"""Return ``(eigenvalues, eigenstates)`` of a Hermitian operator, ascending.
+
+        Parameters
+        ----------
+        op : Operator
+            Hermitian operator to diagonalize.
+        """
         data = self.eigensystem_data(op)
         return data.eigenvalues, data.eigenstates
 
     def eigensystem_data(self, op: Operator) -> EigensystemData:
-        """Return ascending eigenvalues, stacked eigenvector matrix, and lazy eigenstates."""
+        r"""Return ascending eigenvalues, stacked eigenvector matrix, and lazy eigenstates.
+
+        Parameters
+        ----------
+        op : Operator
+            Hermitian operator to diagonalize.
+        """
         dense = np.asarray(self.to_array(op), dtype=complex)
         evals, evecs = np.linalg.eigh(dense)
 
@@ -286,7 +409,15 @@ class Backend(ABC):
         )
 
     def expect(self, op: Operator, state: State) -> complex:
-        """Return the expectation value ⟨state|op|state⟩ — accepts ket or density matrix."""
+        r"""Return the expectation value ⟨state|op|state⟩ — accepts ket or density matrix.
+
+        Parameters
+        ----------
+        op : Operator
+            Observable with the same tensor dimensions as state.
+        state : State
+            Ket or density matrix. No normalization is performed.
+        """
         op_arr = np.asarray(self.to_array(op), dtype=complex)
         state_arr = np.asarray(self.to_array(state), dtype=complex)
         if state_arr.ndim == 2 and state_arr.shape[1] == 1:
@@ -322,7 +453,7 @@ class Backend(ABC):
         return self.from_array(rho.reshape(kept_dim, kept_dim))
 
     def permute_state(self, state: State, dims: Sequence[int], order: Sequence[int]) -> State:
-        """Reorder a composite state's subsystems.
+        r"""Reorder a composite state's subsystems.
 
         ``dims`` are the subsystem levels in *state*'s current tensor order.
         ``order`` follows ``numpy.transpose`` convention: ``order[i]`` is the
@@ -344,6 +475,15 @@ class Backend(ABC):
         ``array_module.prod`` — routing a *shape* value through the array
         module would turn it into a tracer under ``jit`` and make the
         subsequent ``reshape`` fail.
+
+        Parameters
+        ----------
+        state : State
+            Ket or density matrix in the current tensor order.
+        dims : sequence of int
+            Current subsystem dimensions.
+        order : sequence of int
+            Permutation of subsystem indices, listing their positions in the new order.
         """
         xp = self.array_module
         arr = xp.asarray(self.to_array(state), dtype=complex)
@@ -384,11 +524,16 @@ class Backend(ABC):
     # per-time tracers.
 
     def stack_states(self, states: Any) -> Any:
-        """Stack a trajectory's saved states into a single ``(T, …)`` array.
+        r"""Stack a trajectory's saved states into a single ``(T, …)`` array.
 
         Default densifies each state and ``np.stack``s along a new leading
         time axis. Backends whose solver already returns a stacked native
         state (dynamiqs) override this to a no-op pass-through.
+
+        Parameters
+        ----------
+        states : sequence of State
+            Saved states in time order, with matching shapes and tensor dimensions.
         """
         return np.stack([np.asarray(self.to_array(s), dtype=complex) for s in states])
 
@@ -398,12 +543,19 @@ class Backend(ABC):
         return stacked.ndim == 3 and stacked.shape[2] == 1
 
     def expect_over_time(self, op: Operator, stacked_states: Any) -> Any:
-        """Return ⟨op⟩(t) for every save point, as one ``(T,)`` array in :attr:`array_module`.
+        r"""Return ⟨op⟩(t) for every save point, as one ``(T,)`` array in :attr:`array_module`.
 
         Accepts a ket stack ``(T, n, 1)`` (returns ⟨ψ|op|ψ⟩) or a
         density-matrix stack ``(T, n, n)`` (returns ``Tr(op·ρ)``). One einsum
         replaces the per-point ``expect`` loop. Every intermediate stays in
         :attr:`array_module`, so the JAX backend keeps the trace differentiable.
+
+        Parameters
+        ----------
+        op : Operator
+            Observable in the states' tensor-product basis.
+        stacked_states : array_like
+            Backend-stacked kets or density matrices from stack_states.
         """
         xp = self.array_module
         op_arr = xp.asarray(self.to_array(op), dtype=complex)
@@ -414,13 +566,20 @@ class Backend(ABC):
         return xp.einsum("tij,ji->t", rho, op_arr)
 
     def overlap_over_time(self, target: State, stacked_states: Any) -> Any:
-        """Return ⟨target|ψ(t)⟩ for every save point, as one ``(T,)`` array.
+        r"""Return ⟨target|ψ(t)⟩ for every save point, as one ``(T,)`` array.
 
         For a ket stack this is the **phase-sensitive complex amplitude**
         ⟨target|ψ(t)⟩ (never ``|·|²`` — phase-dependent gradients flow
         through it). For a density-matrix stack there is no single phase, so
         it returns the target-state population ⟨target|ρ(t)|target⟩. Stays in
         :attr:`array_module` for JAX traceability.
+
+        Parameters
+        ----------
+        target : State
+            Reference ket in the same Hilbert space.
+        stacked_states : array_like
+            Backend-stacked saved states from stack_states.
         """
         xp = self.array_module
         tgt = xp.asarray(self.to_array(target), dtype=complex).reshape(-1)
@@ -430,11 +589,16 @@ class Backend(ABC):
         return xp.einsum("i,tij,j->t", xp.conj(tgt), arr, tgt)
 
     def populations_over_time(self, stacked_states: Any) -> Any:
-        """Return full-chip diagonal populations ``(T, ∏dims)`` (real) for every save point.
+        r"""Return full-chip diagonal populations ``(T, ∏dims)`` (real) for every save point.
 
         For a ket stack this is ``|ψ(t)|²`` along the level axis (the density
         matrix is never built); for a DM stack it is the real diagonal. Stays
         in :attr:`array_module` for JAX traceability.
+
+        Parameters
+        ----------
+        stacked_states : array_like
+            Backend-stacked saved states; trailing dimensions encode ket or matrix entries.
         """
         xp = self.array_module
         arr = xp.asarray(self.to_array(stacked_states), dtype=complex)
@@ -443,10 +607,19 @@ class Backend(ABC):
         return xp.real(xp.diagonal(arr, axis1=1, axis2=2))
 
     def ptrace_over_time(self, stacked_states: Any, keep: int | list[int], dims: list[int]) -> Any:
-        """Reduce onto subsystem(s) *keep* at every save point, returning a ``(T, k, k)`` DM stack.
+        r"""Reduce onto subsystem(s) *keep* at every save point, returning a ``(T, k, k)`` DM stack.
 
         Reduces a ket or DM trajectory onto subsystem(s) *keep* without a
         per-point Python loop.
+
+        Parameters
+        ----------
+        stacked_states : array_like
+            Backend-stacked saved states from stack_states.
+        keep : int or list of int
+            Subsystem positions to retain.
+        dims : list of int
+            Full tensor-product dimensions before tracing.
         """
         if isinstance(keep, int):
             keep = [keep]
@@ -499,11 +672,20 @@ class Backend(ABC):
         index_b: int,
         dims: Sequence[int],
     ) -> Operator:
-        """Embed a two-body operator on devices *index_a* ⊗ *index_b* into the full space.
+        r"""Embed a two-body operator on devices *index_a* ⊗ *index_b* into the full space.
 
         Handles subsystem SWAP when ``index_a > index_b`` and identity-padding
         for non-adjacent devices, without materializing the dense full matrix
         when the backend supports sparse layouts.
+
+        Parameters
+        ----------
+        op_ab : Operator
+            Two-subsystem operator, in index_a then index_b tensor order.
+        index_a, index_b : int
+            Distinct positions of the target subsystems in dims.
+        dims : sequence of int
+            Full tensor-product dimensions in chip order.
         """
         ...
 
@@ -512,20 +694,41 @@ class Backend(ABC):
     # ------------------------------------------------------------------
 
     def basis(self, n: int, k: int) -> State:
-        """Build the Fock basis ket :math:`|k\\rangle` in an *n*-level space."""
+        r"""Build the Fock basis ket :math:`|k\rangle` in an *n*-level space.
+
+        Parameters
+        ----------
+        n : int
+            Hilbert-space dimension.
+        k : int
+            Number-state index, satisfying 0 <= k < n.
+        """
         vec = np.zeros((n, 1), dtype=complex)
         vec[k, 0] = 1.0
         return self.from_array(vec)
 
     def tensor_states(self, *states: State) -> State:
-        """Return the tensor product of states (defaults to :meth:`tensor`)."""
+        r"""Return the tensor product of states (defaults to :meth:`tensor`).
+
+        Parameters
+        ----------
+        *states : State
+            Factors in tensor-product order.
+        """
         return self.tensor(*states)
 
     def coherent(self, n: int, alpha: complex) -> State:
-        """Build the coherent state :math:`|\\alpha\\rangle` truncated to *n* Fock levels.
+        r"""Build the coherent state :math:`|\alpha\rangle` truncated to *n* Fock levels.
 
         Built from the analytic series
-        :math:`|\\alpha\\rangle = e^{-|\\alpha|^2/2} \\sum_k \\alpha^k/\\sqrt{\\Gamma(k+1)}\\,|k\\rangle`.
+        :math:`|\alpha\rangle = e^{-|\alpha|^2/2} \sum_k \alpha^k/\sqrt{\Gamma(k+1)}\,|k\rangle`.
+
+        Parameters
+        ----------
+        n : int
+            Fock-space truncation.
+        alpha : complex
+            Dimensionless coherent-state amplitude; its squared magnitude sets the untruncated mean occupation.
         """
         import math
 
@@ -537,24 +740,48 @@ class Backend(ABC):
         return self.from_array(coeffs.reshape(n, 1))
 
     def state_to_dm(self, state: State) -> State:
-        """Return a density matrix; pass through if *state* is already one."""
+        r"""Return a density matrix; pass through if *state* is already one.
+
+        Parameters
+        ----------
+        state : State
+            Ket or density matrix to inspect or convert.
+        """
         if not self.is_ket(state):
             return state
         arr = np.asarray(self.to_array(state), dtype=complex).reshape(-1, 1)
         return self.from_array(arr @ np.conj(arr).T)
 
     def is_ket(self, state: State) -> bool:
-        """Return whether *state* is a ket (flat or column vector) rather than a density matrix."""
+        r"""Return whether *state* is a ket (flat or column vector) rather than a density matrix.
+
+        Parameters
+        ----------
+        state : State
+            Ket or density matrix to inspect or convert.
+        """
         arr = np.asarray(self.to_array(state), dtype=complex)
         return arr.ndim == 1 or (arr.ndim == 2 and arr.shape[1] == 1)
 
     def as_density_matrix(self, state: State) -> State:
-        """Promote a ket to its density matrix; pass a density matrix through unchanged."""
+        r"""Promote a ket to its density matrix; pass a density matrix through unchanged.
+
+        Parameters
+        ----------
+        state : State
+            Ket or density matrix to inspect or convert.
+        """
         return self.state_to_dm(state) if self.is_ket(state) else state
 
     @abstractmethod
     def tensor(self, *operators: Operator) -> Operator:
-        """Return the tensor product of operators, preserving subsystem dims metadata."""
+        r"""Return the tensor product of operators, preserving subsystem dims metadata.
+
+        Parameters
+        ----------
+        *operators : Operator
+            Factors in tensor-product order.
+        """
         ...
 
     # ------------------------------------------------------------------
@@ -599,12 +826,32 @@ class Backend(ABC):
         e_ops: list[Operator] | None = None,
         options: dict[str, Any] | None = None,
     ) -> SolverResult:
-        """Solve the Lindblad master equation (Lindblad 1976; Breuer & Petruccione 2002).
+        r"""Solve the Lindblad master equation (Lindblad 1976; Breuer & Petruccione 2002).
 
         Integrates
-        :math:`\\dot\\rho = -i[H,\\rho] + \\sum_k \\mathcal D[L_k]\\rho`
+        :math:`\dot\rho = -i[H,\rho] + \sum_k \mathcal D[L_k]\rho`
         with
-        :math:`\\mathcal D[L]\\rho = L\\rho L^\\dagger - \\tfrac12\\{L^\\dagger L, \\rho\\}`.
+        :math:`\mathcal D[L]\rho = L\rho L^\dagger - \tfrac12\{L^\dagger L, \rho\}`.
+
+        Parameters
+        ----------
+        H : object
+            Native Hamiltonian already scaled to angular frequency in rad/ns; do not multiply by 2*pi again.
+        rho0 : State
+            Initial density matrix or a ket accepted by the concrete solver.
+        tlist : array_like, shape (nt,)
+            Save times in ns, strictly increasing.
+        c_ops : list of Operator or None, default None
+            Collapse operators including square-root rates in 1/sqrt(ns); None supplies no dissipators.
+        e_ops : list of Operator or None, default None
+            Observables in output order; None requests no expectation traces.
+        options : dict or None, default None
+            Native integration options; see the concrete backend resolve_solver_options method.
+
+        Returns
+        -------
+        SolverResult
+            Saved states, expectation traces and solver diagnostics.
         """
         ...
 
@@ -615,11 +862,25 @@ class Backend(ABC):
         n_jobs: int = -1,
         progress: bool = True,
     ) -> list[SolverResult]:
-        """Solve multiple sesolve problems. Default: sequential dispatch.
+        r"""Solve multiple sesolve problems. Default: sequential dispatch.
 
         Backends that can vectorize (dynamiqs ``vmap``) or parallelize (QuTiP
         via loky) override this method. Each problem dict carries the same
         kwargs as :meth:`sesolve`.
+
+        Parameters
+        ----------
+        problems : list of dict
+            One keyword-argument mapping per sesolve call.
+        n_jobs : int, default -1
+            Worker count; -1 requests all CPUs. Ignored by the base sequential implementation.
+        progress : bool, default True
+            Request a progress display where supported.
+
+        Returns
+        -------
+        list of SolverResult
+            Results in input order.
         """
         return [self.sesolve(**p) for p in problems]
 
@@ -630,7 +891,22 @@ class Backend(ABC):
         n_jobs: int = -1,
         progress: bool = True,
     ) -> list[SolverResult]:
-        """Solve multiple mesolve problems. Default: sequential dispatch."""
+        r"""Solve multiple mesolve problems. Default: sequential dispatch.
+
+        Parameters
+        ----------
+        problems : list of dict
+            One keyword-argument mapping per mesolve call.
+        n_jobs : int, default -1
+            Worker count; -1 requests all CPUs. Ignored by the base sequential implementation.
+        progress : bool, default True
+            Request a progress display where supported.
+
+        Returns
+        -------
+        list of SolverResult
+            Results in input order.
+        """
         return [self.mesolve(**p) for p in problems]
 
     # ------------------------------------------------------------------
@@ -642,11 +918,23 @@ class Backend(ABC):
         description: "EngineResult",
         tlist: Any,
     ) -> "PreparedHamiltonian":
-        """Convert a :class:`EngineResult` into a native solver RHS.
+        r"""Convert a :class:`EngineResult` into a native solver RHS.
 
         The engine passes frequencies already converted by ``2π`` (angular
         rad/ns); backends must not rescale. Concrete backends override this
         method to choose their native time-dependence representation.
+
+        Parameters
+        ----------
+        description : EngineResult
+            Captured engine Hamiltonian and channels in solver units.
+        tlist : array_like
+            Requested save times in ns, used by native time-dependent lowering.
+
+        Returns
+        -------
+        PreparedHamiltonian
+            Native right-hand side and numerical integration hints.
         """
         raise NotImplementedError(f"{type(self).__name__} must implement prepare_hamiltonian()")
 
@@ -657,11 +945,25 @@ class Backend(ABC):
         metadata: dict[str, Any],
         tlist: Any,
     ) -> dict[str, Any]:
-        """Merge user options with backend-side defaults and metadata heuristics.
+        r"""Merge user options with backend-side defaults and metadata heuristics.
 
         Default is a shallow copy; concrete backends use *metadata*
         (e.g. ``spectral_bound_ghz``) to fill in integrator step budgets when
         the user did not specify one.
+
+        Parameters
+        ----------
+        options : dict
+            User integration settings; copied before filling missing defaults.
+        metadata : dict
+            Lowering hints, including ordinary-GHz spectral and carrier bounds when available.
+        tlist : array_like
+            Save-time grid in ns used to estimate integration budgets.
+
+        Returns
+        -------
+        dict
+            Resolved options; the input mapping is unchanged.
         """
         return dict(options)
 
@@ -685,7 +987,7 @@ class Backend(ABC):
         return dict(options)
 
     def coerce_state(self, state: State, dims: tuple[int, ...] | None = None) -> State:
-        """Convert a foreign-native *state* into this backend's native form.
+        r"""Convert a foreign-native *state* into this backend's native form.
 
         Called at the solve boundary so a per-call ``backend=`` override
         (see :meth:`QuantumSequence.simulate`) accepts initial states that
@@ -693,16 +995,33 @@ class Backend(ABC):
         ``chip.state(...)`` handed to a dynamiqs gradient solve. Default:
         pass through unchanged. ``dims`` are the chip's subsystem levels,
         for backends whose state type carries tensor structure.
+
+        Parameters
+        ----------
+        state : State or array_like
+            Ket or density matrix to convert to this backend.
+        dims : tuple of int or None, default None
+            Target tensor dimensions. None leaves dimension inference to the backend.
         """
         _ = dims
         return state
 
     def solve_problem(self, problem: "SolveProblem") -> SolverResult:
-        """Lower and solve a :class:`SolveProblem` — the single-element entry point.
+        r"""Lower and solve a :class:`SolveProblem` — the single-element entry point.
 
         Delegates to :meth:`SolveProblem.solver_name`: ``sesolve`` only for a ket
         with no collapse operators, ``mesolve`` otherwise, unless ``problem.solver``
         forces a choice.
+
+        Parameters
+        ----------
+        problem : SolveProblem
+            Complete captured Hamiltonian, initial state, time grid, observables and solver settings.
+
+        Returns
+        -------
+        SolverResult
+            Native solver payload for the requested calculation.
         """
         prepared = self.prepare_hamiltonian(problem.engine_result, problem.tlist)
         tlist_arr, c_ops, solver, opts, e_ops_arg = self._resolve_solve_config(
@@ -723,7 +1042,20 @@ class Backend(ABC):
     def prepare_stationary(
         self, engine_result: "EngineResult", *, prepared: PreparedStationary | None = None,
     ) -> PreparedStationary:
-        """Prepare once, or reuse the same backend and captured operating point."""
+        r"""Prepare once, or reuse the same backend and captured operating point.
+
+        Parameters
+        ----------
+        engine_result : EngineResult
+            Captured static Hamiltonian and collapse channels.
+        prepared : PreparedStationary or None, default None
+            Matching prepared generator; ``None`` builds it.
+
+        Returns
+        -------
+        PreparedStationary
+            Native stationary generator tied to this operating point.
+        """
         if prepared is None:
             return PreparedStationary(self, engine_result, self._stationary_liouvillian(engine_result))
         if prepared.backend is not self or prepared.engine_result is not engine_result:
@@ -731,11 +1063,35 @@ class Backend(ABC):
         return prepared
 
     def steadystate(self, problem: Any, *, prepared: PreparedStationary | None = None) -> SteadyStateSolverResult:
-        """Solve one static Lindblad problem in the backend's native representation."""
+        r"""Solve one static Lindblad problem in the backend's native representation.
+
+        Parameters
+        ----------
+        problem : SteadyStateProblem
+            Captured static model, observables, and stationary solver options.
+        prepared : PreparedStationary or None, default None
+            Matching prepared generator; ``None`` builds it.
+
+        Returns
+        -------
+        SteadyStateSolverResult
+            Stationary density matrix and convergence diagnostics.
+        """
         raise NotImplementedError(f"{type(self).__name__} must implement steadystate()")
 
     def linear_response(self, problem: Any) -> LinearResponseSolverResult:
-        """Solve one passive-linear input-output problem in the backend's native arrays."""
+        r"""Solve one passive-linear input-output problem in the backend's native arrays.
+
+        Parameters
+        ----------
+        problem : LinearResponseProblem
+            Captured passive-linear model, selected ports, probe frequencies, and incident amplitudes.
+
+        Returns
+        -------
+        LinearResponseSolverResult
+            Scattering response, internal amplitudes and numerical diagnostics.
+        """
         raise NotImplementedError(f"{type(self).__name__} must implement linear_response()")
 
     def stationary_resolvent(
@@ -747,13 +1103,31 @@ class Backend(ABC):
         *,
         prepared: PreparedStationary | None = None,
     ) -> dict[tuple[str, str], Any]:
-        """Evaluate trace-zero stationary resolvents in native backend arrays.
+        r"""Evaluate trace-zero stationary resolvents in native backend arrays.
 
         For each ordinary-GHz offset ``f``, form and factor the trace-constrained
         shifted Liouvillian once, then solve ``(L + i 2π f) X = source`` with
         ``Tr(X) = 0`` for every named source column. Return ``Tr(observable X)``
         keyed by ``(source, observable)``. The engine supplies canonical operators;
         the backend owns Liouvillian construction, factorization, and solves.
+
+        Parameters
+        ----------
+        engine_result : EngineResult
+            Captured static operating point.
+        sources : tuple of (str, CanonicalOperator)
+            Named source columns for the constrained linear systems.
+        observables : tuple of (str, CanonicalOperator)
+            Named operators evaluated against each solution.
+        frequencies : array_like
+            Offset frequencies in ordinary GHz.
+        prepared : PreparedStationary or None, default None
+            Matching prepared generator; ``None`` builds it.
+
+        Returns
+        -------
+        dict
+            Arrays keyed by (source_name, observable_name), indexed by frequency.
         """
         raise NotImplementedError(f"{type(self).__name__} must implement stationary_resolvent()")
 
@@ -766,11 +1140,29 @@ class Backend(ABC):
         *,
         prepared: PreparedStationary | None = None,
     ) -> dict[str, Any]:
-        """Propagate an operator under a static Liouvillian and evaluate observables.
+        r"""Propagate an operator under a static Liouvillian and evaluate observables.
 
         ``initial`` need not be a normalized density matrix. This supports
         quantum-regression queries while keeping the propagation algorithm
         and numerical Liouvillian backend-owned.
+
+        Parameters
+        ----------
+        engine_result : EngineResult
+            Captured static operating point.
+        initial : CanonicalOperator
+            Initial operator; normalization and positivity are not required for regression queries.
+        observables : tuple of (str, CanonicalOperator)
+            Named operators evaluated after propagation.
+        times : array_like
+            Propagation delays in ns.
+        prepared : PreparedStationary or None, default None
+            Matching prepared generator; ``None`` builds it.
+
+        Returns
+        -------
+        dict
+            Observable names mapped to arrays indexed by delay.
         """
         raise NotImplementedError(f"{type(self).__name__} must implement stationary_propagate()")
 
@@ -799,7 +1191,7 @@ class Backend(ABC):
         return None
 
     def prepare_batch(self, batch: "SolveBatch") -> "PreparedBatch":
-        """Lower each explicit batch problem into a prepared batch.
+        r"""Lower each explicit batch problem into a prepared batch.
 
         The return type declares the batching strategy:
         :class:`~quchip.backend.containers.EagerBatch` (one RHS per element),
@@ -809,6 +1201,16 @@ class Backend(ABC):
         payload consumed by an overridden :meth:`solve_batch`).
         Default: lowers each element independently via
         :meth:`prepare_hamiltonian` into an :class:`EagerBatch`.
+
+        Parameters
+        ----------
+        batch : SolveBatch
+            Batch of captured problems with compatible save grids.
+
+        Returns
+        -------
+        PreparedBatch
+            Eager, native-vectorized, or deferred representation selected by this backend.
         """
         rhs_list: list[Any] = []
         shared_metadata: dict[str, Any] = {}
@@ -826,11 +1228,23 @@ class Backend(ABC):
         )
 
     def solve_batch(self, batch: "SolveBatch", *, progress: bool = True) -> list[SolverResult]:
-        """Lower and solve a :class:`SolveBatch`.
+        r"""Lower and solve a :class:`SolveBatch`.
 
         Default: prepares the batch then dispatches each element's RHS
         through :meth:`batched_sesolve` / :meth:`batched_mesolve`. Native
         backends override to avoid the per-element unpack.
+
+        Parameters
+        ----------
+        batch : SolveBatch
+            Captured problems and batch parameter values.
+        progress : bool, default True
+            Request a batch progress display.
+
+        Returns
+        -------
+        list of SolverResult
+            Results in batch order.
         """
         if batch.batch_size == 0:
             return []

--- a/quchip/backend/qutip.py
+++ b/quchip/backend/qutip.py
@@ -378,11 +378,9 @@ class QuTiPBackend(Backend):
 
     @property
     def array_module(self) -> Any:
-        """Return the array module for backend-aware numeric code (``numpy``)."""
         return np
 
     def to_array(self, op: Operator) -> Any:
-        """Return a dense ``numpy`` array for *op*."""
         if isinstance(op, Qobj):
             return np.asarray(op.full(), dtype=complex)
         if hasattr(op, "to_jax"):
@@ -390,18 +388,27 @@ class QuTiPBackend(Backend):
         return np.asarray(op, dtype=complex)
 
     def overlap(self, a: State, b: State) -> complex:
-        """Return the scalar inner product ⟨a|b⟩ for two kets."""
         value = a.dag() @ b
         if isinstance(value, Qobj):
             return complex(value.full()[0, 0])
         return complex(value)
 
     def norm(self, state_or_op: State | Operator) -> float:
-        """Return the norm of a state or operator via ``Qobj.norm``."""
+        r"""Return the native QuTiP norm.
+
+        Parameters
+        ----------
+        state_or_op : qutip.Qobj
+            Ket or bra for the Euclidean norm; matrix for the trace norm.
+
+        Returns
+        -------
+        float
+            ``Qobj.norm()`` with its default norm selection.
+        """
         return float(state_or_op.norm())
 
     def trace(self, op: Operator) -> complex:
-        """Return the scalar trace ``Tr(op)`` via ``Qobj.tr``."""
         return complex(op.tr())
 
     # ------------------------------------------------------------------
@@ -417,23 +424,18 @@ class QuTiPBackend(Backend):
         return cached
 
     def destroy(self, n: int) -> Operator:
-        """Return the annihilation operator for an *n*-level Fock space (``qutip.destroy``, memoized)."""
         return self._cached_op("destroy", n, qutip.destroy)
 
     def create(self, n: int) -> Operator:
-        """Return the creation operator for an *n*-level Fock space (``qutip.create``, memoized)."""
         return self._cached_op("create", n, qutip.create)
 
     def number(self, n: int) -> Operator:
-        """Return the number operator for an *n*-level Fock space (``qutip.num``, memoized)."""
         return self._cached_op("number", n, qutip.num)
 
     def identity(self, n: int) -> Operator:
-        """Return the identity operator for an *n*-level space (``qutip.qeye``, memoized)."""
         return self._cached_op("identity", n, qutip.qeye)
 
     def from_array(self, data: Any, dims: list[list[int]] | None = None) -> Operator:
-        """Construct a ``Qobj`` from a dense matrix with optional row/col *dims*."""
         if isinstance(data, Qobj):
             return data if dims is None or data.dims == dims else Qobj(data.data, dims=dims)
         if hasattr(data, "to_jax"):
@@ -441,7 +443,6 @@ class QuTiPBackend(Backend):
         return Qobj(data, dims=dims)
 
     def to_canonical_operator(self, op: Operator) -> Any:
-        """Serialize a ``Qobj`` into the backend-agnostic canonical IR (CSR or dense)."""
         from quchip.engine.ir import CanonicalOperator
 
         if isinstance(op, Qobj):
@@ -464,30 +465,20 @@ class QuTiPBackend(Backend):
         )
 
     def from_canonical_operator(self, canonical: Any) -> Operator:
-        """Reconstruct a ``Qobj`` from the canonical IR payload."""
         return self._canonical_to_qobj(canonical)
 
     def coerce_operator(self, op: Operator) -> Operator:
-        """Wrap an array-like operator into a ``Qobj`` (native ``Qobj`` passthrough)."""
         if isinstance(op, Qobj):
             return op
         return self.from_array(np.asarray(op, dtype=complex))
 
     def dag(self, op: Operator) -> Operator:
-        """Return the Hermitian conjugate ``op†`` via ``Qobj.dag`` (array-likes coerced first)."""
         return self.coerce_operator(op).dag()
 
     def eigenenergies(self, op: Operator) -> Any:
-        """Return the ascending eigenvalues of a Hermitian operator (``Qobj.eigenenergies``)."""
         return op.eigenenergies()
 
     def eigensystem_data(self, op: Operator) -> EigensystemData:
-        """Return ascending eigenvalues, eigenvector matrix, and primed eigenstate kets.
-
-        A ``Qobj`` uses ``Qobj.eigenstates`` verbatim to preserve the exact
-        degenerate-subspace basis; dense inputs fall through to the protocol
-        default.
-        """
         if isinstance(op, Qobj):
             # Keep ``Qobj.eigenstates()`` verbatim: it preserves the exact
             # degenerate-subspace basis that ``operator_in_dressed_basis``
@@ -510,14 +501,9 @@ class QuTiPBackend(Backend):
         return super().eigensystem_data(op)
 
     def expect(self, op: Operator, state: State) -> complex:
-        """Return the expectation value ⟨op⟩ for a ket or density matrix via ``qutip.expect``."""
         return qutip.expect(op, state)
 
     def ptrace(self, state: State, keep: int | list[int], dims: list[int]) -> State:
-        """Reduce onto subsystem(s) *keep* via ``Qobj.ptrace`` (partial trace).
-
-        Rebuilds the composite *dims* when the incoming state carries flat dims.
-        """
         # QuTiP's Qobj.ptrace needs the correct composite dims. Rebuild when the
         # incoming state carries flat dims (as when assembled outside tensor).
         if isinstance(state, Qobj):
@@ -527,12 +513,6 @@ class QuTiPBackend(Backend):
         return state.ptrace(keep)
 
     def permute_state(self, state: State, dims: Sequence[int], order: Sequence[int]) -> State:
-        """Reorder a ``Qobj``'s subsystems via ``Qobj.permute`` (sparse-friendly, keeps dims).
-
-        Rebuilds composite ``dims`` first when the incoming state carries
-        flat dims, mirroring :meth:`ptrace`. Non-``Qobj`` inputs fall
-        through to the protocol default.
-        """
         if not isinstance(state, Qobj):
             return super().permute_state(state, dims, order)
         dims = list(dims)
@@ -542,7 +522,6 @@ class QuTiPBackend(Backend):
         return state.permute(list(order))
 
     def tensor(self, *operators: Operator) -> Operator:
-        """Return the tensor product of operators via ``qutip.tensor`` (array-likes coerced first)."""
         return qutip.tensor([self.coerce_operator(op) for op in operators])
 
     # ------------------------------------------------------------------
@@ -556,11 +535,6 @@ class QuTiPBackend(Backend):
         index_b: int,
         dims: Sequence[int],
     ) -> Operator:
-        """Embed a two-body operator on devices *index_a* ⊗ *index_b* into the full space.
-
-        Reorders subsystems (via sparse SWAP when ``index_a > index_b``) and
-        identity-pads spectators without densifying the full matrix.
-        """
         op_ordered, first_idx, second_idx = self._reorder_two_body_op(op_ab, index_a, index_b, dims)
         return self._embed_ordered_two_body(op_ordered, first_idx, second_idx, dims)
 
@@ -626,28 +600,22 @@ class QuTiPBackend(Backend):
     # ------------------------------------------------------------------
 
     def basis(self, n: int, k: int) -> State:
-        """Return the Fock basis ket |k⟩ in an *n*-level space (``qutip.basis``)."""
         return qutip.basis(n, k)
 
     def tensor_states(self, *states: State) -> State:
-        """Return the tensor product of states via ``qutip.tensor``."""
         return qutip.tensor(list(states))
 
     def coherent(self, n: int, alpha: complex) -> State:
-        """Return the coherent state |α⟩ truncated to *n* Fock levels (``qutip.coherent``)."""
         return qutip.coherent(n, alpha)
 
     def state_to_dm(self, state: State) -> State:
-        """Return a density matrix; pass through if *state* is already one."""
         state = self.coerce_state(state)
         return state if not state.isket else qutip.ket2dm(state)
 
     def is_ket(self, state: State) -> bool:
-        """Return whether *state* is a ket rather than a density matrix; foreign arrays go by shape."""
         return state.isket if isinstance(state, Qobj) else super().is_ket(state)
 
     def is_native_state(self, state: Any) -> bool:
-        """Return whether *state* is a QuTiP quantum object."""
         return isinstance(state, Qobj)
 
     # ------------------------------------------------------------------
@@ -661,30 +629,27 @@ class QuTiPBackend(Backend):
         metadata: dict[str, Any],
         tlist: Any,
     ) -> dict[str, Any]:
-        """Fill in ``nsteps`` and ``max_step`` from Hamiltonian-metadata heuristics when unset.
+        r"""Resolve QuTiP integration options without changing the input mapping.
 
-        ``nsteps`` is an abort ceiling on the integrator's total internal
-        step count, not a step-size bound — see :func:`default_solver_steps`
-        for the heuristic that derives it from the Hamiltonian's fastest
-        frequency scale.
+        Parameters
+        ----------
+        options : dict
+            Native QuTiP settings, including ``method``, ``atol``, ``rtol``,
+            ``nsteps`` (step ceiling), and ``max_step`` (ns). Unspecified step
+            controls use engine hints. Explicit settings take precedence.
+            See `QuTiP solver options
+            <https://qutip.readthedocs.io/en/stable/apidoc/solver.html>`_ for
+            method-specific keys. Use the simulation's ``states`` argument to
+            select saved-state storage.
+        metadata : dict
+            Lowering hints, including ordinary-GHz spectral/carrier bounds.
+        tlist : array_like
+            Save-time grid in ns used to estimate integration budgets.
 
-        ``max_step`` bounds the size of an individual adaptive step. Without
-        it, QuTiP's adaptive integrator can step clean over a finite-support
-        pulse that sits inside a long idle span, sampling it only at points
-        where its envelope happens to be near zero. When the user has not
-        set ``max_step`` and ``metadata["max_step_ns"]`` carries a concrete,
-        positive, finite value — half the narrowest window across the
-        Hamiltonian's dynamic terms, computed by
-        :func:`~quchip.engine.solver_hints._solver_hint_metadata` — it is
-        used as the ceiling. An explicit user ``max_step`` is always
-        authoritative, including QuTiP's own ``max_step=0`` (unbounded):
-        the key's *presence* in ``options`` decides, not its truthiness.
-
-        The automatic step-count budget also covers this step-size cap.
-        An explicit ``nsteps`` remains authoritative.
-
-        Unsupported options are left for the native solver to reject;
-        explicit numerical controls are never removed for portability.
+        Returns
+        -------
+        dict
+            Copied options with missing integration defaults filled.
         """
         resolved = dict(options)
         if "nsteps" not in resolved:
@@ -750,12 +715,6 @@ class QuTiPBackend(Backend):
     _default_nsteps = staticmethod(default_solver_steps)
 
     def coerce_state(self, state: State, dims: tuple[int, ...] | None = None) -> State:
-        """Wrap a foreign-native array state (ket or density matrix) into a ``Qobj``.
-
-        Used when a per-call ``backend="qutip"`` override consumes states
-        built under the dynamiqs backend. ``dims`` restores the tensor
-        structure QuTiP's solvers require to match the Hamiltonian's dims.
-        """
         if isinstance(state, Qobj):
             return state
         arr = np.asarray(state)
@@ -777,7 +736,6 @@ class QuTiPBackend(Backend):
         e_ops: list[Operator] | None = None,
         options: dict[str, Any] | None = None,
     ) -> SolverResult:
-        """Solve the Schrödinger equation — wraps ``qutip.solver.sesolve.SESolver``."""
         runner = SESolver(self._coerce_solver_rhs(H), options=self._runner_options(options))
         result = runner.run(psi0, tlist, e_ops=e_ops)
         return self._wrap_result(result, solver="sesolve", extra_stats=self._solver_stats(runner))
@@ -791,7 +749,6 @@ class QuTiPBackend(Backend):
         e_ops: list[Operator] | None = None,
         options: dict[str, Any] | None = None,
     ) -> SolverResult:
-        """Solve the Lindblad master equation — wraps ``qutip.solver.mesolve.MESolver``."""
         runner = MESolver(self._coerce_solver_rhs(H), c_ops, options=self._runner_options(options))
         result = runner.run(rho0, tlist, e_ops=e_ops)
         return self._wrap_result(result, solver="mesolve", extra_stats=self._solver_stats(runner))
@@ -812,7 +769,32 @@ class QuTiPBackend(Backend):
         return sparse.csr_matrix(liouvillian.data.to_array())
 
     def steadystate(self, problem: Any, *, prepared: PreparedStationary | None = None) -> SteadyStateSolverResult:
-        """Solve a static Lindblad generator with :func:`qutip.steadystate`."""
+        r"""Solve a static Lindblad generator with :func:`qutip.steadystate`.
+
+        Parameters
+        ----------
+        problem : SteadyStateProblem
+            Captured static model, observables, and stationary solver options.
+        prepared : PreparedStationary or None, default None
+            Matching prepared generator; ``None`` builds it.
+
+        Returns
+        -------
+        SteadyStateSolverResult
+            Stationary density matrix and convergence diagnostics.
+
+        See Also
+        --------
+        quchip.backend.protocol.Backend.steadystate
+
+        Notes
+        -----
+        ``problem.options`` accepts native QuTiP stationary-solver keywords,
+        including ``method`` (default ``"direct"``) and ``solver`` (default None).
+        quchip consumes ``rank_tolerance`` (singular-value cutoff, default automatic)
+        and ``diagnostic_max_dimension`` (default 16). Nullity is not computed above
+        that Hilbert dimension; ``None`` means unchecked, not a unique state.
+        """
         liouvillian = self.prepare_stationary(problem.engine_result, prepared=prepared).liouvillian
         options = dict(problem.options)
         rank_tolerance = options.pop("rank_tolerance", None)
@@ -866,7 +848,6 @@ class QuTiPBackend(Backend):
         return float(stationary_condition_number(liouvillian, math.prod(engine_result.dims), xp=np))
 
     def linear_response(self, problem: Any) -> LinearResponseSolverResult:
-        """Solve passive-linear scattering with batched NumPy mode matrices."""
         return linear_response(problem, xp=np)
 
     def stationary_resolvent(
@@ -878,7 +859,6 @@ class QuTiPBackend(Backend):
         *,
         prepared: PreparedStationary | None = None,
     ) -> dict[tuple[str, str], Any]:
-        """Evaluate stationary resolvents with QuTiP's sparse Liouvillian."""
         liouvillian = self.prepare_stationary(engine_result, prepared=prepared).liouvillian
         matrix = self._scipy_liouvillian(liouvillian)
         native_sources = [(label, self.from_canonical_operator(operator)) for label, operator in sources]
@@ -929,7 +909,6 @@ class QuTiPBackend(Backend):
         *,
         prepared: PreparedStationary | None = None,
     ) -> dict[str, Any]:
-        """Propagate regression operators with QuTiP's sparse Liouvillian."""
         liouvillian = self.prepare_stationary(engine_result, prepared=prepared).liouvillian
         matrix = self._scipy_liouvillian(liouvillian)
         initial_operator = self.from_canonical_operator(initial)
@@ -979,7 +958,25 @@ class QuTiPBackend(Backend):
         *,
         progress: bool = True,
     ) -> list[SolverResult] | None:
-        """Solve large structurally heterogeneous problem lists through loky workers."""
+        r"""Solve large structurally heterogeneous problem lists through loky workers.
+
+        Parameters
+        ----------
+        problems
+            Problems that cannot be merged into one structural batch.
+        progress
+            Display solver progress when supported.
+
+        Returns
+        -------
+        list[SolverResult] | None
+            Backend results in input order, or ``None`` to retain the engine's
+            structural-group dispatch.
+
+        See Also
+        --------
+        quchip.backend.protocol.Backend.parallel_solve_problems
+        """
         if len(problems) < self._PARALLEL_MIN_BATCH:
             return None
         return self._parallel_map(
@@ -997,7 +994,6 @@ class QuTiPBackend(Backend):
         n_jobs: int = -1,
         progress: bool = True,
     ) -> list[SolverResult]:
-        """Run sesolve in parallel via loky workers; fall back to sequential on failure."""
         return self._batched_solve(problems, solver_fn="sesolve", n_jobs=n_jobs, progress=progress)
 
     def batched_mesolve(
@@ -1007,7 +1003,6 @@ class QuTiPBackend(Backend):
         n_jobs: int = -1,
         progress: bool = True,
     ) -> list[SolverResult]:
-        """Run mesolve in parallel via loky workers; fall back to sequential on failure."""
         return self._batched_solve(problems, solver_fn="mesolve", n_jobs=n_jobs, progress=progress)
 
     def _batched_solve(
@@ -1037,7 +1032,7 @@ class QuTiPBackend(Backend):
         description: Any,
         tlist: Any | None = None,
     ) -> PreparedHamiltonian:
-        """Convert a :class:`EngineResult` into a ``Qobj`` or ``QobjEvo``.
+        r"""Convert a :class:`EngineResult` into a ``Qobj`` or ``QobjEvo``.
 
         Each dynamic coefficient is band-normalized: every carrier stays
         analytic while only its slow, carrier-free envelope is sampled
@@ -1046,6 +1041,22 @@ class QuTiPBackend(Backend):
         avoids cubic-spline error from pre-sampling the full
         ``envelope·carrier`` product, including for resonant carriers in the
         lab frame.
+
+        Parameters
+        ----------
+        description : EngineResult
+            Captured engine Hamiltonian and channels in solver units.
+        tlist : array_like
+            Requested save times in ns, used by native time-dependent lowering.
+
+        Returns
+        -------
+        PreparedHamiltonian
+            Native right-hand side and numerical integration hints.
+
+        See Also
+        --------
+        quchip.backend.protocol.Backend.prepare_hamiltonian
         """
         static_rhs = self._sum_terms(description.static_terms, self._canonical_to_qobj)
         metadata = dict(description.metadata)
@@ -1064,7 +1075,7 @@ class QuTiPBackend(Backend):
         return PreparedHamiltonian(rhs=rhs, metadata=metadata)
 
     def prepare_batch(self, batch: Any) -> DeferredBatch:
-        """Build a deferred-construction batch; per-element ``QobjEvo`` is built in workers.
+        r"""Build a deferred-construction batch; per-element ``QobjEvo`` is built in workers.
 
         Each unique :class:`CanonicalOperator` is converted exactly once
         (shared across elements) and only the slow, carrier-free envelope
@@ -1072,6 +1083,20 @@ class QuTiPBackend(Backend):
         edge (carriers stay analytic — see :func:`_band_coefficient`).
         Final ``QobjEvo`` assembly lives in :meth:`solve_batch` so larger
         concrete sweeps can build and solve each point inside loky workers.
+
+        Parameters
+        ----------
+        batch : SolveBatch
+            Batch of captured problems with compatible save grids.
+
+        Returns
+        -------
+        PreparedBatch
+            Eager, native-vectorized, or deferred representation selected by this backend.
+
+        See Also
+        --------
+        quchip.backend.protocol.Backend.prepare_batch
         """
         cached_qobj = self._make_op_cache()
         engine_results = tuple(problem.engine_result for problem in batch.problems)
@@ -1107,7 +1132,24 @@ class QuTiPBackend(Backend):
         )
 
     def solve_batch(self, batch: Any, *, progress: bool = True) -> list[SolverResult]:
-        """Solve a :class:`SolveBatch` with per-element ``QobjEvo`` built in loky workers."""
+        r"""Solve a :class:`SolveBatch` with per-element ``QobjEvo`` built in loky workers.
+
+        Parameters
+        ----------
+        batch : SolveBatch
+            Captured problems and batch parameter values.
+        progress : bool, default True
+            Request a batch progress display.
+
+        Returns
+        -------
+        list of SolverResult
+            Results in batch order.
+
+        See Also
+        --------
+        quchip.backend.protocol.Backend.solve_batch
+        """
         if batch.batch_size == 0:
             return []
 
@@ -1215,17 +1257,12 @@ class QuTiPBackend(Backend):
     # ------------------------------------------------------------------
 
     def warmup(self, n_jobs: int = -1) -> None:
-        """Pre-spawn the reusable loky worker pool out of any timed region.
+        """Start the reusable solver pool.
 
-        Entirely optional: ``solve_batch`` spins the pool up on demand, so
-        the only reason to call this is to move that one-time spin-up cost
-        out of a region you are timing (benchmarks). Ordinary scripts and
-        notebooks never need it.
-
-        Forks the workers and pays the per-worker import cost up front by
-        mapping a no-op over the worker count. A subsequent sweep then reuses
-        the live pool instead of paying cold spin-up inside the timed solve.
-        No-op (with a warning) when loky is unavailable.
+        Parameters
+        ----------
+        n_jobs : int, default -1
+            Worker count; ``-1`` selects all CPUs.
         """
         try:
             executor = self._get_executor(n_jobs)

--- a/quchip/chip/analysis.py
+++ b/quchip/chip/analysis.py
@@ -264,6 +264,13 @@ class KerrMatrix:
     ``labels`` follows chip device order. ``values`` is a real symmetric
     square array: diagonal entries are dressed anharmonicities and
     off-diagonal entries are full-pull cross-Kerr shifts.
+
+    Parameters
+    ----------
+    labels : tuple[str, ...]
+        Device labels in chip order.
+    values : array-like
+        Real symmetric Kerr matrix in GHz.
     """
 
     labels: tuple[str, ...]
@@ -356,6 +363,11 @@ class ChipAnalysis:
     covering backend identity and the ``state_version`` of every device
     and coupling. Any mutation that bumps a version
     invalidates the cache on next access.
+
+    Parameters
+    ----------
+    chip : Chip
+        Chip whose exact static lab-frame Hamiltonian is analyzed.
     """
 
     def __init__(self, chip: "Chip") -> None:
@@ -740,6 +752,13 @@ class ChipAnalysis:
         this is safe inside ``jax.jit``/``grad``/``vmap`` — gradients
         flow through ``eigenvalues[labeling.indices[bare_idx]]`` to any
         traced chip parameters.
+
+        Parameters
+        ----------
+        device_states : mapping or None, default=None
+            Bare product-state levels; unspecified devices use level zero.
+        **device_state_kwargs : int
+            Per-device energy levels keyed by label.
         """
         resolved = normalize_device_state_mapping(self._chip, device_states, device_state_kwargs)
         label_t = self._label_from_plain_mapping(resolved)
@@ -814,12 +833,26 @@ class ChipAnalysis:
         /,
         **device_state_kwargs: int,
     ) -> int | None:
-        """Dressed-state index assigned to a bare label, or ``None`` if unassigned."""
+        """Return the dressed index assigned to a bare label.
+
+        Parameters
+        ----------
+        device_states : mapping or None, default=None
+            Bare product-state levels; unspecified devices use level zero.
+        **device_state_kwargs : int
+            Per-device energy levels keyed by label.
+        """
         label = self._state_label_from_mapping(device_states, **device_state_kwargs)
         return self._ensure_dressed().state_map.get(label)
 
     def bare_label(self, dressed_index: int) -> tuple[int, ...]:
-        """Bare-state label assigned to a dressed-state index."""
+        """Return the bare label assigned to a dressed index.
+
+        Parameters
+        ----------
+        dressed_index : int
+            Index in ascending dressed-energy order.
+        """
         if isinstance(dressed_index, bool) or not isinstance(dressed_index, int):
             raise TypeError(f"dressed_index must be an integer, got {type(dressed_index).__name__}")
         try:
@@ -1048,6 +1081,15 @@ class ChipAnalysis:
 
         ``state`` may be an ``int`` (direct dressed index) or a mapping
         of ``{device: Fock}`` (dressed index resolved via label matching).
+
+        Parameters
+        ----------
+        state : int, mapping, or None, default=None
+            Dressed index or bare label; ``None`` uses keyword levels.
+        n_components : int, default=5
+            Maximum number of components returned.
+        **device_state_kwargs : int
+            Per-device energy levels keyed by label.
         """
         if n_components <= 0:
             raise ValueError(f"n_components must be positive, got {n_components}")
@@ -1181,7 +1223,13 @@ class ChipAnalysis:
         return 0.5 * (effective + effective.conj().T)
 
     def dressed_anharmonicity(self, device: str | BaseDevice) -> float:
-        """Dressed anharmonicity (GHz): ``E_2 − 2·E_1 + E_0``, others grounded."""
+        """Return dressed anharmonicity in GHz.
+
+        Parameters
+        ----------
+        device : str or BaseDevice
+            Device label or object; all other devices are grounded.
+        """
         index, _ = self._chip._resolve_device_index(device)
         eigenvalues, _, _, kernel_labeling = self._compute_array_labeled()
         return kerr_entry(
@@ -1203,6 +1251,15 @@ class ChipAnalysis:
 
         Unspecified spectators are grounded. The target cannot appear in
         ``when``. Traceable under ``jit``/``grad``/``vmap``.
+
+        Parameters
+        ----------
+        target : str or BaseDevice
+            Device whose transition is measured.
+        lower, upper : int
+            Lower and upper local energy levels.
+        when : dict or None, default=None
+            Conditioning levels for spectator devices.
         """
         idx_target, target_device = self._chip._resolve_device_index(target)
         _validate_level_pair(lower, upper, self._semantic_dims()[idx_target])
@@ -1307,6 +1364,13 @@ class ChipAnalysis:
         Safe inside ``jax.jit``/``grad``/``vmap``: under tracing the
         eigenvector column is selected through the array kernel, so a
         dressed initial state is differentiable end-to-end.
+
+        Parameters
+        ----------
+        device_states : mapping, str, or None, default=None
+            Bare product-state label used for dressed assignment.
+        **device_state_kwargs : int
+            Per-device energy levels keyed by label.
         """
         resolved = normalize_device_state_mapping(self._chip, device_states, device_state_kwargs)
         self._label_from_resolved(resolved)

--- a/quchip/chip/baths.py
+++ b/quchip/chip/baths.py
@@ -139,7 +139,13 @@ class Bath:
         super().__setattr__(name, value)
 
     def resolve_targets(self, chip: "Chip") -> list[str]:
-        """Return the ordered target device labels (defaults to all devices)."""
+        """Return ordered target labels, defaulting to all devices.
+
+        Parameters
+        ----------
+        chip : Chip
+            Chip supplying labels when targets were omitted.
+        """
         if self._targets is None or self._retained is not None:
             return [d.label for d in chip.devices]
         return [resolve_label(t) for t in self._targets]
@@ -183,7 +189,13 @@ class Bath:
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "Bath":
-        """Reconstruct a bath from serialized state (targets as label strings)."""
+        """Reconstruct a bath from serialized state.
+
+        Parameters
+        ----------
+        d : dict[str, Any]
+            Payload produced by :meth:`to_dict`; targets are label strings.
+        """
         bath = cls(
             d["recipe"],
             targets=d.get("targets"),
@@ -259,7 +271,15 @@ class Bath:
         }
 
     def set_parameter_value(self, name: str, value: Any) -> None:
-        """Apply one bath value on an isolated bath copy."""
+        """Apply one bath value on an isolated bath copy.
+
+        Parameters
+        ----------
+        name : {"temperature", "rate"}
+            Local parameter name.
+        value : Any
+            Temperature in mK or rate in 1/ns.
+        """
         if name not in self._parameter_names:
             raise KeyError(name)
         setattr(self, name, value)
@@ -349,6 +369,13 @@ class Bath:
 
         Contributions remain backend-neutral; the engine projects and lowers
         them with the same basis records used for Hamiltonian terms.
+
+        Parameters
+        ----------
+        chip : Chip
+            Chip whose targets and tensor-product order define the operators.
+        bases : mapping or None, default=None
+            Captured basis records keyed by device label. ``None`` resolves them.
         """
         fields = {name: Parameter() for name in self._parameter_names}
         p = ParameterNamespace(f"bath.{self.label}", fields)
@@ -419,7 +446,15 @@ class Bath:
         chip: "Chip",
         bases: Mapping[str, Any] | None = None,
     ) -> tuple[CollapseChannel, ...]:
-        """Return normalized full-chip bath channels."""
+        """Return normalized full-chip bath channels.
+
+        Parameters
+        ----------
+        chip : Chip
+            Chip whose targets define the channels.
+        bases : mapping or None, default=None
+            Captured basis records, or ``None`` to resolve them.
+        """
         return tuple(
             channel
             for channel, _paths in self._collapse_channels_with_paths(chip, bases)

--- a/quchip/chip/chip.py
+++ b/quchip/chip/chip.py
@@ -137,21 +137,8 @@ def _frame_cache_value(frame: Any) -> Any:
 class Chip:
     """Composite quantum system: devices + couplings + (optional) control.
 
-    The chip is the primary user-facing object. It exposes:
-
-    - structural access (:attr:`devices`, :attr:`couplings`, :attr:`dims`),
-    - Hamiltonian construction (:meth:`hamiltonian`),
-    - dressed-state analysis (:meth:`dress`, :meth:`energy`, :meth:`freq`, …)
-      delegated to :class:`~quchip.chip.analysis.ChipAnalysis`,
-    - state factories (:meth:`state`, :meth:`bare_state`),
-    - observable construction (:meth:`observable`, :meth:`e_ops`),
-    - solver surface (:meth:`solve`, :meth:`solve_many`, :meth:`steadystate`),
-    - control wiring (:meth:`wire`, :meth:`connect`),
-    - serialization / cloning (:meth:`to_dict`, :meth:`from_dict`,
-      :meth:`clone`, :meth:`updated`).
-
-    Methods that accept a device reference take either a device object
-    **or** its label string; object references are preferred in examples.
+    Device arguments accept an object or its label. The ordered device list
+    fixes tensor-product positions.
 
     Parameters
     ----------
@@ -401,6 +388,13 @@ class Chip:
         ``frame=None`` uses :attr:`frame`; an explicit frame resolves this
         snapshot only. ``approximation=None`` likewise uses the chip default.
         Neither override mutates chip intent.
+
+        Parameters
+        ----------
+        frame : FrameSpec or None, default=None
+            Snapshot frame, or ``None`` to use :attr:`frame`.
+        approximation : Approximation or None, default=None
+            Snapshot approximation, or ``None`` to use :attr:`approximation`.
         """
         return self._resolve(frame=frame, approximation=approximation)
 
@@ -564,6 +558,11 @@ class Chip:
         (polaron-frame) master equation, and applies chip-wide regardless of
         which components carry noise — see the ``"chip"`` entry of
         :meth:`physics_notes`.
+
+        Parameters
+        ----------
+        bases : mapping or None, default=None
+            Captured basis records, or ``None`` to resolve them.
         """
         return [
             (operator, rate, support, source, channel, parameter_paths)
@@ -708,7 +707,13 @@ class Chip:
         return self._coupling_map
 
     def coupling(self, coupling: "str | BaseCoupling") -> "BaseCoupling":
-        """Return a coupling by label or object."""
+        """Return a coupling by label or object.
+
+        Parameters
+        ----------
+        coupling : str or BaseCoupling
+            Coupling label or object.
+        """
         label = resolve_label(coupling)
         if label not in self._coupling_map:
             raise KeyError(
@@ -777,7 +782,13 @@ class Chip:
         return self._basis
 
     def resolve_basis(self, device: str | BaseDevice) -> Literal["native", "eigen"]:
-        """Resolve a device override against the chip basis policy."""
+        """Resolve a device override against the chip basis policy.
+
+        Parameters
+        ----------
+        device : str or BaseDevice
+            Device label or object.
+        """
         resolved = self[device]
         return resolved.resolved_basis(self._basis)
 
@@ -802,7 +813,13 @@ class Chip:
         return self._port_network
 
     def port(self, port: str | Port) -> Port:
-        """Return one declared port by object or label."""
+        """Return one declared port by object or label.
+
+        Parameters
+        ----------
+        port : str or Port
+            Port label or object.
+        """
         label = resolve_label(port)
         for candidate in self.ports:
             if candidate.label == label:
@@ -810,7 +827,13 @@ class Chip:
         raise KeyError(f"No port labeled '{label}'. Available: {[candidate.label for candidate in self.ports]}")
 
     def connect_network(self, network: PortNetwork) -> None:
-        """Attach the chip's one complete accessible field boundary."""
+        """Attach the chip's one complete accessible field boundary.
+
+        Parameters
+        ----------
+        network : PortNetwork
+            Network whose ports target this chip.
+        """
         if not isinstance(network, PortNetwork):
             raise TypeError(f"Expected a PortNetwork, got {type(network).__name__}: {network!r}")
         if self._port_network is not None:
@@ -831,6 +854,13 @@ class Chip:
     def add_bath(self, bath: Bath) -> Bath:
         """Attach a bath to this chip and return it (for fluent use).
 
+        Parameters
+        ----------
+        bath : Bath
+            Shared or collective dissipation model targeting this chip.
+
+        Notes
+        -----
         Baths may be added at any time after construction — the next
         simulate/solve collects the bath's collapse operators automatically,
         no rebuild needed. The bath is validated immediately: a non-``Bath``
@@ -876,38 +906,23 @@ class Chip:
     ) -> None:
         """Replace this chip's entire noise description in one call.
 
-        The call is the chip's complete noise state: for every device, each
-        noise parameter (see
-        :meth:`~quchip.devices.base.BaseDevice.noise_parameter_names`) is set
-        from *config* when given and reset to ``None`` otherwise, and the
-        chip's baths become exactly *baths* (omitted → no baths).
-        ``chip.set_noise()`` therefore clears all noise. Re-running the same
-        call is a silent no-op, so notebook cells converge instead of
-        stacking duplicate baths.
-
-        Only dissipation knobs are reachable — a key that is not a noise
-        parameter of that device (e.g. ``freq``) raises, so an optimized
-        Hamiltonian cannot be perturbed by this call. The full target state
-        is validated *before* anything is written (the same checks the
-        constructors run); on error the chip is left exactly as it was.
-        Applied changes are printed one per line; a no-op prints nothing.
-
-        Custom dissipation is supported by declaring it on the device class
-        beforehand with a ``parameter(noise=True)`` rate field and a
-        :meth:`~quchip.devices.base.BaseDevice.dissipation` override. The
-        declared rate is then an ordinary noise parameter here:
-        sweepable, differentiable, serializable. Runtime closure-style
-        channels are deliberately not supported — their rates could be
-        neither swept, nor differentiated, nor serialized.
+        Omitted device noise fields reset to ``None`` and omitted ``baths``
+        clears all baths. The complete target state is validated before any
+        write. Custom noise rates must be declared with
+        ``parameter(noise=True)`` and implemented by
+        :meth:`~quchip.devices.base.BaseDevice.dissipation` so they remain
+        sweepable, differentiable, and serializable.
+        Applied changes are printed; repeating the same call is a silent no-op.
 
         Parameters
         ----------
         config : mapping, optional
             ``{device_or_label: {noise_param: value}}``. Devices may appear
-            as objects or labels, once each.
+            as objects or labels, once each. Non-noise parameters are rejected.
         baths : list[Bath], optional
             The chip's complete new bath list (validated like
             :meth:`add_bath`).
+
         """
         # Resolve config keys (objects or labels; each device at most once).
         resolved: dict[str, Mapping[str, Any]] = {}
@@ -978,7 +993,13 @@ class Chip:
         return self._control_equipment.crosstalks
 
     def device_index(self, label: str | BaseDevice) -> int:
-        """Tensor-product index of a device. Accepts a label string or object."""
+        """Return a device's tensor-product index.
+
+        Parameters
+        ----------
+        label : str or BaseDevice
+            Device label or object.
+        """
         return self._resolve_device_index(label)[0]
 
     def _resolve_device_index(self, device: str | BaseDevice) -> tuple[int, BaseDevice]:
@@ -1008,7 +1029,21 @@ class Chip:
         values: str = "bare",
         **kwargs: Any,
     ) -> str:
-        """Render chip topology — delegates to :mod:`quchip.viz.chip`."""
+        """Render chip topology through :mod:`quchip.viz.chip`.
+
+        Parameters
+        ----------
+        path : str, default="chip_topology.html"
+            Output HTML path.
+        full : bool, default=True
+            Include the complete topology view.
+        exclude : set[str] or None, default=None
+            Labels omitted from the rendering.
+        values : str, default="bare"
+            Parameter-value view forwarded to the renderer.
+        **kwargs : Any
+            Additional renderer options.
+        """
         from quchip.viz.chip import plot_graph
 
         return plot_graph(
@@ -1021,7 +1056,15 @@ class Chip:
         )
 
     def plot_energy_levels(self, *, ax: Any = None, **kwargs: Any) -> Any:
-        """Render dressed spectrum — delegates to :mod:`quchip.viz.chip`."""
+        """Render the dressed spectrum through :mod:`quchip.viz.chip`.
+
+        Parameters
+        ----------
+        ax : object or None, default=None
+            Matplotlib axes; ``None`` creates axes.
+        **kwargs : Any
+            Additional renderer options.
+        """
         from quchip.viz.chip import plot_energy_levels
 
         return plot_energy_levels(self, ax=ax, **kwargs)
@@ -1045,6 +1088,11 @@ class Chip:
 
         Frame changes never alter dressed-state data — dressing is
         always computed from the lab-frame static Hamiltonian.
+
+        Parameters
+        ----------
+        frame : {"lab", "rotating", "auto"}, scalar-like, or mapping
+            Frame specification. Frequencies are in GHz.
         """
         if isinstance(frame, str):
             if frame not in ("lab", "rotating", "auto"):
@@ -1092,7 +1140,17 @@ class Chip:
         force: bool = False,
         labeling: str = "DE",
     ) -> DressedResult:
-        """Diagonalize the exact lab-frame Hamiltonian, independently of :attr:`approximation`."""
+        """Diagonalize the exact lab-frame Hamiltonian.
+
+        Parameters
+        ----------
+        overlap_threshold : float, default=0.5
+            Minimum bare-state overlap used for labels.
+        force : bool, default=False
+            Recompute even when a valid result is cached.
+        labeling : {"DE"}, default="DE"
+            Confidence-ordered row-greedy overlap assignment.
+        """
         return self._analysis.dress(
             overlap_threshold=overlap_threshold,
             force=force,
@@ -1113,7 +1171,15 @@ class Chip:
         /,
         **device_state_kwargs: int,
     ) -> float:
-        """Dressed eigenenergy (GHz) for a bare-state label. See :meth:`ChipAnalysis.energy`."""
+        """Return dressed eigenenergy in GHz for a bare-state label.
+
+        Parameters
+        ----------
+        device_states : mapping, optional
+            Device labels or objects mapped to levels.
+        **device_state_kwargs : int
+            Device-label keyword levels.
+        """
         return self._analysis.energy(device_states, **device_state_kwargs)
 
     def dressed_spectrum(self) -> Any:
@@ -1126,11 +1192,25 @@ class Chip:
         /,
         **device_state_kwargs: int,
     ) -> int | None:
-        """Dressed-state index matching a bare-state label, or ``None``. See :meth:`ChipAnalysis.dressed_index`."""
+        """Return the matching dressed index, or ``None``.
+
+        Parameters
+        ----------
+        device_states : mapping, optional
+            Device labels or objects mapped to levels.
+        **device_state_kwargs : int
+            Device-label keyword levels.
+        """
         return self._analysis.dressed_index(device_states, **device_state_kwargs)
 
     def bare_label(self, dressed_index: int) -> tuple[int, ...]:
-        """Bare-state label assigned to a dressed-state index. See :meth:`ChipAnalysis.bare_label`."""
+        """Return the bare-state label assigned to a dressed index.
+
+        Parameters
+        ----------
+        dressed_index : int
+            Dressed eigenstate index.
+        """
         return self._analysis.bare_label(dressed_index)
 
     def operator_in_dressed_basis(
@@ -1142,7 +1222,16 @@ class Chip:
     ) -> Operator:
         """Embedded device operator transformed to the dressed eigenbasis.
 
-        See :meth:`ChipAnalysis.operator_in_dressed_basis`.
+        See :meth:`ChipAnalysis.operator_in_dressed_basis` for the owner contract.
+
+        Parameters
+        ----------
+        device : str or BaseDevice
+            Device owning the local operator.
+        op : str or array-like
+            Named or explicit local operator.
+        truncate : int, optional
+            Retain only the lowest dressed states.
         """
         return self._analysis.operator_in_dressed_basis(device, op, truncate=truncate)
 
@@ -1159,8 +1248,15 @@ class Chip:
         elements set the effective driven-Hamiltonian coefficients. See
         E. Magesan and J. M. Gambetta, Phys. Rev. A 101, 052308 (2020),
         DOI 10.1103/PhysRevA.101.052308, and
-        :meth:`ChipAnalysis.drive_matrix_elements` for the transition
-        shorthand, parameters, return type, and error conditions.
+        :meth:`ChipAnalysis.drive_matrix_elements` for the owner contract.
+
+        Parameters
+        ----------
+        transition : str, BaseDevice, or pair of mappings
+            Transition shorthand or explicit lower/upper bare labels.
+        drives : sequence, optional
+            Drive labels or objects to include; defaults to all wired drives.
+
         """
         return self._analysis.drive_matrix_elements(transition, drives=drives)
 
@@ -1172,7 +1268,17 @@ class Chip:
         n_components: int = 5,
         **device_state_kwargs: int,
     ) -> dict[tuple[int, ...], float]:
-        """Leading bare-basis probabilities for a dressed eigenstate. See :meth:`ChipAnalysis.state_components`."""
+        """Return leading bare-basis probabilities for a dressed eigenstate.
+
+        Parameters
+        ----------
+        state : int or mapping, optional
+            Dressed index or bare-state label.
+        n_components : int, default=5
+            Number of largest components to return.
+        **device_state_kwargs : int
+            Device-label keyword levels.
+        """
         return self._analysis.state_components(
             state,
             n_components=n_components,
@@ -1182,7 +1288,10 @@ class Chip:
     def dispersive_shift(self, device_a: str | BaseDevice, device_b: str | BaseDevice) -> float:
         """Dressed cross-Kerr shift (GHz): ``E(1,1) − E(1,0) − E(0,1) + E(0,0)``.
 
-        See :meth:`ChipAnalysis.dispersive_shift`.
+        Parameters
+        ----------
+        device_a, device_b : str or BaseDevice
+            Devices whose dressed cross-Kerr shift is requested.
         """
         return self._analysis.dispersive_shift(device_a, device_b)
 
@@ -1202,6 +1311,11 @@ class Chip:
         """Dressed anharmonicity of one device with others grounded (GHz).
 
         See :meth:`ChipAnalysis.dressed_anharmonicity`.
+
+        Parameters
+        ----------
+        device : str or BaseDevice
+            Device label or object.
         """
         return self._analysis.dressed_anharmonicity(device)
 
@@ -1213,6 +1327,15 @@ class Chip:
         when: dict[str | BaseDevice, int] | None = None,
     ) -> Any:
         """Return a dressed transition in GHz with optional spectator levels.
+
+        Parameters
+        ----------
+        target : str or BaseDevice
+            Device whose transition is requested.
+        lower, upper : int
+            Lower and upper local levels.
+        when : mapping, optional
+            Spectator device levels.
 
         Unspecified spectators are in their ground state. ``target`` and
         entries in ``when`` accept either device objects or labels.
@@ -1234,6 +1357,11 @@ class Chip:
         """Dressed effective Hamiltonian in a labeled bare subspace.
 
         See :meth:`ChipAnalysis.effective_subspace_hamiltonian`.
+
+        Parameters
+        ----------
+        states : sequence of mappings or level tuples
+            Bare labels spanning the requested subspace.
         """
         return self._analysis.effective_subspace_hamiltonian(states)
 
@@ -1256,7 +1384,14 @@ class Chip:
         target: str | BaseDevice | None = None,
         when: dict[str | BaseDevice, int] | None = None,
     ) -> dict[str, float] | float:
-        """All dressed 0→1 frequencies (GHz), or one conditional transition. See :meth:`ChipAnalysis.freq`.
+        """Return dressed 0→1 frequencies in GHz, optionally conditioned on spectators.
+
+        Parameters
+        ----------
+        target : str or BaseDevice, optional
+            Device label or object; omitted returns all frequencies.
+        when : mapping, optional
+            Spectator device levels.
 
         Overloaded: no ``target`` returns the full ``{label: freq}`` dict;
         a single ``target`` (label or device) returns one scalar 0→1
@@ -1325,7 +1460,13 @@ class Chip:
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "Chip":
-        """Reconstruct a chip from :meth:`to_dict` output."""
+        """Reconstruct a chip from :meth:`to_dict` output.
+
+        Parameters
+        ----------
+        d : dict[str, Any]
+            Serialized chip payload.
+        """
         from quchip.chip.serialization import deserialize_chip
 
         return deserialize_chip(d)
@@ -1434,7 +1575,13 @@ class Chip:
         )
 
     def with_params(self, bindings: Mapping[str, Any]) -> "Chip":
-        """Return an isolated structural copy with component-owned values rebound."""
+        """Return an isolated structural copy with values rebound.
+
+        Parameters
+        ----------
+        bindings : mapping[str, Any]
+            Fully qualified parameter paths and replacement values.
+        """
         from quchip.utils.values import copy_value
 
         bindings = dict(bindings)
@@ -1553,6 +1700,13 @@ class Chip:
         that device's subspace and embedded into the full tensor-product
         space. With ``device=None`` the array must already span the full
         chip Hilbert space.
+
+        Parameters
+        ----------
+        data : array-like
+            Local or full-space operator array.
+        device : str, BaseDevice, or None, default=None
+            Local operator owner; ``None`` treats ``data`` as full-space.
         """
         from quchip.chip.observables import from_array
 
@@ -1571,6 +1725,13 @@ class Chip:
         values use :meth:`e_ops`, which keeps operators *local* so the
         demodulation pipeline can band-decompose and embed them
         correctly.
+
+        Parameters
+        ----------
+        device : str or BaseDevice
+            Device whose local space owns the operator.
+        op : str or array-like
+            Named or explicit local operator.
         """
         from quchip.chip.observables import observable
 
@@ -1594,6 +1755,13 @@ class Chip:
         device-label pairs → operator pairs. Returns local-space
         operators (not embedded) — the demodulation pipeline embeds as
         needed.
+
+        Parameters
+        ----------
+        correlators : dict or None, default=None
+            Device-pair keys mapped to pairs of local operator specifications.
+        **specs : str, list, or array-like
+            Device labels mapped to local operator specifications.
 
         Examples
         --------
@@ -1629,6 +1797,13 @@ class Chip:
 
         Every chip device must be named exactly once.
 
+        Parameters
+        ----------
+        *devices : str or BaseDevice
+            All chip devices in shorthand order.
+        levels : mapping[str, int] or None, default=None
+            Extra one-character level symbols and their indices.
+
         Examples
         --------
         >>> from quchip import DuffingTransmon, Resonator, Chip
@@ -1656,6 +1831,11 @@ class Chip:
 
         Unlike :meth:`state`, this stays in the bare product basis — no
         dressed diagonalization — so the probe basis is explicit.
+
+        Parameters
+        ----------
+        *components : mapping, str, or tuple
+            Bare-state specifications, optionally paired with amplitudes.
 
         Examples
         --------
@@ -1694,6 +1874,13 @@ class Chip:
         dressed initial states are differentiable end-to-end. The global
         phase is gauge-dependent (``eigh`` column convention) —
         populations and ``|overlap|`` figures of merit are unaffected.
+
+        Parameters
+        ----------
+        device_states : mapping, str, or None, default=None
+            Product-state level labels used for dressed assignment.
+        **device_state_kwargs : int
+            Per-device energy levels keyed by label.
         """
         from quchip.chip.states import state
 
@@ -1714,6 +1901,13 @@ class Chip:
 
         Accepts a string shorthand (e.g. ``"eg1"``) when
         :meth:`set_state_order` has been called.
+
+        Parameters
+        ----------
+        device_states : mapping, str, or None, default=None
+            Per-device levels or local kets; omitted devices use level zero.
+        **device_state_kwargs : int or State
+            Per-device levels or local kets keyed by label.
         """
         from quchip.chip.states import bare_state
 
@@ -1733,6 +1927,13 @@ class Chip:
         Preferred user-facing API for attaching control to a chip. If
         *lines* is omitted, the existing connected lines are reused and
         only the signal chain is replaced.
+
+        Parameters
+        ----------
+        *lines : BaseDrive
+            Classical control lines to attach.
+        signal_chain : sequence of SignalTransform or None, default=None
+            Ordered classical signal transforms.
 
         Examples
         --------
@@ -1781,6 +1982,11 @@ class Chip:
         object or its label. Returns the removed drive so it can be rewired
         later. Removing the last line detaches the equipment entirely
         (``control_equipment`` becomes ``None``).
+
+        Parameters
+        ----------
+        line : BaseDrive or str
+            Drive object or label to remove.
         """
         if self._control_equipment is None:
             raise ValueError("chip.unwire(...) requires connected control equipment; nothing is wired.")
@@ -1808,6 +2014,11 @@ class Chip:
         Validates every drive target and rejects duplicate drive labels,
         then reconnects each drive to this chip's canonical device or
         coupling instance. User-facing code should prefer :meth:`wire`.
+
+        Parameters
+        ----------
+        control_equipment : ControlEquipment
+            Complete classical control wiring to attach.
         """
         drive_duplicates = [
             lbl for lbl, n in Counter(d.label for d in control_equipment.lines).items() if n > 1
@@ -1908,6 +2119,15 @@ class Chip:
         chokepoint, so the Hilbert-truncation safety net applies by default;
         pass ``check_truncation=False`` to opt out or retune
         ``truncation_threshold``.
+
+        Parameters
+        ----------
+        problem : SolveProblem
+            Prepared problem built for this chip.
+        check_truncation : bool, default=True
+            Check boundary populations after the solve.
+        truncation_threshold : float, default=0.001
+            Maximum allowed boundary population.
         """
         from quchip.engine import solve_problem
 
@@ -1928,6 +2148,17 @@ class Chip:
         was built for *this* chip); the input-shape dispatch and batching are
         delegated to :func:`quchip.engine.solve_many`, which owns the single
         SolveBatch / list dispatch.
+
+        Parameters
+        ----------
+        batch_or_problems : SolveBatch or sequence of SolveProblem
+            Batch or prepared problems built for this chip.
+        progress : bool, default=True
+            Show backend progress where supported.
+        check_truncation : bool, default=True
+            Check boundary populations after each solve.
+        truncation_threshold : float, default=0.001
+            Maximum allowed boundary population.
         """
         from quchip.engine import solve_many
         from quchip.engine.ir import SolveBatch
@@ -1951,7 +2182,19 @@ class Chip:
         frame: FrameSpec | None = None,
         approximation: Approximation | None = None,
     ) -> "SteadyStateResult":
-        """Solve this chip's unique static Lindblad steady state."""
+        """Solve this chip's unique static Lindblad steady state.
+
+        Parameters
+        ----------
+        e_ops : dict or None, default=None
+            Static expectation operators.
+        options : dict or None, default=None
+            Backend solver options.
+        frame : FrameSpec or None, default=None
+            Solve frame, or ``None`` to use the chip default.
+        approximation : Approximation or None, default=None
+            Solve approximation, or ``None`` to use the chip default.
+        """
         from quchip.engine.steady_state import steadystate
 
         return steadystate(
@@ -1971,7 +2214,23 @@ class Chip:
         approximation: Approximation | None = None,
         progress: bool = True,
     ) -> Any:
-        """Solve static Lindblad steady states over parameter sweep axes."""
+        """Solve static Lindblad steady states over parameter sweep axes.
+
+        Parameters
+        ----------
+        *axes : Any
+            Parameter sweep axes accepted by the batch builder.
+        e_ops : dict or None, default=None
+            Static expectation operators.
+        options : dict or None, default=None
+            Backend solver options.
+        frame : FrameSpec or None, default=None
+            Solve frame, or ``None`` to use the chip default.
+        approximation : Approximation or None, default=None
+            Solve approximation, or ``None`` to use the chip default.
+        progress : bool, default=True
+            Show backend progress where supported.
+        """
         from quchip.engine.steady_state import steadystate_batch
 
         return steadystate_batch(

--- a/quchip/chip/coupling_base.py
+++ b/quchip/chip/coupling_base.py
@@ -91,7 +91,13 @@ class BaseCoupling(StateVersioned, Registrable, ABC, registry_root=True):
         self.label = label if label is not None else auto_label(type(self)._type_prefix)
 
     def copy(self, device_map: dict[str, BaseDevice]) -> "BaseCoupling":
-        """Copy authored values and rebind endpoints to *device_map*."""
+        """Copy authored values and rebind endpoints.
+
+        Parameters
+        ----------
+        device_map : dict[str, BaseDevice]
+            Destination devices keyed by label.
+        """
         from quchip.declarative.parameters import copy_authored_fields
 
         cloned = copy.copy(self)
@@ -108,7 +114,15 @@ class BaseCoupling(StateVersioned, Registrable, ABC, registry_root=True):
         return {self.coupling_strength_name: self.coupling_strength}
 
     def set_parameter_value(self, name: str, value: Any) -> None:
-        """Apply one local parameter value on an isolated coupling copy."""
+        """Apply one local parameter value on an isolated coupling copy.
+
+        Parameters
+        ----------
+        name : str
+            Local parameter name.
+        value : Any
+            Replacement value in the parameter's declared units.
+        """
         fields = getattr(type(self), "__quchip_param_fields__", None)
         if fields is not None and name in fields:
             setattr(self, name, value)
@@ -181,6 +195,11 @@ class BaseCoupling(StateVersioned, Registrable, ABC, registry_root=True):
 
         Examples include ``g``, ``g_0``, and ``chi``. Override when the writable
         attribute differs from that name.
+
+        Parameters
+        ----------
+        value : Any
+            Coupling strength in GHz.
         """
         setattr(self, self.coupling_strength_name, value)
 

--- a/quchip/chip/couplings.py
+++ b/quchip/chip/couplings.py
@@ -112,7 +112,15 @@ class Capacitive(CouplingModel):
         return super().default_dressed_target()
 
     def interaction(self, a: EndpointOps, b: EndpointOps, p: Any) -> PhysicsExpr:
-        """Return the full capacitive interaction ``g * (a + a†)(b + b†)``."""
+        """Return the full capacitive interaction ``g * (a + a†)(b + b†)``.
+
+        Parameters
+        ----------
+        a, b : EndpointOps
+            Resolved operators for the two endpoints.
+        p : ParameterNamespace
+            Bound parameters, including ``g`` in GHz.
+        """
         return _full(p.g, a, b)
 
     def physics_notes(self) -> list[str]:
@@ -132,7 +140,15 @@ class Capacitive(CouplingModel):
         device_a: BaseDevice,
         device_b: BaseDevice,
     ) -> "Capacitive":
-        """Reconstruct a capacitive coupling from serialized state."""
+        """Reconstruct a capacitive coupling from serialized state.
+
+        Parameters
+        ----------
+        d : dict[str, Any]
+            Serialized coupling fields.
+        device_a, device_b : BaseDevice
+            Resolved endpoint devices.
+        """
         return cls(
             device_a=device_a,
             device_b=device_b,
@@ -213,11 +229,27 @@ class TunableCapacitive(CouplingModel):
     g_0: Scalar = parameter(default=UNBOUND, unit="GHz", symbol="g_0")
 
     def interaction(self, a: EndpointOps, b: EndpointOps, p: Any) -> PhysicsExpr:
-        """Static contribution ``g_0 · (a + a†)(b + b†)``."""
+        """Return the static ``g_0 · (a + a†)(b + b†)`` contribution.
+
+        Parameters
+        ----------
+        a, b : EndpointOps
+            Resolved endpoint operators.
+        p : ParameterNamespace
+            Bound parameters, including ``g_0`` in GHz.
+        """
         return _full(p.g_0, a, b)
 
     def parametric_interaction(self, a: EndpointOps, b: EndpointOps, p: Any) -> PhysicsExpr:
-        """Modulable charge-charge structure a scheduled pump multiplies."""
+        """Return the charge-charge structure multiplied by a pump.
+
+        Parameters
+        ----------
+        a, b : EndpointOps
+            Resolved endpoint operators.
+        p : ParameterNamespace
+            Bound parameters; unused because the pump supplies the coefficient.
+        """
         _ = p
         return a.charge * b.charge
 
@@ -274,11 +306,27 @@ class CrossKerr(CouplingModel):
     chi: Scalar = parameter(default=UNBOUND, unit="GHz", symbol=r"\chi")
 
     def interaction(self, a: EndpointOps, b: EndpointOps, p: Any) -> PhysicsExpr:
-        """Full form ``χ · n̂_a n̂_b`` (diagonal; identical under RWA)."""
+        """Return ``χ · n̂_a n̂_b``, identical under RWA.
+
+        Parameters
+        ----------
+        a, b : EndpointOps
+            Resolved endpoint operators.
+        p : ParameterNamespace
+            Bound parameters, including ``chi`` in GHz.
+        """
         return p.chi * (a.level * b.level)
 
     def parametric_interaction(self, a: EndpointOps, b: EndpointOps, p: Any) -> PhysicsExpr:
-        """Modulable structure ``n̂_a n̂_b`` — δχ(t) pumps ride this."""
+        """Return the number-number structure multiplied by a pump.
+
+        Parameters
+        ----------
+        a, b : EndpointOps
+            Resolved endpoint operators.
+        p : ParameterNamespace
+            Bound parameters; unused because the pump supplies the coefficient.
+        """
         _ = p
         return a.level * b.level
 
@@ -323,6 +371,19 @@ class Coupling(_BaseCoupling):
 
     The selected chip approximation is applied to the complete user-supplied
     operator after authored physics is assembled.
+
+    Parameters
+    ----------
+    device_a, device_b : BaseDevice or str
+        Coupled devices or late-bound labels.
+    g : float
+        Scalar interaction strength in GHz.
+    op_a, op_b : callable or None, default=None
+        Local operator factories for product form.
+    interaction : callable or None, default=None
+        Callable receiving both devices and the active backend.
+    label : str or None, default=None
+        Coupling label; generated when omitted.
     """
 
     _type_prefix: ClassVar[str] = "coupling"
@@ -401,7 +462,15 @@ class Coupling(_BaseCoupling):
         device_a: "BaseDevice",
         device_b: "BaseDevice",
     ) -> "Coupling":
-        """Reject deserialization because callables cannot be reconstructed."""
+        """Reject deserialization because callables cannot be reconstructed.
+
+        Parameters
+        ----------
+        d : dict[str, Any]
+            Serialized fields; unsupported for callable interactions.
+        device_a, device_b : BaseDevice
+            Endpoint devices; unused because deserialization is unsupported.
+        """
         raise NotImplementedError(
             "Generic Coupling carries user-defined callables and cannot be deserialized. "
             "Use a concrete coupling subclass for persistent storage."

--- a/quchip/chip/effective.py
+++ b/quchip/chip/effective.py
@@ -135,6 +135,21 @@ class EffectiveTerms:
     its authored terms; it does not recompute this captured correction.
     ``projection`` carries the source coordinates of surviving operators;
     channels already stored here are in retained coordinates and bypass it.
+
+    Parameters
+    ----------
+    labels : tuple[str, ...]
+        Device labels defining the retained tensor-product order.
+    dims : tuple[int, ...]
+        Authored dimensions aligned with ``labels``.
+    hamiltonian : array-like
+        Hermitian retained Hamiltonian in GHz.
+    channels : tuple[CollapseChannel, ...], default=()
+        Retained jump operators and Lindblad rates in 1/ns.
+    label : str, default="effective"
+        Name used for diagnostics and the generated expression.
+    projection : OperatorProjection or None, default=None
+        Captured source-to-retained operator coordinates.
     """
 
     labels: tuple[str, ...]
@@ -188,12 +203,25 @@ class EffectiveTerms:
         object.__setattr__(self, "channels", channels)
 
     def expression(self, matrix: Any = None) -> PhysicsExpr:
-        """Return a captured matrix through the ordinary authored-expression path."""
+        """Return a captured matrix through the authored-expression path.
+
+        Parameters
+        ----------
+        matrix : array-like or None, default=None
+            Matrix in GHz. ``None`` uses :attr:`hamiltonian`.
+        """
         return PhysicsExpr.from_matrix(
             self.hamiltonian if matrix is None else matrix, labels=self.labels, dims=self.dims, name=self.label
         )
 
     def validate_for(self, chip: Any) -> None:
+        """Validate retained labels and dimensions against a chip.
+
+        Parameters
+        ----------
+        chip : Chip
+            Chip that will receive these terms.
+        """
         unknown = set(self.labels) - chip.device_map.keys()
         if unknown:
             raise ValueError(f"Effective terms {self.label!r} target unknown devices {sorted(unknown)}.")
@@ -231,7 +259,13 @@ class EffectiveTerms:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> EffectiveTerms:
-        """Recreate validated retained terms from their numerical payload."""
+        """Recreate validated retained terms from their numerical payload.
+
+        Parameters
+        ----------
+        data : dict[str, Any]
+            Payload produced by :meth:`to_dict`.
+        """
         if set(data) != {"label", "labels", "dims", "hamiltonian", "channels", "projection"}:
             raise ValueError("Invalid serialized EffectiveTerms fields.")
 

--- a/quchip/chip/port_network.py
+++ b/quchip/chip/port_network.py
@@ -41,7 +41,17 @@ TerminalKey = tuple[str, str]
 
 @dataclass(frozen=True)
 class FieldTerminal:
-    """One directional terminal owned by a :class:`PortNetwork`."""
+    """One directional terminal owned by a :class:`PortNetwork`.
+
+    Parameters
+    ----------
+    component : str
+        Owning component label.
+    name : str
+        Component-local terminal name.
+    direction : {"input", "output"}
+        Field-propagation direction.
+    """
 
     component: str
     name: str
@@ -56,7 +66,19 @@ class FieldTerminal:
 
 @dataclass(frozen=True)
 class SLHComponent:
-    """Minimal public boundary component: scalar ``S`` plus named terminals."""
+    """Boundary component with scalar scattering and named terminals.
+
+    Parameters
+    ----------
+    label : str
+        Unique component label.
+    input_names, output_names : tuple[str, ...]
+        Terminal names in scattering column and row order.
+    scattering : array-like
+        Dimensionless scalar scattering matrix.
+    sides : tuple[str, ...], default=()
+        Names pairing physical input and output terminals.
+    """
 
     label: str
     input_names: tuple[str, ...]
@@ -74,7 +96,13 @@ class SLHComponent:
     _transfer: Callable[..., Any] | None = field(default=None, repr=False, compare=False)
 
     def port(self, name: str | int) -> "ComponentPort":
-        """Return a component port with incoming and outgoing field connections."""
+        """Return a component port with both field directions.
+
+        Parameters
+        ----------
+        name : str or int
+            Physical side name.
+        """
         label = str(name)
         if not self.sides:
             raise ValueError(
@@ -86,7 +114,13 @@ class SLHComponent:
         return ComponentPort(self.input_terminal(label), self.output_terminal(label))
 
     def side(self, name: str | int) -> "ComponentPort":
-        """Deprecated alias for :meth:`port`."""
+        """Deprecated alias for :meth:`port`.
+
+        Parameters
+        ----------
+        name : str or int
+            Physical side name.
+        """
         warn_renamed("component.side()", "component.port()")
         return self.port(name)
 
@@ -107,7 +141,13 @@ class SLHComponent:
         )
 
     def input_terminal(self, name: str) -> FieldTerminal:
-        """Return one named input terminal."""
+        """Return one named input terminal.
+
+        Parameters
+        ----------
+        name : str
+            Input terminal name.
+        """
         try:
             index = self.input_names.index(name)
         except ValueError as exc:
@@ -117,7 +157,13 @@ class SLHComponent:
         return self.inputs[index]
 
     def output_terminal(self, name: str) -> FieldTerminal:
-        """Return one named output terminal."""
+        """Return one named output terminal.
+
+        Parameters
+        ----------
+        name : str
+            Output terminal name.
+        """
         try:
             index = self.output_names.index(name)
         except ValueError as exc:
@@ -151,7 +197,13 @@ class SLHComponent:
 
 @dataclass(frozen=True)
 class ComponentPort:
-    """A component port pairing its incoming and outgoing field connections."""
+    """A component port pairing incoming and outgoing field connections.
+
+    Parameters
+    ----------
+    input, output : FieldTerminal
+        Incoming and outgoing terminals on the same physical side.
+    """
 
     input: FieldTerminal
     output: FieldTerminal
@@ -163,6 +215,11 @@ class NetworkPort:
 
     The reference plane specifies where these fields are defined. A device's
     :class:`Port` instead specifies its coupling to the network.
+
+    Parameters
+    ----------
+    label : str
+        External reference-plane label.
     """
 
     label: str
@@ -243,6 +300,11 @@ class IncludedNetwork:
     ``component(name)`` returns a copied component. Template exposures made with
     ``expose(..., at=...)`` are available through ``side(name)``; asymmetric
     exposures use ``input(name)`` and ``output(name)``.
+
+    Parameters
+    ----------
+    prefix : str
+        Label prefix assigned to the included copy.
     """
 
     prefix: str
@@ -250,24 +312,48 @@ class IncludedNetwork:
     _interfaces: Mapping[str, tuple[TerminalKey, TerminalKey]] = field(repr=False, compare=False)
 
     def component(self, name: str) -> SLHComponent:
-        """Return the copied component that was called ``name`` in the template."""
+        """Return a copied template component.
+
+        Parameters
+        ----------
+        name : str
+            Unprefixed template component name.
+        """
         label = f"{self.prefix}/{name}"
         if label not in self._host._components:
             raise KeyError(f"No component {name!r} in block {self.prefix!r}.")
         return self._host._components[label]
 
     def input(self, name: str) -> FieldTerminal:
-        """Return the input terminal of the exported network port ``name``."""
+        """Return an exported input terminal.
+
+        Parameters
+        ----------
+        name : str
+            Template external-port name.
+        """
         key = self._interface(name)[0]
         return self._host._components[key[0]].input_terminal(key[1])
 
     def output(self, name: str) -> FieldTerminal:
-        """Return the output terminal of the exported network port ``name``."""
+        """Return an exported output terminal.
+
+        Parameters
+        ----------
+        name : str
+            Template external-port name.
+        """
         key = self._interface(name)[1]
         return self._host._components[key[0]].output_terminal(key[1])
 
     def port(self, name: str) -> ComponentPort:
-        """Return a component port exported by the network block."""
+        """Return an exported component port.
+
+        Parameters
+        ----------
+        name : str
+            Symmetric template external-port name.
+        """
         input_key, output_key = self._interface(name)
         component = self._host._components[input_key[0]]
         if input_key != output_key or input_key[1] not in component.sides:
@@ -275,7 +361,13 @@ class IncludedNetwork:
         return component.port(input_key[1])
 
     def side(self, name: str) -> ComponentPort:
-        """Deprecated alias for :meth:`port`."""
+        """Deprecated alias for :meth:`port`.
+
+        Parameters
+        ----------
+        name : str
+            Symmetric template external-port name.
+        """
         warn_renamed("block.side()", "block.port()")
         return self.port(name)
 
@@ -330,7 +422,20 @@ class _CompiledNetwork:
 
 
 class PortNetwork:
-    """Ports and an instantaneous scalar-S field-routing graph with algebraic feedback."""
+    """Compose Markovian ports with instantaneous scalar scattering.
+
+    The network acts on fields at one reference frequency. Scattering matrices
+    are dimensionless and must be unitary; loss and noise are represented by
+    explicit hidden channels or reference components. Feedback loops are
+    reduced algebraically, so this class does not model propagation retardation.
+
+    Parameters
+    ----------
+    scattering : array-like or mapping, optional
+        Authored instantaneous scattering matrix or labeled entries.
+    label : str, optional
+        Network label.
+    """
 
     _type_prefix = "port_network"
 
@@ -340,6 +445,17 @@ class PortNetwork:
         scattering: Any = None,
         label: str | None = None,
     ) -> None:
+        """Create an empty network, optionally with an authored scattering map.
+
+        Parameters
+        ----------
+        scattering : array-like or mapping, optional
+            Static scattering matrix, or ``{(output, input): amplitude}``
+            entries keyed by external labels. A callable is rejected because
+            the network is instantaneous.
+        label : str, optional
+            Network label; generated when omitted.
+        """
         self.label = label if label is not None else auto_label(self._type_prefix)
         self._token = object()
         if callable(scattering):
@@ -370,7 +486,23 @@ class PortNetwork:
         scattering: Any = None,
         label: str | None = None,
     ) -> "PortNetwork":
-        """Build an identity-exposed network around existing ports."""
+        """Build a network containing ``ports`` in declaration order.
+
+        Parameters
+        ----------
+        ports : sequence of Port
+            Quantum coupling channels to add. Each port may belong to only one
+            network; pass a copy to reuse it elsewhere.
+        scattering : array-like or mapping, optional
+            Initial external scattering specification.
+        label : str, optional
+            Network label.
+
+        Returns
+        -------
+        PortNetwork
+            Network with the supplied ports and no internal components.
+        """
         network = cls(scattering=scattering, label=label)
         for port in ports:
             network._add_port(port)
@@ -398,12 +530,24 @@ class PortNetwork:
         return self.external_ports
 
     def exposure(self, exposure: str | NetworkPort) -> NetworkPort:
-        """Deprecated alias for :meth:`external_port`."""
+        """Deprecated alias for :meth:`external_port`.
+
+        Parameters
+        ----------
+        exposure : str or NetworkPort
+            External reference plane.
+        """
         warn_renamed("network.exposure()", "network.external_port()")
         return self.external_port(exposure)
 
     def external_port(self, exposure: str | NetworkPort) -> NetworkPort:
-        """Return one external network port by object or label."""
+        """Return one external network port by object or label.
+
+        Parameters
+        ----------
+        exposure : str or NetworkPort
+            External reference plane.
+        """
         if isinstance(exposure, NetworkPort) and exposure._network_token is not self._token:
             raise ValueError(f"Network port {exposure.label!r} belongs to another PortNetwork.")
         label = resolve_label(exposure)
@@ -434,7 +578,15 @@ class PortNetwork:
         return MappingProxyType(values)
 
     def set_parameter_value(self, name: str, value: Any) -> None:
-        """Set one network-owned scalar on an isolated structural copy."""
+        """Set one network-owned scalar on an isolated structural copy.
+
+        Parameters
+        ----------
+        name : str
+            Path below ``scattering`` or ``component``.
+        value : Any
+            Replacement scalar in the component parameter's declared units.
+        """
         parts = name.split(".")
         if (
             len(parts) == 3
@@ -462,7 +614,21 @@ class PortNetwork:
         operator: Any = None,
         phase: Any = 0.0,
     ) -> Port:
-        """Create and return one quantum coupling port owned by this network."""
+        """Create and add one quantum coupling port.
+
+        Parameters
+        ----------
+        label : str
+            Unique port label.
+        target, rate, external_quality_factor, operator, phase
+            See :class:`~quchip.chip.ports.Port`.
+
+        Returns
+        -------
+        Port
+            The network-owned port, whose ``input``, ``output`` and ``side``
+            terminals can be connected immediately.
+        """
         port = Port(
             target,
             rate=rate,
@@ -481,7 +647,25 @@ class PortNetwork:
         scattering: Any,
         terminals: Sequence[str] | None = None,
     ) -> SLHComponent:
-        """Add a zero-coupling scalar scattering component."""
+        """Add a scalar scattering component with named terminals.
+
+        Parameters
+        ----------
+        label : str
+            Unique component label.
+        scattering : square array-like
+            Dimensionless scattering matrix. Rows are outputs and columns are
+            inputs; concrete matrices must be unitary.
+        terminals : sequence of str, optional
+            Names for both input and output terminals. Defaults to ``("signal",)``
+            for one channel and numeric names otherwise.
+
+        Returns
+        -------
+        SLHComponent
+            Component handle used with :meth:`connect`, :meth:`cascade`, or
+            :meth:`link`.
+        """
         return self._scattering_component(label, scattering=scattering, terminals=terminals, kind="scattering")
 
     def _scattering_component(
@@ -512,11 +696,25 @@ class PortNetwork:
         return self._add_component(component)
 
     def through(self, label: str) -> SLHComponent:
-        """Add a one-channel identity through component."""
+        """Add a one-channel identity through component.
+
+        Parameters
+        ----------
+        label : str
+            Component label.
+        """
         return self._scattering_component(label, scattering=[[1.0]], terminals=("signal",), kind="through")
 
     def phase_shift(self, label: str, *, phase: Any) -> SLHComponent:
-        """Add a one-channel phase shift."""
+        """Add a one-channel phase shift.
+
+        Parameters
+        ----------
+        label : str
+            Component label.
+        phase : float or array-like
+            Phase in radians.
+        """
         xp = select_array_module(contains_tracer(phase))
         return self._scattering_component(
             label,
@@ -533,6 +731,13 @@ class PortNetwork:
         ``t = sqrt(eta)`` and ``r = sqrt(1 - eta)``, the scattering matrix is
         ``[[t, r], [-r, t]]``. This component has no component ports; use
         ``input_terminal()``, ``output_terminal()``, or ``cascade()``.
+
+        Parameters
+        ----------
+        label : str
+            Component label.
+        eta : float or array-like, default=0.5
+            Power transmission in [0, 1].
         """
         matrix = self._transmission_matrix(eta)
         return self._scattering_component(
@@ -545,6 +750,11 @@ class PortNetwork:
         The scattering matrix is ``[[1, 1j], [1j, 1]] / sqrt(2)``. This
         component has no component ports; use ``input_terminal()``,
         ``output_terminal()``, or ``cascade()``.
+
+        Parameters
+        ----------
+        label : str
+            Unique component label.
         """
         return self._scattering_component(
             label,
@@ -554,7 +764,15 @@ class PortNetwork:
         )
 
     def permutation(self, label: str, *, order: Sequence[int]) -> SLHComponent:
-        """Add an output permutation; ``order[row]`` selects the input column."""
+        """Add an output permutation.
+
+        Parameters
+        ----------
+        label : str
+            Unique component label.
+        order : sequence of int
+            Input column selected by each output row.
+        """
         order = tuple(order)
         if sorted(order) != list(range(len(order))):
             raise ValueError("Permutation order must contain each input index exactly once.")
@@ -571,6 +789,17 @@ class PortNetwork:
         They default to vacuum. ``thermal_occupation`` gives both loads a mean
         thermal population in quanta, constant across the modeled band.
         Specify either power transmission ``eta`` or positive ``loss_db``.
+
+        Parameters
+        ----------
+        label : str
+            Unique component label.
+        eta : scalar or None, default=None
+            Power transmission in the interval [0, 1].
+        loss_db : scalar or None, default=None
+            Positive power loss in dB, mutually exclusive with ``eta``.
+        thermal_occupation : scalar or None, default=None
+            Mean occupation of each hidden load in quanta; ``None`` means vacuum.
         """
         power = {key: value for key, value in (("eta", eta), ("loss_db", loss_db)) if value is not None}
         transmission = attenuation_value(power)
@@ -602,6 +831,13 @@ class PortNetwork:
         never enters Markovian ``S``, ``L``, or ``H``. Every reference section must
         belong to an exposed run or an acyclic downstream output graph. Its duration is tracked at
         ``network.component.<label>.duration``.
+
+        Parameters
+        ----------
+        label : str
+            Component label.
+        duration : float or array-like
+            Reference-plane delay in ns.
         """
         ReferenceDelay(label, duration)
         return self._reference_component(label, kind="delay", parameters={"duration": duration})
@@ -630,6 +866,17 @@ class PortNetwork:
         A scalar transfer alone does not distinguish absorption from reflection.
         Colored thermal emission cannot feed a quantum coupling through a
         reference section; use a dynamical filter/bath model for that case.
+
+        Parameters
+        ----------
+        label : str
+            Unique component label.
+        transfer : callable
+            Passive complex amplitude transfer versus frequency in GHz.
+        thermal_occupation : scalar or None, default=None
+            Mean matched-load occupation in quanta; ``None`` means vacuum.
+        **parameters : Any
+            Named transfer-function parameters tracked by the network.
         """
         parameters.update(noise_parameters(thermal_occupation))
         return self._reference_component(label, kind="filter", parameters=dict(parameters), transfer=transfer)
@@ -654,6 +901,15 @@ class PortNetwork:
 
         ``gain_db`` may replace linear ``gain``. Added quanta are constant
         across the modeled band and exclude the input's own noise.
+
+        Parameters
+        ----------
+        label : str
+            Component label.
+        added_noise : float or array-like
+            Input-referred symmetrized added noise in quanta.
+        gain, gain_db : float or array-like, optional
+            Power gain, specified linearly or in dB; supply at most one.
         """
         parameters = {key: value for key, value in (
             ("gain", gain), ("gain_db", gain_db), ("added_noise", added_noise)) if value is not None}
@@ -683,6 +939,13 @@ class PortNetwork:
         """Add an ideal circulator routing side ``k`` to side ``k + 1``.
 
         The highest-numbered side routes back to side 1.
+
+        Parameters
+        ----------
+        label : str
+            Unique component label.
+        ports : int, default=3
+            Number of physical sides; must be at least three.
         """
         if ports < 3:
             raise ValueError(f"A circulator needs at least three sides, got {ports}.")
@@ -698,6 +961,13 @@ class PortNetwork:
         The reverse field is dumped into ``hidden.<label>.load``. Its thermal
         population travels back toward side 1. ``thermal_occupation`` is in
         quanta, constant across the modeled band; the default is vacuum.
+
+        Parameters
+        ----------
+        label : str
+            Unique component label.
+        thermal_occupation : scalar or None, default=None
+            Mean hidden-load occupation in quanta; ``None`` means vacuum.
         """
         component = self._permutation_component(
             label,
@@ -716,6 +986,13 @@ class PortNetwork:
 
         ``thermal_occupation`` is the mean thermal population in quanta,
         constant across the modeled band. The default is vacuum.
+
+        Parameters
+        ----------
+        label : str
+            Unique component label.
+        thermal_occupation : scalar or None, default=None
+            Mean load occupation in quanta; ``None`` means vacuum.
         """
         component = self._permutation_component(
             label, ("1", "load"), (1, 0), kind="termination",
@@ -754,7 +1031,13 @@ class PortNetwork:
         return self._add_component(component)
 
     def connect(self, output: FieldTerminal, input: FieldTerminal) -> None:
-        """Connect one component output to one component input."""
+        """Connect one component output to one component input.
+
+        Parameters
+        ----------
+        output, input : FieldTerminal
+            Unused directional terminals from this network.
+        """
         self._validate_terminal(output, "output")
         self._validate_terminal(input, "input")
         self._reject_hidden_terminal(output)
@@ -774,6 +1057,11 @@ class PortNetwork:
         When a two-sided component is passed directly, the chain enters side 1
         and leaves side 2. Pass ``component.port(k)`` to select a side
         explicitly.
+
+        Parameters
+        ----------
+        *items : Port, SLHComponent, or ComponentPort
+            At least two two-sided endpoints.
         """
         for first, second in self._pairs("link", items):
             left = self._side_of(first, leaving=True)
@@ -782,7 +1070,13 @@ class PortNetwork:
             self.connect(right.output, left.input)
 
     def cascade(self, *items: Port | SLHComponent | FieldTerminal) -> None:
-        """Connect each item's output to the next item's input in sequence."""
+        """Connect each item's output to the next item's input in sequence.
+
+        Parameters
+        ----------
+        *items : Port, SLHComponent, or FieldTerminal
+            At least two compatible endpoints.
+        """
         for first, second in self._pairs("cascade", items):
             self.connect(self._endpoint_of(first, "output"), self._endpoint_of(second, "input"))
 
@@ -805,6 +1099,15 @@ class PortNetwork:
         Pass ``at=`` to expose one component port. Use ``input=`` and
         ``output=`` for separate input and output connections; ports and components then select
         their sole or ``signal`` terminal unless explicit terminals are passed.
+
+        Parameters
+        ----------
+        label : str
+            Unique external reference-plane label.
+        at : Port, SLHComponent, ComponentPort, or None, default=None
+            Physical side to expose for both directions.
+        input, output : FieldTerminal, Port, SLHComponent, or None, default=None
+            Separate incoming and outgoing connection points.
         """
         if at is not None:
             if input is not None or output is not None:
@@ -830,7 +1133,13 @@ class PortNetwork:
         return exposure
 
     def validate_for(self, chip: Any) -> None:
-        """Validate every quantum port target against ``chip``."""
+        """Validate every quantum port target against a chip.
+
+        Parameters
+        ----------
+        chip : Chip
+            Chip whose device labels must contain every port target.
+        """
         for port in self._ports:
             port.resolve_targets(chip)
 
@@ -861,7 +1170,13 @@ class PortNetwork:
     def resolve(
         self, base: "ResolvedSLH", *, _compiled: _CompiledNetwork | None = None,
     ) -> "ResolvedSLH":
-        """Compose this boundary onto port channels in an input-free SLH value."""
+        """Compose this boundary onto an input-free SLH value.
+
+        Parameters
+        ----------
+        base : ResolvedSLH
+            Resolved quantum-port channels to compose with the network.
+        """
         from quchip.engine.ir import (
             CollapseTerm,
             HamiltonianProgram,
@@ -1033,7 +1348,13 @@ class PortNetwork:
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> "PortNetwork":
-        """Reconstruct a static network produced by :meth:`to_dict`."""
+        """Reconstruct a static network produced by :meth:`to_dict`.
+
+        Parameters
+        ----------
+        data : mapping
+            Serialized network payload.
+        """
         unknown = set(data) - {
             "label",
             "ports",
@@ -1296,6 +1617,11 @@ class PortNetwork:
         coordinates but leaves the summed Lindbladian invariant. Each
         downstream/upstream coupling pair generated by SLH series composition
         contributes the union of its two quantum-port supports.
+
+        Parameters
+        ----------
+        chip : Chip
+            Chip used to resolve port target supports.
         """
         supports = {
             port.label: port.resolve_targets(chip)
@@ -1318,6 +1644,13 @@ class PortNetwork:
         Each coefficient combines the scattering entry from the exposure to a
         channel with that port's weight in the channel. A coherent input ``β``
         therefore reaches the port coupling as ``c = coefficient · β``.
+
+        Parameters
+        ----------
+        chip : Chip
+            Chip used to resolve the network boundary.
+        exposure : str
+            External input reference-plane label.
         """
         compiled = self._compile() if _compiled is None else _compiled
         labels = [item.exposure.label for item in compiled.channels]

--- a/quchip/chip/ports.py
+++ b/quchip/chip/ports.py
@@ -23,6 +23,24 @@ class Port:
     between solves; each remains constant within a solve. Model shaped
     emission with an explicit buffer or coupler device holding a static ``Port``
     and a modulated Hamiltonian coupling.
+
+    Parameters
+    ----------
+    target : object or sequence of object
+        Device target(s), or labels resolved when attached to a chip. Multiple
+        targets require an explicit joint ``operator``.
+    rate : float or array-like or None, default=None
+        External coupling rate in 1/ns. Mutually exclusive with
+        ``external_quality_factor``.
+    external_quality_factor : float or array-like or None, default=None
+        Dimensionless external quality factor for one target, giving the rate
+        ``2*pi*freq/Q`` in 1/ns.
+    operator : object or str or None, default=None
+        Dimensionless coupling operator; ``None`` uses the target's lowering operator.
+    phase : float or array-like, default=0.0
+        Reference-plane phase in radians.
+    label : str or None, default=None
+        Stable channel label; generated when omitted.
     """
 
     _type_prefix = "port"
@@ -107,7 +125,13 @@ class Port:
         super().__setattr__(name, value)
 
     def resolve_targets(self, chip: "Chip") -> tuple[str, ...]:
-        """Return target labels after checking that they belong to *chip*."""
+        """Return target labels after checking that they belong to a chip.
+
+        Parameters
+        ----------
+        chip : Chip
+            Chip against which labels are resolved.
+        """
         labels = tuple(resolve_label(target) for target in self._targets)
         unknown = [label for label in labels if label not in chip.device_map]
         if unknown:
@@ -117,7 +141,13 @@ class Port:
         return labels
 
     def rate_value(self, chip: "Chip") -> Any:
-        """Return the external coupling rate in ``1/ns``."""
+        """Return the external coupling rate in 1/ns.
+
+        Parameters
+        ----------
+        chip : Chip
+            Chip providing the target frequency for a quality-factor rate.
+        """
         if self.rate is not None:
             return self.rate
         label = self.resolve_targets(chip)[0]
@@ -167,7 +197,15 @@ class Port:
         }
 
     def set_parameter_value(self, name: str, value: Any) -> None:
-        """Set one port parameter on an isolated chip copy."""
+        """Set one port parameter on an isolated chip copy.
+
+        Parameters
+        ----------
+        name : {"rate", "external_quality_factor", "phase"}
+            Local parameter name.
+        value : Any
+            Replacement value in 1/ns, dimensionless units, or radians.
+        """
         if name not in self._parameter_names:
             raise KeyError(name)
         setattr(self, name, value)
@@ -221,7 +259,13 @@ class Port:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "Port":
-        """Reconstruct a port from label-based serialized data."""
+        """Reconstruct a port from label-based serialized data.
+
+        Parameters
+        ----------
+        data : dict[str, Any]
+            Payload produced by :meth:`to_dict`.
+        """
         targets = data["targets"]
         target: Any = targets[0] if len(targets) == 1 else targets
         operator = data.get("operator")

--- a/quchip/chip/transformations/active_patch.py
+++ b/quchip/chip/transformations/active_patch.py
@@ -160,7 +160,13 @@ class ActivePatchResult:
                             DeferredValue(lambda: reduce(jnp.matmul, (m.embedding for m in maps))))
 
     def simulate(self, **kwargs: Any) -> Any:
-        """Solve the patch sequence (automatic partitioning still applies inside)."""
+        """Solve the patch sequence.
+
+        Parameters
+        ----------
+        **kwargs : Any
+            Arguments forwarded to :meth:`QuantumSequence.simulate`.
+        """
         return self.sequence.simulate(**kwargs)
 
 

--- a/quchip/chip/transformations/dispatch.py
+++ b/quchip/chip/transformations/dispatch.py
@@ -72,7 +72,13 @@ _ELIMINATION_TARGETS: list[EliminationTarget] = []
 
 
 def register_elimination_target(target: EliminationTarget) -> None:
-    """Register an :class:`EliminationTarget` kind for :func:`eliminate` to dispatch on."""
+    """Register an elimination target kind.
+
+    Parameters
+    ----------
+    target : EliminationTarget
+        Target handler added to the dispatch registry.
+    """
     _ELIMINATION_TARGETS.append(target)
 
 

--- a/quchip/chip/transformations/methods.py
+++ b/quchip/chip/transformations/methods.py
@@ -212,7 +212,13 @@ _REDUCTION_METHODS: dict[str, ReductionMethod] = {}
 
 
 def register_reduction_method(method: ReductionMethod) -> None:
-    """Register a reduction strategy under its :attr:`ReductionMethod.name`."""
+    """Register a reduction strategy under its name.
+
+    Parameters
+    ----------
+    method : ReductionMethod
+        Strategy added under its unique ``name``.
+    """
     _REDUCTION_METHODS[method.name] = method
 
 

--- a/quchip/chip/transformations/result.py
+++ b/quchip/chip/transformations/result.py
@@ -58,6 +58,13 @@ class ReductionMap:
     first-order generator; their interpretation is perturbative, even though
     the map is isometric. Jumps follow that map; the SW Hamiltonian retains
     its separately stated second-order truncation.
+
+    Parameters
+    ----------
+    source_labels, target_labels : tuple[str, ...]
+        Device labels defining the source and retained tensor-product orders.
+    source_dims, target_dims : tuple[int, ...]
+        Hilbert-space dimensions aligned with the corresponding labels.
     """
 
     source_labels: tuple[str, ...]
@@ -73,7 +80,13 @@ class ReductionMap:
         return self._embedding()
 
     def project_operator(self, operator: Any) -> Any:
-        """Restrict a source operator to the retained subspace."""
+        """Restrict a source operator to the retained subspace.
+
+        Parameters
+        ----------
+        operator : array-like or backend operator
+            Full source-space operator.
+        """
         array = jnp.asarray(self._backend.to_array(operator))
         size = prod(self.source_dims)
         if array.shape != (size, size):
@@ -83,11 +96,23 @@ class ReductionMap:
         return self._backend.from_array(reduced, dims=[list(self.target_dims), list(self.target_dims)])
 
     def project_state(self, state: Any) -> Any:
-        """Project a source ket or density matrix without renormalizing it."""
+        """Project a source state without renormalizing it.
+
+        Parameters
+        ----------
+        state : array-like or backend state
+            Source-space ket or density matrix.
+        """
         return self._map_state(state, self.embedding.conj().T, self.source_dims, self.target_dims)
 
     def lift_state(self, state: Any) -> Any:
-        """Lift a retained ket or density matrix into the captured source space."""
+        """Lift a retained state into the captured source space.
+
+        Parameters
+        ----------
+        state : array-like or backend state
+            Retained-space ket or density matrix.
+        """
         return self._map_state(state, self.embedding, self.target_dims, self.source_dims)
 
     def _map_state(self, state: Any, transform: Any, source: tuple[int, ...], target: tuple[int, ...]) -> Any:

--- a/quchip/control/batch.py
+++ b/quchip/control/batch.py
@@ -23,6 +23,25 @@ class BatchAxis:
     Created by :meth:`PulseHandle.vary`, :meth:`DelayHandle.vary`, or
     :meth:`QuantumSequence.vary`, and consumed by
     :meth:`QuantumSequence.build_batch`.
+
+    Attributes
+    ----------
+    owner : QuantumSequence
+        Sequence that owns the axis.
+    field : str
+        Swept field name.
+    values : sequence
+        Values evaluated along this axis.
+    name : str
+        Display name in result metadata.
+    target_kind : {"entry", "sequence", "parameter"}
+        Kind of value the axis overrides.
+    entry_index : int or None
+        Scheduled-entry index for entry axes.
+    entry_field : str or None
+        Normalized field on the scheduled entry.
+    entry : object or None
+        Scheduled entry captured by identity.
     """
 
     owner: "QuantumSequence"
@@ -48,7 +67,13 @@ class BatchAxis:
 
 @dataclass(frozen=True)
 class ZippedBatchAxis:
-    """Multiple :class:`BatchAxis` objects swept pairwise as one dimension."""
+    """Multiple :class:`BatchAxis` objects swept pairwise as one dimension.
+
+    Attributes
+    ----------
+    axes : tuple of BatchAxis
+        Equal-length axes evaluated at matching indices.
+    """
 
     axes: tuple[BatchAxis, ...]
 
@@ -87,7 +112,17 @@ class _BaseEntryHandle:
         return self._entry
 
     def vary(self, field: str, values: Any, *, name: str | None = None) -> BatchAxis:
-        """Create a :class:`BatchAxis` that sweeps *field* over *values*."""
+        """Create a batch axis over one entry field.
+
+        Parameters
+        ----------
+        field : str
+            Pulse or delay field name.
+        values : array-like
+            Values along the axis.
+        name : str or None, default=None
+            Display name; defaults to the normalized field.
+        """
         normalized = self._normalize_field(field)
         return BatchAxis(
             owner=self._sequence,
@@ -108,6 +143,13 @@ class PulseHandle(_BaseEntryHandle):
 
     Sweepable fields: ``freq``, ``phase``, ``start_time``, and declared
     envelope parameters (e.g. ``amplitude``, ``duration``, ``sigmas``).
+
+    Parameters
+    ----------
+    sequence : QuantumSequence
+        Sequence owning the scheduled pulse.
+    entry_index : int
+        Pulse entry index in the sequence.
     """
 
     _reserved_fields = ("freq", "phase", "start_time")
@@ -128,7 +170,17 @@ class PulseHandle(_BaseEntryHandle):
 
 
 class DelayHandle(_BaseEntryHandle):
-    """Reference to a scheduled delay entry. Only ``duration`` is sweepable."""
+    """Reference to a scheduled delay entry.
+
+    Only ``duration`` is sweepable.
+
+    Parameters
+    ----------
+    sequence : QuantumSequence
+        Sequence owning the scheduled delay.
+    entry_index : int
+        Delay entry index in the sequence.
+    """
 
     def _normalize_field(self, field: str) -> str:
         self._resolve_entry()

--- a/quchip/control/drive.py
+++ b/quchip/control/drive.py
@@ -117,6 +117,9 @@ class BaseDrive(Registrable, registry_root=True, metaclass=KeywordOnlyDeclarativ
         be connected later or resolved by label through :class:`Chip`.
     label : str | None
         Optional explicit label; otherwise auto-generated.
+    **params : Any
+        Numerical parameters declared by the concrete drive class.
+
     Examples
     --------
     >>> from quchip import DuffingTransmon, ChargeDrive
@@ -170,6 +173,11 @@ class BaseDrive(Registrable, registry_root=True, metaclass=KeywordOnlyDeclarativ
         If previously attached, the drive is removed from the old device's
         ``_connected_drives`` list. :class:`CouplingDrive` overrides this
         handshake because couplings do not own connected-drive lists.
+
+        Parameters
+        ----------
+        target : BaseDevice
+            Device attached to this control line.
         """
         old_target = self._target
         if old_target is not None and not isinstance(old_target, str) and old_target is not target:
@@ -182,7 +190,15 @@ class BaseDrive(Registrable, registry_root=True, metaclass=KeywordOnlyDeclarativ
         return {name: getattr(self, name) for name in type(self).__quchip_param_fields__}
 
     def set_parameter_value(self, name: str, value: Any) -> None:
-        """Apply one drive-owned value on an isolated drive copy."""
+        """Apply one drive-owned value on an isolated drive copy.
+
+        Parameters
+        ----------
+        name : str
+            Declared drive parameter name.
+        value : Any
+            Replacement value in the parameter's declared units.
+        """
         spec = type(self).__quchip_param_fields__.get(name)
         if spec is None:
             raise KeyError(name)
@@ -212,7 +228,17 @@ class BaseDrive(Registrable, registry_root=True, metaclass=KeywordOnlyDeclarativ
         op: LocalOps,
         p: ParameterNamespace,
     ) -> tuple[CollapseChannel, ...]:
-        """Return target-local Lindblad channels contributed by this line."""
+        """Return target-local Lindblad channels contributed by this line.
+
+        Parameters
+        ----------
+        target : BaseDevice
+            Connected target device.
+        op : LocalOps
+            Target-local authored operators.
+        p : ParameterNamespace
+            Bound drive parameters.
+        """
         _ = (target, op, p)
         return ()
 
@@ -239,12 +265,28 @@ class BaseDrive(Registrable, registry_root=True, metaclass=KeywordOnlyDeclarativ
         )
 
     def signal(self, pulse: Any, target: Any) -> AnalyticSignal:
-        """Build the complete scheduled analytic signal for one pulse."""
+        """Build the complete scheduled analytic signal for one pulse.
+
+        Parameters
+        ----------
+        pulse : object
+            Scheduled pulse record.
+        target : object
+            Connected drive target.
+        """
         _ = target
         return AnalyticSignal.from_pulse(pulse)
 
     def hamiltonian(self, target: Any, signal: AnalyticSignal) -> Any:
-        """Map a delivered classical signal to target-local quantum physics."""
+        """Map a delivered signal to target-local quantum physics.
+
+        Parameters
+        ----------
+        target : object
+            Connected device or coupling.
+        signal : AnalyticSignal
+            Complete delivered classical signal.
+        """
         raise NotImplementedError(
             f"{type(self).__name__} must implement hamiltonian(target, signal)"
         )
@@ -259,7 +301,13 @@ class BaseDrive(Registrable, registry_root=True, metaclass=KeywordOnlyDeclarativ
         return [f"Target: '{target}'"]
 
     def copy(self, *, target: BaseDevice | None = None) -> "BaseDrive":
-        """Return a shallow copy, optionally rebound to a new target."""
+        """Return a shallow copy, optionally rebound to a new target.
+
+        Parameters
+        ----------
+        target : BaseDevice or None, default=None
+            Replacement target; ``None`` leaves the copy unconnected.
+        """
         cloned = copy.copy(self)
         cloned._target = None
         if target is not None:
@@ -329,7 +377,18 @@ class BaseDrive(Registrable, registry_root=True, metaclass=KeywordOnlyDeclarativ
 
 
 class DeviceDrive(BaseDrive):
-    """Drive authoring base for a device-local Hamiltonian."""
+    """Drive base for a device-local Hamiltonian contribution.
+
+    Subclasses must implement :meth:`hamiltonian` and accept a compatible
+    device capability such as charge, phase, or flux coupling.
+
+    Parameters
+    ----------
+    target : BaseDevice or str, optional
+        Device object or label; labels resolve when connected to a chip.
+    label : str, optional
+        Drive label.
+    """
 
 
 class CouplingDrive(BaseDrive):
@@ -337,6 +396,13 @@ class CouplingDrive(BaseDrive):
 
     Subclasses implement :meth:`hamiltonian` for the coupling physics they
     accept. The base class imposes no parametric-interaction requirement.
+
+    Parameters
+    ----------
+    target : BaseCoupling or str, optional
+        Coupling object or label.
+    label : str, optional
+        Drive label.
     """
 
     @property
@@ -353,7 +419,13 @@ class CouplingDrive(BaseDrive):
         return target if isinstance(target, str) else target.label
 
     def connect(self, target: Any) -> None:
-        """Attach this line to a coupling without a device-side handshake."""
+        """Attach this line to a coupling without a device-side handshake.
+
+        Parameters
+        ----------
+        target : BaseCoupling
+            Coupling attached to this control line.
+        """
         self._target = target
 
 
@@ -378,11 +450,27 @@ class ChargeDrive(DeviceDrive):
     >>> drive = ChargeDrive(target=q)
     >>> drive.target_label == q.label
     True
+
+    Parameters
+    ----------
+    target : BaseDevice or str, optional
+        Charge-coupled device or label.
+    label : str, optional
+        Drive label.
     """
 
     _type_prefix: ClassVar[str] = "charge"
 
     def hamiltonian(self, device: Any, signal: AnalyticSignal) -> Any:
+        """Return the charge-coupling Hamiltonian in the device-local basis.
+
+        Parameters
+        ----------
+        device : BaseDevice
+            Connected charge-coupled device.
+        signal : AnalyticSignal
+            Delivered classical signal.
+        """
         if not isinstance(device, ChargeCoupled):
             raise TypeError(
                 f"ChargeDrive requires {type(device).__name__} to define "
@@ -395,6 +483,7 @@ class ChargeDrive(DeviceDrive):
         )
 
     def physics_notes(self) -> list[str]:
+        """Describe the charge operator and delivered I-quadrature convention."""
         return super().physics_notes() + [
             "Drive coupling: delivered in-phase signal times the device charge operator"
         ]
@@ -408,10 +497,26 @@ class PhaseDrive(DeviceDrive):
     phase-noise channels or drives whose physical coupling is already
     referenced to the field quadrature. See Krantz et al. 2019, Sec.
     IV.A for the two conventions.
+
+    Parameters
+    ----------
+    target : BaseDevice or str, optional
+        Phase-coupled device or label.
+    label : str, optional
+        Drive label.
     """
 
     _type_prefix: ClassVar[str] = "phase"
     def hamiltonian(self, device: Any, signal: AnalyticSignal) -> Any:
+        """Return the phase-coupling Hamiltonian in the device-local basis.
+
+        Parameters
+        ----------
+        device : BaseDevice
+            Connected phase-coupled device.
+        signal : AnalyticSignal
+            Delivered classical signal.
+        """
         if not isinstance(device, PhaseCoupled):
             raise TypeError(
                 f"PhaseDrive requires {type(device).__name__} to define "
@@ -424,6 +529,7 @@ class PhaseDrive(DeviceDrive):
         )
 
     def physics_notes(self) -> list[str]:
+        """Describe the phase operator and delivered I-quadrature convention."""
         return super().physics_notes() + [
             "Drive coupling: delivered in-phase signal times the device phase operator"
         ]
@@ -444,11 +550,27 @@ class FluxDrive(DeviceDrive):
     >>> flux = FluxDrive(target=q)
     >>> flux.target_label == q.label
     True
+
+    Parameters
+    ----------
+    target : BaseDevice or str, optional
+        Flux-coupled device or label.
+    label : str, optional
+        Drive label.
     """
 
     _type_prefix: ClassVar[str] = "flux"
 
     def hamiltonian(self, device: Any, signal: AnalyticSignal) -> Any:
+        """Return the flux-coupling Hamiltonian in the device-local basis.
+
+        Parameters
+        ----------
+        device : BaseDevice
+            Connected flux-tunable device.
+        signal : AnalyticSignal
+            Delivered baseband flux signal.
+        """
         if not isinstance(device, FluxCoupled):
             raise TypeError(
                 f"FluxDrive requires {type(device).__name__} to define "
@@ -461,6 +583,7 @@ class FluxDrive(DeviceDrive):
         )
 
     def physics_notes(self) -> list[str]:
+        """Describe the flux operator and delivered I-quadrature convention."""
         return super().physics_notes() + [
             "Drive coupling: delivered in-phase signal times the device flux operator"
         ]
@@ -482,7 +605,7 @@ class ParametricDrive(CouplingDrive):
 
     Parameters
     ----------
-    coupling : BaseCoupling | str
+    target : BaseCoupling | str
         Modulable coupling to pump, given as the coupling object or its
         label. A string label late-binds to the coupling instance via
         :meth:`Chip.connect`.
@@ -505,11 +628,26 @@ class ParametricDrive(CouplingDrive):
         return f"{type(self).__name__}(label='{self.label}', coupling='{self.target_label}')"
 
     def connect(self, coupling: Any) -> None:
-        """Attach this line after confirming that the coupling is modulable."""
+        """Attach this line after confirming that the coupling is modulable.
+
+        Parameters
+        ----------
+        coupling : BaseCoupling
+            Coupling implementing ``parametric_interaction``.
+        """
         _probe_modulable(coupling)
         self._target = coupling
 
     def hamiltonian(self, coupling: Any, signal: AnalyticSignal) -> Any:
+        """Return the delivered pump times the coupling's parametric term.
+
+        Parameters
+        ----------
+        coupling : BaseCoupling
+            Connected modulable coupling.
+        signal : AnalyticSignal
+            Delivered pump signal.
+        """
         operator = coupling._bind_parametric_interaction()
         if operator is None:
             raise TypeError(
@@ -519,6 +657,7 @@ class ParametricDrive(CouplingDrive):
         return signal.i * operator
 
     def physics_notes(self) -> list[str]:
+        """Describe the edge-pump convention recorded for this drive."""
         return super().physics_notes() + [
             "Edge pump: delivered in-phase signal multiplies the coupling's parametric structure"
         ]

--- a/quchip/control/drives_two_photon.py
+++ b/quchip/control/drives_two_photon.py
@@ -85,7 +85,8 @@ class TwoPhotonDrive(DeviceDrive):
         ----------
         device : BaseDevice
             The cavity device being driven.
-
+        signal : AnalyticSignal
+            Delivered two-photon pump signal.
         """
         a = device.lowering_operator()
         a_dag = device.raising_operator()

--- a/quchip/control/envelopes.py
+++ b/quchip/control/envelopes.py
@@ -72,7 +72,19 @@ def _synthesize_envelope_init(cls: type["Envelope"]) -> Any:
 
 
 class Envelope(Registrable, ABC, registry_root=True, metaclass=DeclarativeMeta):
-    """Local complex pulse shape evaluated relative to its scheduled start."""
+    """Local complex pulse shape evaluated relative to its scheduled start.
+
+    Concrete subclasses declare ``duration`` and shape parameters with
+    :func:`~quchip.declarative.parameters.parameter`; constructors are
+    synthesized from those declarations. Times are in ns and values are
+    complex I/Q amplitudes.
+
+    Parameters
+    ----------
+    **params : Any
+        Declared envelope fields; concrete subclasses define their names,
+        defaults, units, and validation constraints.
+    """
 
     duration: Scalar
 
@@ -94,7 +106,6 @@ class Envelope(Registrable, ABC, registry_root=True, metaclass=DeclarativeMeta):
         jtu.register_pytree_node(cls, _flatten, _unflatten)
 
     def __init__(self, **params: Any) -> None:
-        """Initialize an envelope from its declared parameter values."""
         values = resolve_declared_params(type(self), params)
         if "duration" not in values:
             raise TypeError(
@@ -122,7 +133,14 @@ class Envelope(Registrable, ABC, registry_root=True, metaclass=DeclarativeMeta):
         return {name: getattr(self, name) for name in names}
 
     def with_params(self, bindings: Mapping[str, Any]) -> Self:
-        """Return an independent envelope validated after all values are applied."""
+        """Return an independent envelope after applying parameter bindings.
+
+        Parameters
+        ----------
+        bindings : mapping[str, Any]
+            Declared field names and replacement values; unknown names raise
+            ``ValueError``.
+        """
         from quchip.utils.values import copy_value
 
         unknown = set(bindings) - self.parameter_values().keys()
@@ -136,7 +154,13 @@ class Envelope(Registrable, ABC, registry_root=True, metaclass=DeclarativeMeta):
 
     @abstractmethod
     def value(self, local_time: Any) -> Any:
-        """Return complex I/Q shape at time relative to the pulse start."""
+        """Return complex I/Q shape at local time in ns.
+
+        Parameters
+        ----------
+        local_time : scalar or array-like
+            Time relative to the scheduled pulse start.
+        """
         ...
 
     def sampling_times(self) -> Any:
@@ -148,7 +172,15 @@ class Envelope(Registrable, ABC, registry_root=True, metaclass=DeclarativeMeta):
         return qnp.linspace(0.0, self.duration, 65)
 
     def sample(self, local_time: Any, *, real: bool = False) -> Any:
-        """Evaluate the shape on an array, optionally returning only I."""
+        """Evaluate the shape, optionally returning only its real I component.
+
+        Parameters
+        ----------
+        local_time : scalar or array-like
+            Local sample times in ns.
+        real : bool, default False
+            Return real I values instead of complex I/Q values.
+        """
         xp = _pick_namespace(local_time)
         values = xp.asarray(
             self.value(xp.asarray(local_time, dtype=float)),
@@ -249,6 +281,23 @@ class Gaussian(Envelope):
     ``0.011 * amplitude`` at the default ``sigmas=3``. The pulse turns
     on and off with that jump; the Gaussian waveform itself is
     unchanged.
+
+    Parameters
+    ----------
+    duration : float
+        Pulse duration in ns; positive.
+    sigmas : float, default 3
+        Number of standard deviations from the pulse center to each window
+        edge, so ``sigma = duration/(2*sigmas)``; positive.
+    amplitude : float, default 1.0
+        Peak in-phase envelope amplitude. Its physical unit is supplied by
+        the consuming drive (for example GHz for a Hamiltonian drive or
+        1/sqrt(ns) for an incident field).
+
+    References
+    ----------
+    Motzoi et al., *Phys. Rev. Lett.* 103, 110501 (2009),
+    https://doi.org/10.1103/PhysRevLett.103.110501.
     """
 
     duration: Scalar = parameter(positive=True, unit="ns")
@@ -259,7 +308,13 @@ class Gaussian(Envelope):
         return _gaussian_sampling_times(self.duration, self.sigmas)
 
     def value(self, t: Any) -> Any:
-        """Evaluate the centered Gaussian envelope at time points *t*."""
+        """Evaluate the centered Gaussian envelope.
+
+        Parameters
+        ----------
+        t : scalar or array-like
+            Local times in ns.
+        """
         center = self.duration / 2.0
         sigma = self.duration / (2.0 * self.sigmas)
         return qnp.asarray(
@@ -278,6 +333,23 @@ class GaussianDRAG(Envelope):
 
     ``beta`` is signed and measured in ns. Its sign therefore owns the
     quadrature convention without an additional polarity flag.
+
+    Parameters
+    ----------
+    duration : float
+        Pulse duration in ns; positive.
+    sigmas : float, default 3
+        Number of standard deviations from the pulse center to each window
+        edge, so ``sigma = duration/(2*sigmas)``; positive.
+    amplitude : float, default 1.0
+        Peak in-phase envelope amplitude; physical units come from the drive.
+    beta : float, default 0.0
+        Derivative-quadrature coefficient in ns; signed.
+
+    References
+    ----------
+    Motzoi et al., *Phys. Rev. Lett.* 103, 110501 (2009),
+    https://doi.org/10.1103/PhysRevLett.103.110501.
     """
 
     duration: Scalar = parameter(positive=True, unit="ns")
@@ -289,6 +361,13 @@ class GaussianDRAG(Envelope):
         return _gaussian_sampling_times(self.duration, self.sigmas)
 
     def value(self, t: Any) -> Any:
+        """Evaluate the DRAG envelope.
+
+        Parameters
+        ----------
+        t : scalar or array-like
+            Local times in ns.
+        """
         center = self.duration / 2.0
         sigma = self.duration / (2.0 * self.sigmas)
         in_phase = self.amplitude * qnp.exp(-((t - center) ** 2) / (2.0 * sigma**2))
@@ -344,7 +423,13 @@ class GaussianEdge(Envelope):
         return _gaussian_edge_sampling_times(self.duration, self.edge_duration, self.sigmas)
 
     def value(self, t: Any) -> Any:
-        """Evaluate the flat-top Gaussian-edge envelope at time points *t*."""
+        """Evaluate the flat-top Gaussian-edge envelope.
+
+        Parameters
+        ----------
+        t : scalar or array-like
+            Local times in ns.
+        """
         return _gaussian_flat_top(t, self.duration, self.edge_duration, self.sigmas, self.amplitude)
 
 
@@ -396,7 +481,13 @@ class SquareWithGaussianEdges(Envelope):
         return _gaussian_edge_sampling_times(self.duration, self.edge_duration, self.sigmas)
 
     def value(self, t: Any) -> Any:
-        """Evaluate the fraction-parameterized Gaussian-edge envelope."""
+        """Evaluate the fraction-parameterized Gaussian-edge envelope.
+
+        Parameters
+        ----------
+        t : scalar or array-like
+            Local times in ns.
+        """
         return _gaussian_flat_top(t, self.duration, self.edge_duration, self.sigmas, self.amplitude)
 
 
@@ -500,5 +591,11 @@ class Square(Envelope):
         return qnp.asarray([0.0, self.duration])
 
     def value(self, t: Any) -> Any:
-        """Evaluate the constant envelope at time points *t*."""
+        """Evaluate the constant envelope.
+
+        Parameters
+        ----------
+        t : scalar or array-like
+            Local times in ns.
+        """
         return qnp.ones_like(t, dtype=complex) * self.amplitude

--- a/quchip/control/equipment.py
+++ b/quchip/control/equipment.py
@@ -70,7 +70,13 @@ class CrosstalkMatrix(SignalTransform, serializable=True):
                 raise ValueError(f"{name} matrix shape {getattr(matrix, 'shape', None)} does not match {shape}")
 
     def apply(self, signals: SignalMap) -> SignalMap:
-        """Apply all directed leakage edges to one shared input snapshot."""
+        """Apply all directed leakage edges to one shared input snapshot.
+
+        Parameters
+        ----------
+        signals : SignalMap
+            Signals keyed by ``(line, source_index)``.
+        """
         output = dict(signals)
         line_index = {label: index for index, label in enumerate(self.labels)}
         for key, signal in signals.items():
@@ -92,9 +98,17 @@ class CrosstalkMatrix(SignalTransform, serializable=True):
         return output
 
     def referenced_lines(self) -> tuple[str, ...]:
+        """Return drive labels referenced by this transform."""
         return self.labels
 
     def without_line(self, line: str) -> "CrosstalkMatrix | None":
+        """Return a copy with ``line`` removed, or ``None`` below two lines.
+
+        Parameters
+        ----------
+        line : str
+            Drive label to remove.
+        """
         if line not in self.labels:
             return self
         keep = [index for index, label in enumerate(self.labels) if label != line]
@@ -144,6 +158,13 @@ class ControlEquipment:
 
     The equipment pipes complete analytic signals through ``signal_chain``
     before destination drives author Hamiltonian terms.
+
+    Parameters
+    ----------
+    lines : list of BaseDrive
+        Drive lines in wiring order.
+    signal_chain : list of SignalTransform, optional
+        Sequential transforms applied after scheduling.
     """
 
     def __init__(
@@ -329,7 +350,14 @@ class ControlEquipment:
         ]
 
     def copy(self, device_map: dict[str, Any], coupling_map: dict[str, Any] | None = None) -> "ControlEquipment":
-        """Return a structural copy with drive lines rebound to *device_map* / *coupling_map*.
+        """Return a structural copy with drive lines rebound to target maps.
+
+        Parameters
+        ----------
+        device_map : dict[str, object]
+            Device labels to copied devices.
+        coupling_map : dict[str, object], optional
+            Coupling labels to copied couplings.
 
         Coupling-target lines rebind via *coupling_map*, keyed by coupling
         label; device-target lines rebind via *device_map*.
@@ -363,7 +391,16 @@ class ControlEquipment:
         dev_map: dict[str, Any],
         coupling_map: dict[str, Any] | None = None,
     ) -> "ControlEquipment":
-        """Reconstruct from :meth:`to_dict` output, rebinding drives via *dev_map* / *coupling_map*.
+        """Reconstruct from :meth:`to_dict` output and target maps.
+
+        Parameters
+        ----------
+        d : dict
+            Serialized equipment dictionary.
+        dev_map : dict[str, object]
+            Device labels to target objects.
+        coupling_map : dict[str, object], optional
+            Coupling labels to target objects.
 
         Each line's ``target_label`` is resolved against *dev_map* first,
         then *coupling_map* — device and coupling labels are disjoint by

--- a/quchip/control/field.py
+++ b/quchip/control/field.py
@@ -44,6 +44,13 @@ class CoherentInput:
     The scheduled analytic signal is interpreted directly as
     ``beta(t) = A(t) exp(i theta) exp(-i 2*pi*f*t)`` in ``1/sqrt(ns)``.
     Consequently ``abs(beta)**2`` is photon flux in photons/ns.
+
+    Parameters
+    ----------
+    exposure : str or object
+        External network exposure label.
+    label : str, optional
+        Endpoint label; generated when omitted.
     """
 
     exposure: str
@@ -64,6 +71,14 @@ class CoherentInput:
         return self.exposure
 
     def signal(self, pulse: Any, target: Any = None) -> AnalyticSignal:
-        """Build beta from the existing envelope, phase, carrier, and timing grammar."""
+        """Build beta from the pulse's envelope, phase, carrier, and timing.
+
+        Parameters
+        ----------
+        pulse : object
+            Scheduled pulse record.
+        target : object, optional
+            Ignored; accepted to satisfy the control-endpoint protocol.
+        """
         _ = target
         return AnalyticSignal.from_pulse(pulse)

--- a/quchip/control/sequence.py
+++ b/quchip/control/sequence.py
@@ -434,7 +434,19 @@ class QuantumSequence:
         freq: float | None = None,
         phase: float = 0.0,
     ) -> PulseHandle:
-        """Schedule a :class:`ChargeDrive` pulse; *freq* defaults to ``chip.freq(device)``."""
+        """Schedule a charge-drive pulse.
+
+        Parameters
+        ----------
+        target : str or BaseDevice
+            Driven device.
+        envelope : Envelope
+            Pulse envelope; time parameters are in ns and amplitudes in GHz.
+        freq : float or None, default=None
+            Carrier frequency in GHz; ``None`` uses ``chip.freq(target)``.
+        phase : float, default=0.0
+            Carrier phase in radians.
+        """
         label = resolve_label(target)
         self._validate_target(label)
         drive = self._find_drive_by_type(label, ChargeDrive)
@@ -450,7 +462,19 @@ class QuantumSequence:
         freq: float,
         phase: float = 0.0,
     ) -> PulseHandle:
-        """Schedule a :class:`PhaseDrive` pulse; *freq* is required."""
+        """Schedule a phase-drive pulse.
+
+        Parameters
+        ----------
+        target : str or BaseDevice
+            Driven device.
+        envelope : Envelope
+            Pulse envelope; time parameters are in ns and amplitudes in GHz.
+        freq : float
+            Carrier frequency in GHz.
+        phase : float, default=0.0
+            Carrier phase in radians.
+        """
         label = resolve_label(target)
         self._validate_target(label)
         drive = self._find_drive_by_type(label, PhaseDrive)
@@ -462,7 +486,15 @@ class QuantumSequence:
         *,
         envelope: Envelope,
     ) -> PulseHandle:
-        """Schedule a :class:`FluxDrive` pulse (no carrier frequency)."""
+        """Schedule a baseband flux-drive pulse.
+
+        Parameters
+        ----------
+        target : str or BaseDevice
+            Driven flux-tunable device.
+        envelope : Envelope
+            Baseband pulse envelope in GHz versus time in ns.
+        """
         label = resolve_label(target)
         self._validate_target(label)
         drive = self._find_drive_by_type(label, FluxDrive)
@@ -477,7 +509,21 @@ class QuantumSequence:
         start_time: float | None = None,
         phase: float = 0.0,
     ) -> PulseHandle:
-        """Schedule an edge pump: baseband δ(t)=A(t) when ``freq`` is None, else A(t)·cos(2πft-φ)."""
+        """Schedule an edge pump.
+
+        Parameters
+        ----------
+        coupling : str or BaseCoupling
+            Modulable coupling to pump.
+        envelope : Envelope
+            Pump-amplitude envelope in GHz versus time in ns.
+        freq : float or None, default=None
+            Carrier frequency in GHz; ``None`` applies the envelope at baseband.
+        start_time : float or None, default=None
+            Absolute start time in ns; ``None`` uses the channel cursor.
+        phase : float, default=0.0
+            Carrier phase in radians.
+        """
         label = resolve_label(coupling)
         drive = self._find_coupling_drive(label)
         return self._schedule_on_drive(drive, envelope=envelope, freq=freq, start_time=start_time, phase=phase)
@@ -534,13 +580,28 @@ class QuantumSequence:
         ``phase_offset``. This is the standard software-Z trick for
         transmons (McKay et al., PRA 96, 022330 (2017)). Baseband flux
         pulses are unaffected.
+
+        Parameters
+        ----------
+        target : str or BaseDevice
+            Device receiving the virtual frame shift.
+        angle : float
+            Z-frame shift in radians.
         """
         label = resolve_label(target)
         self._validate_target(label)
         self._entries.append(_FrameShiftEntry(device_label=label, angle=angle))
 
     def delay(self, scope: str | BaseDevice, duration: float) -> DelayHandle:
-        """Insert an idle delay on all drive channels of *scope*."""
+        """Insert an idle delay on all drive channels of a target.
+
+        Parameters
+        ----------
+        scope : str or BaseDevice
+            Device label or object whose channels advance.
+        duration : float
+            Delay in ns.
+        """
         target = resolve_label(scope)
         self._validate_target(target)
         _require_positive_duration(duration)
@@ -555,6 +616,11 @@ class QuantumSequence:
         device targets, only those devices' cursors are aligned. Use
         this to guarantee that pulses scheduled after the barrier
         start no earlier than any pulse scheduled before it.
+
+        Parameters
+        ----------
+        *labels : str or BaseDevice
+            Devices to synchronize; omitted means all device-drive cursors.
         """
         if not labels:
             self._entries.append(_BarrierEntry(device_labels=()))
@@ -798,10 +864,14 @@ class QuantumSequence:
             A ket, density matrix, or mapping for
             :meth:`~quchip.chip.chip.Chip.state`. Defaults to the chip's
             default initial state when omitted.
+        approximation : Approximation, optional
+            Engine approximation override. ``None`` uses the chip default.
         frame : FrameSpec, optional
             Integration-frame override. Defaults to the chip's declared frame.
             ``"auto"`` derives constraints from delivered scheduled signals and
             weights them over ``tlist[-1] - tlist[0]``.
+        dissipation : bool, default=True
+            Include authored collapse channels when true.
 
         Returns
         -------
@@ -833,7 +903,15 @@ class QuantumSequence:
         frame: FrameSpec | None = None,
         approximation: Approximation | None = None,
     ) -> EngineResult:
-        """Resolve the backend-neutral Hamiltonian and noise description."""
+        """Resolve the backend-neutral Hamiltonian and noise description.
+
+        Parameters
+        ----------
+        frame : FrameSpec or None, default=None
+            Resolution frame, or ``None`` to use the chip default.
+        approximation : Approximation or None, default=None
+            Engine approximation, or ``None`` to use the chip default.
+        """
         drive_ops = self._materialize_drive_ops()
         base_result = resolve_for_operations(self._chip, drive_ops, frame=frame, approximation=approximation)
         return build_engine_result(
@@ -993,7 +1071,31 @@ class QuantumSequence:
         dissipation: bool = True,
         duration: Any | None = None,
     ) -> "SolveBatch":
-        """Build a batched solve request from explicit sweep axes."""
+        """Build a batched solve request from explicit sweep axes.
+
+        Parameters
+        ----------
+        *axes : BatchAxis or ZippedBatchAxis
+            Independent or pairwise-zipped sweep axes.
+        tlist : array-like or None, default=None
+            Solver time grid in ns.
+        solver : str or None, default=None
+            Backend solver name; ``None`` uses its default.
+        options : dict or None, default=None
+            Backend numerical options.
+        e_ops : dict or None, default=None
+            Local expectation-operator specifications.
+        initial_state : Any or None, default=None
+            Initial ket, density matrix, or state mapping.
+        approximation : Approximation or None, default=None
+            Engine approximation override.
+        states : {"all", "final", "none"}, default="all"
+            State-retention policy.
+        dissipation : bool, default=True
+            Include authored collapse channels when true.
+        duration : float or None, default=None
+            Automatically sampled interval from zero, in ns.
+        """
         self._validate_axes(axes)
         shape, expanded = _expand_axis_overrides(axes)
         params_store = np.empty(shape if shape else (), dtype=object)
@@ -1162,32 +1264,64 @@ class QuantumSequence:
         dissipation: bool = True,
         duration: Any | None = None,
     ) -> "SimulationResult":
-        """Build and solve a single simulation, routed through :func:`~quchip.engine.simulate`.
+        """Build and solve one scheduled simulation.
 
-        ``backend`` — name (``"qutip"``/``"dynamiqs"``) or instance — scopes
-        this one call, outranking the chip's and the process default (so a
-        gradient solve can run on dynamiqs while everything around it stays
-        on QuTiP). Foreign-native initial states are coerced at the solve
-        boundary. Caveat: Python evaluates arguments *before* the scope
-        opens, so an ``initial_state=chip.state(...)`` expression inline in
-        the call is built under the surrounding backend — fine for concrete
-        chips (the state is coerced), but a chip carrying JAX tracers needs
-        a JAX-capable surrounding backend (chip-level or process default)
-        for that construction itself.
+        Parameters
+        ----------
+        tlist : array-like, optional
+            Sample times in ns. Mutually exclusive with ``duration``. If
+            omitted, quchip builds an automatic grid through the schedule end.
+        solver : str, optional
+            Backend solver name, such as ``"mesolve"`` or ``"sesolve"``.
+        options : dict, optional
+            Backend-specific solver options.
+        e_ops : dict, optional
+            Named observables to evaluate.
+        initial_state : object or mapping, optional
+            Initial state in the chip basis. ``None`` uses the joint ground state;
+            mappings may supply one state per partitioned component.
+        backend : object or {"qutip", "dynamiqs"}, optional
+            Per-call backend override.
+        check_truncation : bool, default=True
+            Check retained-level populations against ``truncation_threshold``.
+        truncation_threshold : float, default=1e-3
+            Maximum allowed omitted-level population for the check.
+        partition : bool, default=True
+            Solve independent chip components separately when the initial state
+            permits it.
+        approximation : Approximation, optional
+            Override the chip's approximation for this solve.
+        states : {"all", "final", "none"}, default="all"
+            State storage policy for the returned result.
+        dissipation : bool, default=True
+            Include declared collapse channels when ``True``.
+        duration : float, optional
+            Positive simulation end time in ns when ``tlist`` is omitted.
 
-        Inherits the Hilbert-truncation safety net from :func:`~quchip.engine.solve_problem`;
-        pass ``check_truncation=False`` to opt out or retune
-        ``truncation_threshold``.
+        Returns
+        -------
+        SimulationResult
+            Time samples, requested observables, and states according to
+            ``states``.
 
-        ``partition``, default ``True``, forwards to
-        :func:`~quchip.engine.simulate`: when the chip splits into
-        independent sub-chips (:meth:`Chip.partition`), each component is
-        dispatched separately and combined into a
+        Raises
+        ------
+        ValueError
+            If ``tlist`` and ``duration`` are both supplied, timing is invalid,
+            or automatic sampling needs concrete timing.
+
+        Notes
+        -----
+        A per-call ``backend`` outranks the chip and process defaults, and
+        foreign-native initial states are coerced at the solve boundary.
+        Python evaluates an inline ``initial_state=chip.state(...)`` before
+        this scope opens, so constructing a traced state still requires a
+        JAX-capable surrounding backend.
+
+        Partitioning returns a
         :class:`~quchip.results.partitioned.PartitionedSimulationResult`.
-        This only engages when ``initial_state`` is ``None`` or a
-        ``Mapping``. String shorthand and concrete states always take the
-        joint path. Pass ``partition=False`` to force the joint solve
-        unconditionally.
+        It requires ``initial_state`` to be ``None`` or a mapping; string
+        shorthand and concrete states take the joint path.
         """
         from quchip.engine import simulate as _engine_simulate
 
@@ -1222,13 +1356,42 @@ class QuantumSequence:
         dissipation: bool = True,
         duration: Any | None = None,
     ) -> "SimulationBatchResult":
-        """Build and solve a batched sweep. Equivalent to ``chip.solve_many(seq.build_batch(...))``.
+        """Build and solve a batched sweep over pulse or sequence parameters.
 
-        ``backend`` scopes this one call exactly as in :meth:`simulate`.
+        Parameters
+        ----------
+        *axes : BatchAxis or ZippedBatchAxis
+            Cartesian sweep axes. A :class:`ZippedBatchAxis` pairs member axes
+            pointwise and therefore contributes one batch dimension.
+        tlist, solver, options, e_ops, initial_state, backend
+            As for :meth:`simulate`; one initial state is reused for every
+            batch point unless it is a supported mapping.
+        progress : bool, default=True
+            Show backend batch progress when supported.
+        check_truncation : bool, default=True
+            Check retained-level populations at every batch point.
+        truncation_threshold : float, default=1e-3
+            Maximum allowed omitted-level population.
+        approximation : Approximation, optional
+            Per-batch approximation override.
+        states : {"all", "final", "none"}, default="all"
+            State storage policy for each batch result.
+        dissipation : bool, default=True
+            Include declared collapse channels.
+        duration : float, optional
+            Positive end time in ns when ``tlist`` is omitted.
 
-        The shared batch dispatcher samples and checks each component's truncation
-        boundary (default on). Pass ``check_truncation=False`` to opt out or retune
-        ``truncation_threshold``.
+        Returns
+        -------
+        SimulationBatchResult
+            Results indexed by the Cartesian or zipped axis shape.
+
+        Raises
+        ------
+        ValueError
+            If an axis is invalid, timing is inconsistent, or a sweep changes
+            a structural quantity that cannot vary within one batch.
+
         """
         with self._scoped_backend(backend):
             problem_batch = self.build_batch(
@@ -1254,6 +1417,13 @@ class QuantumSequence:
         Convenience for :func:`quchip.chip.transformations.active_patch`;
         see it for the activity rule, elimination order, and validity
         reporting.
+
+        Parameters
+        ----------
+        hops : int, default=1
+            Coupling-graph expansion beyond scheduled targets.
+        method : {"sw", "exact"}, default="sw"
+            Reduction method forwarded to each elimination.
         """
         from quchip.chip.transformations import active_patch as _active_patch
 
@@ -1322,7 +1492,13 @@ class QuantumSequence:
         )
 
     def with_params(self, bindings: Mapping[str, Any]) -> "QuantumSequence":
-        """Return a cloned sequence with Chip or ``pulse.<index>`` values rebound."""
+        """Return a cloned sequence with values rebound.
+
+        Parameters
+        ----------
+        bindings : mapping[str, Any]
+            Chip parameter paths or ``pulse.<index>`` fields and new values.
+        """
         available = self.parameters
         unknown = set(bindings) - set(available)
         if unknown:

--- a/quchip/control/signal.py
+++ b/quchip/control/signal.py
@@ -77,6 +77,15 @@ class AnalyticSignal:
     ``program`` includes the envelope, schedule timing and phase, and any
     carrier. Classical equipment transforms this complete value before a
     drive maps its physical quadratures into the quantum Hamiltonian.
+
+    Parameters
+    ----------
+    program : SignalProgram
+        Complete envelope, timing, phase, and carrier program.
+    carrier : Any or None, default=None
+        Carrier frequency in GHz, when uniquely defined.
+    phase_reference : Any or None, default=None
+        Reference used to track coherent phase alignment.
     """
 
     program: SignalProgram
@@ -85,7 +94,13 @@ class AnalyticSignal:
 
     @classmethod
     def from_pulse(cls, pulse: Any) -> "AnalyticSignal":
-        """Build the complete scheduled signal for one pulse record."""
+        """Build the complete scheduled signal for one pulse record.
+
+        Parameters
+        ----------
+        pulse : object
+            Scheduled pulse entry with envelope, timing, phase, and carrier.
+        """
         local = Window(
             child=EnvelopeRef(pulse.envelope),
             start=0.0,
@@ -113,11 +128,25 @@ class AnalyticSignal:
         return PhysicsExpr.from_signal(ImagPart(self.program), name="Q")
 
     def evaluate(self, t: Any, *, xp: Any | None = None) -> Any:
-        """Evaluate the complete complex signal at time *t*."""
+        """Evaluate the complete complex signal.
+
+        Parameters
+        ----------
+        t : array-like
+            Evaluation times in ns.
+        xp : array namespace or None, default=None
+            Numerical array module; inferred when omitted.
+        """
         return evaluate_signal_program(self.program, t, xp=xp)
 
     def shifted(self, delta_t: Any) -> "AnalyticSignal":
-        """Return the signal delayed by ``delta_t`` ns."""
+        """Return a delayed signal.
+
+        Parameters
+        ----------
+        delta_t : Any
+            Delay in ns.
+        """
         return type(self)(
             program=Shift(self.program, delta_t=delta_t),
             carrier=self.carrier,
@@ -125,7 +154,13 @@ class AnalyticSignal:
         )
 
     def scaled(self, factor: Any) -> "AnalyticSignal":
-        """Return the signal multiplied by a complex factor."""
+        """Return a signal multiplied by a complex factor.
+
+        Parameters
+        ----------
+        factor : Any
+            Dimensionless complex scale factor.
+        """
         return type(self)(
             program=Scale(self.program, factor=factor),
             carrier=self.carrier,
@@ -133,7 +168,15 @@ class AnalyticSignal:
         )
 
     def polar_scaled(self, amplitude: Any, theta: Any) -> "AnalyticSignal":
-        """Return the signal multiplied by ``amplitude * exp(i theta)``."""
+        """Return a signal multiplied by ``amplitude * exp(i theta)``.
+
+        Parameters
+        ----------
+        amplitude : Any
+            Dimensionless amplitude scale.
+        theta : Any
+            Phase rotation in radians.
+        """
         return type(self)(
             program=PolarScale(self.program, amplitude=amplitude, theta=theta),
             carrier=self.carrier,
@@ -192,6 +235,11 @@ class SignalTransform(Registrable, ABC, registry_root=True, metaclass=KeywordOnl
 
     Implement ``apply`` and declare ``serializable=True`` on classes whose
     fields can be saved. Import the extension before loading its instances.
+
+    Parameters
+    ----------
+    **values : Any
+        Settings and numerical parameters declared by the concrete transform.
     """
 
     _serializable = False
@@ -231,7 +279,15 @@ class SignalTransform(Registrable, ABC, registry_root=True, metaclass=KeywordOnl
         return copied
 
     def with_parameter_value(self, name: str, value: Any) -> "SignalTransform":
-        """Validate and rebind one numerical field on an independent transform."""
+        """Validate and rebind one numerical field on an independent transform.
+
+        Parameters
+        ----------
+        name : str
+            Declared numerical field name.
+        value : Any
+            Replacement value in the field's declared units.
+        """
         if name not in parameter_fields(type(self)):
             raise KeyError(name)
         rebound = self.copy()
@@ -253,19 +309,39 @@ class SignalTransform(Registrable, ABC, registry_root=True, metaclass=KeywordOnl
 
     @abstractmethod
     def apply(self, signals: SignalMap) -> SignalMap:
-        """Return the transformed signal map."""
+        """Return the transformed signal map.
+
+        Parameters
+        ----------
+        signals : SignalMap
+            Signals keyed by control line and source index.
+        """
 
     def referenced_lines(self) -> tuple[str, ...]:
         """Return control-line labels referenced by this transform."""
         return ()
 
     def without_line(self, line: str) -> "SignalTransform | None":
-        """Return this transform without *line*, or ``None`` when it must be dropped."""
+        """Return this transform without a line, or ``None`` if it must be dropped.
+
+        Parameters
+        ----------
+        line : str
+            Removed control-line label.
+        """
         return None if line in self.referenced_lines() else self
 
 
 class Delay(SignalTransform, serializable=True):
-    """Shift every signal on *line* in time by ``delta_t`` ns."""
+    """Shift every signal on one control line by ``delta_t`` ns.
+
+    Parameters
+    ----------
+    line : str or object
+        Drive label or drive object.
+    delta_t : float
+        Delay in ns; positive values shift the signal later.
+    """
 
     line: str = setting()
     delta_t: float = parameter()
@@ -276,7 +352,13 @@ class Delay(SignalTransform, serializable=True):
         object.__setattr__(self, "delta_t", delta_t)
 
     def apply(self, signals: SignalMap) -> SignalMap:
-        """Time-shift every signal on :attr:`line` by ``delta_t`` ns."""
+        """Time-shift every signal on :attr:`line` by ``delta_t`` ns.
+
+        Parameters
+        ----------
+        signals : SignalMap
+            Signals keyed by ``(line, source_index)``.
+        """
         s = dict(signals)
         for key in list(s):
             if key[0] == self.line:
@@ -284,10 +366,19 @@ class Delay(SignalTransform, serializable=True):
         return s
 
     def referenced_lines(self) -> tuple[str, ...]:
+        """Return the line label affected by this delay."""
         return (self.line,)
 
 class Gain(SignalTransform, serializable=True):
-    """Scale every signal on *line* by a complex *factor*."""
+    """Scale every signal on one control line by a complex factor.
+
+    Parameters
+    ----------
+    line : str or object
+        Drive label or drive object.
+    factor : complex
+        Dimensionless amplitude and phase multiplier.
+    """
 
     line: str = setting()
     factor: complex = parameter()
@@ -298,7 +389,13 @@ class Gain(SignalTransform, serializable=True):
         object.__setattr__(self, "factor", factor)
 
     def apply(self, signals: SignalMap) -> SignalMap:
-        """Scale every signal on :attr:`line` by the complex ``factor``."""
+        """Scale every signal on :attr:`line` by the complex ``factor``.
+
+        Parameters
+        ----------
+        signals : SignalMap
+            Signals keyed by ``(line, source_index)``.
+        """
         s = dict(signals)
         for key in list(s):
             if key[0] == self.line:
@@ -306,6 +403,7 @@ class Gain(SignalTransform, serializable=True):
         return s
 
     def referenced_lines(self) -> tuple[str, ...]:
+        """Return the line label affected by this gain."""
         return (self.line,)
 
 class Crosstalk(SignalTransform, serializable=True):
@@ -360,7 +458,13 @@ class Crosstalk(SignalTransform, serializable=True):
         object.__setattr__(self, "delay", delay)
 
     def apply(self, signals: SignalMap) -> SignalMap:
-        """Add the phase-rotated, delayed source signal onto the victim line."""
+        """Add the phase-rotated, delayed source signal onto the victim line.
+
+        Parameters
+        ----------
+        signals : SignalMap
+            Signals keyed by ``(line, source_index)``.
+        """
         output = dict(signals)
         for key, signal in signals.items():
             if key[0] != self.source:
@@ -372,4 +476,5 @@ class Crosstalk(SignalTransform, serializable=True):
         return output
 
     def referenced_lines(self) -> tuple[str, ...]:
+        """Return source and victim labels referenced by this crosstalk edge."""
         return (self.source, self.victim)

--- a/quchip/declarative/dissipation.py
+++ b/quchip/declarative/dissipation.py
@@ -21,7 +21,17 @@ def collapse_parameter_paths(operator: Any, rate: Any) -> tuple[str, ...]:
 
 @dataclass(frozen=True)
 class CollapseChannel:
-    """One unscaled Lindblad operator and its rate in inverse nanoseconds."""
+    """One unscaled Lindblad operator and its rate in inverse nanoseconds.
+
+    Parameters
+    ----------
+    operator : expression or backend operator
+        Unscaled collapse operator :math:`L`; the engine applies the rate.
+    rate : float or expression
+        Non-negative Lindblad rate in 1/ns.
+    name : str
+        Non-empty stable channel name.
+    """
 
     operator: Any
     rate: Any

--- a/quchip/declarative/dynamics.py
+++ b/quchip/declarative/dynamics.py
@@ -80,7 +80,13 @@ class TimeCoefficient(Registrable, ABC, registry_root=True, metaclass=Declarativ
 
     @abstractmethod
     def value(self, t: Any) -> Any:
-        """Evaluate the coefficient at time *t* in ns."""
+        """Evaluate the coefficient at time *t* in ns.
+
+        Parameters
+        ----------
+        t : scalar or array-like
+            Time in ns.
+        """
 
     def _signal_program(self) -> Any:
         """Lower this coefficient to the engine's private signal program."""
@@ -105,7 +111,17 @@ class TimeCoefficient(Registrable, ABC, registry_root=True, metaclass=Declarativ
 
 
 class CosineCoefficient(TimeCoefficient):
-    """Cosine coefficient with amplitude in GHz and frequency in GHz."""
+    r"""Cosine coefficient :math:`A\cos(2\pi f t+\phi)`.
+
+    Parameters
+    ----------
+    amplitude : float
+        Coefficient amplitude in GHz; may be signed.
+    frequency : float
+        Ordinary modulation frequency in GHz; positive.
+    phase : float, default 0.0
+        Phase offset in radians.
+    """
 
     amplitude: Scalar = parameter(default=UNBOUND, unit="GHz")
     frequency: Scalar = parameter(default=UNBOUND, positive=True, unit="GHz")
@@ -145,7 +161,15 @@ def bind_time_coefficient(
 
 @dataclass(frozen=True)
 class TimeDependentTerm:
-    """An authored local operator and its time coefficient."""
+    """An authored local operator and its time coefficient.
+
+    Parameters
+    ----------
+    operator : PhysicsExpr or backend operator
+        Hamiltonian operator multiplied by the coefficient.
+    coefficient : TimeCoefficient
+        Scalar coefficient evaluated as a function of time in ns.
+    """
 
     operator: Any
     coefficient: TimeCoefficient

--- a/quchip/declarative/expr.py
+++ b/quchip/declarative/expr.py
@@ -24,7 +24,18 @@ def is_opaque_callable(value: Any) -> bool:
 
 @dataclass(frozen=True)
 class PhysicsExpr:
-    """Authored scalar and operator algebra, independent of numerical values."""
+    """Authored scalar and operator algebra, independent of numerical values.
+
+    Parameters
+    ----------
+    kind : str
+        Expression node kind, such as ``"op"``, ``"add"``, ``"parameter"``
+        or ``"matrix"``.
+    args : tuple, default ()
+        Node payload in the representation required by ``kind``.
+    labels : tuple[str, ...], default ()
+        Ordered endpoint labels supporting this expression.
+    """
 
     kind: str
     args: tuple[Any, ...] = ()
@@ -40,12 +51,26 @@ class PhysicsExpr:
         symbol: str | None = None,
         unit: str | None = None,
     ) -> "PhysicsExpr":
-        """Create a symbolic declared-parameter leaf."""
+        """Create a symbolic declared-parameter leaf.
+
+        Parameters
+        ----------
+        scope, name : str
+            Dotted owner scope and declared field name.
+        symbol, unit : str or None
+            Optional display symbol and unit metadata.
+        """
         return cls("parameter", (f"{scope}.{name}", symbol or name, unit))
 
     @classmethod
     def literal(cls, value: Any) -> "PhysicsExpr":
-        """Create a literal scalar leaf."""
+        """Create a literal scalar leaf.
+
+        Parameters
+        ----------
+        value : scalar
+            Numerical constant copied into the expression.
+        """
         return cls("literal", (copy_value(value, readonly=True),))
 
     @classmethod
@@ -57,7 +82,17 @@ class PhysicsExpr:
         dims: tuple[int, ...],
         name: str | None = None,
     ) -> "PhysicsExpr":
-        """Create a named backend-neutral matrix contribution."""
+        """Create a named backend-neutral matrix contribution.
+
+        Parameters
+        ----------
+        value : array-like
+            Matrix payload with one local block per ``dims`` entry.
+        labels, dims : tuple
+            Matching ordered endpoint labels and positive dimensions.
+        name : str or None
+            Optional display name.
+        """
         if len(labels) != len(dims):
             raise ValueError("Matrix labels and dimensions must have the same length.")
         return cls("matrix", (copy_value(value, readonly=True), tuple(dims), name), tuple(labels))
@@ -76,6 +111,17 @@ class PhysicsExpr:
         The function runs only during numerical materialization. Display keeps
         its declared name and arguments, such as ``X(a, b)``, without exposing
         the implementation as symbolic algebra.
+
+        Parameters
+        ----------
+        function : callable
+            Pure callable evaluated during numerical materialization.
+        *arguments : Any
+            Expression arguments passed to ``function``.
+        labels, dims : tuple
+            Matching endpoint labels and dimensions.
+        name : str or None
+            Display name; required for anonymous callables.
         """
         if len(labels) != len(dims):
             raise ValueError("Function labels and dimensions must have the same length.")
@@ -99,7 +145,17 @@ class PhysicsExpr:
         dims: tuple[int, ...],
         name: str,
     ) -> "PhysicsExpr":
-        """Create a named authored ket contribution."""
+        """Create a named authored ket contribution.
+
+        Parameters
+        ----------
+        value : array-like
+            Ket payload.
+        labels, dims : tuple
+            Matching endpoint labels and dimensions.
+        name : str
+            Display name.
+        """
         return cls("state", (copy_value(value, readonly=True), tuple(dims), name), tuple(labels))
 
     @classmethod
@@ -111,7 +167,19 @@ class PhysicsExpr:
         dims: tuple[int, ...],
         name: str,
     ) -> "PhysicsExpr":
-        """Create an opaque callable ket contribution."""
+        """Create an opaque callable ket contribution.
+
+        Parameters
+        ----------
+        function : callable
+            Callable returning a ket during materialization.
+        *arguments : Any
+            Expression arguments passed to ``function``.
+        labels, dims : tuple
+            Matching endpoint labels and dimensions.
+        name : str
+            Display name.
+        """
         if not callable(function):
             raise TypeError("function must be callable.")
         return cls(
@@ -122,11 +190,25 @@ class PhysicsExpr:
 
     @classmethod
     def from_signal(cls, signal: Any, *, name: str = "f") -> "PhysicsExpr":
-        """Create a scalar time-function leaf backed by an engine signal."""
+        """Create a scalar time-function leaf backed by an engine signal.
+
+        Parameters
+        ----------
+        signal : object
+            Engine signal object evaluated at runtime.
+        name : str, default ``"f"``
+            Display name for the signal node.
+        """
         return cls("signal", (signal, name))
 
     def embed(self, labels: tuple[str, ...], dims: tuple[int, ...]) -> "PhysicsExpr":
-        """Embed this local contribution into an ordered composite Hilbert space."""
+        """Embed this local contribution into an ordered composite Hilbert space.
+
+        Parameters
+        ----------
+        labels, dims : tuple
+            Complete ordered composite labels and matching dimensions.
+        """
         if len(labels) != len(dims):
             raise ValueError("Composite labels and dimensions must have the same length.")
         missing = set(self.labels) - set(labels)
@@ -135,7 +217,13 @@ class PhysicsExpr:
         return PhysicsExpr("embed", (self, tuple(labels), tuple(dims)), tuple(labels))
 
     def with_bindings(self, bindings: Mapping[str, Any]) -> "PhysicsExpr":
-        """Attach default values used only by direct numerical inspection."""
+        """Attach default values used only by direct numerical inspection.
+
+        Parameters
+        ----------
+        bindings : mapping[str, Any]
+            Dotted parameter paths to numerical values.
+        """
         return replace(self, _bindings=copy_value(dict(bindings), readonly=True))
 
     def parameter_paths(self) -> tuple[str, ...]:
@@ -277,7 +365,17 @@ class PhysicsExpr:
         t: Any | None = None,
         backend: Any = None,
     ) -> Any:
-        """Materialize this expression and return its dense numerical array."""
+        """Materialize this expression and return its dense numerical array.
+
+        Parameters
+        ----------
+        bindings : mapping or None, optional
+            Values for unresolved parameter paths.
+        t : scalar or None, keyword-only
+            Time for signal evaluation.
+        backend : backend or None, keyword-only
+            Backend lowering object; ``None`` selects the default.
+        """
         if backend is None:
             from quchip.backend import get_default_backend
 
@@ -341,7 +439,28 @@ def as_operator_expr(
     scope: str | None = None,
     allowed: Mapping[str, Any] | None = None,
 ) -> PhysicsExpr:
-    """Normalize symbolic, matrix, or opaque callable operator authorship."""
+    """Normalize symbolic, matrix, or opaque callable operator authorship.
+
+    Parameters
+    ----------
+    value : PhysicsExpr, callable, or matrix
+        Authored operator representation.
+    labels, dims : tuple
+        Ordered endpoint labels and matching dimensions.
+    name : str
+        Display name for opaque or matrix contributions.
+    arguments : tuple, default ()
+        Arguments for an opaque callable.
+    owner : object or None, default None
+        Object whose fields bind a callable's positional argument names.
+        Mutually exclusive with explicit ``arguments``.
+    scope : str or None, default None
+        Dotted-path prefix for owner-bound parameters, such as a device label.
+        Required with ``owner`` when the callable has arguments.
+    allowed : mapping or None, default None
+        Permitted owner-field names (mapping keys). ``None`` accepts any
+        named field present on the owner; values in this mapping are unused.
+    """
     expected = (prod(dims), prod(dims))
     if isinstance(value, PhysicsExpr):
         if not value.labels:
@@ -383,7 +502,26 @@ def as_scalar_expr(
     scope: str | None = None,
     allowed: Mapping[str, Any] | None = None,
 ) -> PhysicsExpr:
-    """Normalize symbolic, numeric, or opaque callable scalar authorship."""
+    """Normalize symbolic, numeric, or opaque callable scalar authorship.
+
+    Parameters
+    ----------
+    value : PhysicsExpr, scalar, or callable
+        Authored scalar representation.
+    name : str
+        Display name for opaque callables.
+    arguments : tuple, default ()
+        Arguments for an opaque callable.
+    owner : object or None, default None
+        Object whose fields bind a callable's positional argument names.
+        Mutually exclusive with explicit ``arguments``.
+    scope : str or None, default None
+        Dotted-path prefix for owner-bound parameters, such as a device label.
+        Required with ``owner`` when the callable has arguments.
+    allowed : mapping or None, default None
+        Permitted owner-field names (mapping keys). ``None`` accepts any
+        named field present on the owner; values in this mapping are unused.
+    """
     if isinstance(value, PhysicsExpr):
         if value.labels:
             raise TypeError("A scalar expression cannot carry subsystem labels.")
@@ -413,7 +551,28 @@ def as_state_expr(
     scope: str | None = None,
     allowed: Mapping[str, Any] | None = None,
 ) -> PhysicsExpr:
-    """Normalize an authored ket array or opaque callable without evaluating it."""
+    """Normalize an authored ket array or opaque callable without evaluating it.
+
+    Parameters
+    ----------
+    value : PhysicsExpr, callable, or array
+        Authored ket representation.
+    labels, dims : tuple
+        Ordered endpoint labels and matching dimensions.
+    name : str
+        Display name for the state contribution.
+    arguments : tuple, default ()
+        Arguments for an opaque callable.
+    owner : object or None, default None
+        Object whose fields bind a callable's positional argument names.
+        Mutually exclusive with explicit ``arguments``.
+    scope : str or None, default None
+        Dotted-path prefix for owner-bound parameters, such as a device label.
+        Required with ``owner`` when the callable has arguments.
+    allowed : mapping or None, default None
+        Permitted owner-field names (mapping keys). ``None`` accepts any
+        named field present on the owner; values in this mapping are unused.
+    """
     expected = (prod(dims), 1)
     if isinstance(value, PhysicsExpr):
         if value.labels != labels:

--- a/quchip/declarative/models.py
+++ b/quchip/declarative/models.py
@@ -287,6 +287,15 @@ class DeviceModel(BaseDevice, metaclass=DeclarativeMeta):
     >>> device = DuffingOscillator(freq=5.0, anharmonicity=-0.3, levels=4)
     >>> device.freq
     5.0
+
+    Parameters
+    ----------
+    levels : int, keyword-only, default 2
+        Native local-space dimension or truncation.
+    label : str or None, keyword-only, default None
+        Stable device label; ``None`` selects an automatic label.
+    **params : Any
+        Declared model parameters and optional noise fields.
     """
 
     levels: int = constructor_field(default=2, kw_only=True)
@@ -478,12 +487,27 @@ class DeviceModel(BaseDevice, metaclass=DeclarativeMeta):
         raise NotImplementedError
 
     def time_terms(self, op: Any, p: Any) -> tuple[TimeDependentTerm, ...]:
-        """Return local time-dependent Hamiltonian terms beyond the static model."""
+        """Return local time-dependent Hamiltonian terms beyond the static model.
+
+        Parameters
+        ----------
+        op : LocalOps
+            Local operator namespace.
+        p : ParameterNamespace
+            Symbolic declared parameters.
+        """
         _ = (op, p)
         return ()
 
     def dissipation(self, op: Any, p: Any) -> tuple[CollapseChannel, ...]:
         """Return device-local Lindblad channels.
+
+        Parameters
+        ----------
+        op : LocalOps
+            Local operator namespace.
+        p : ParameterNamespace
+            Symbolic declared parameters.
 
         The base channels implement T1, T2, and thermal occupation. Subclasses
         may append channels with ``super().dissipation(op, p)``.
@@ -538,7 +562,13 @@ class DeviceModel(BaseDevice, metaclass=DeclarativeMeta):
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "DeviceModel":
-        """Reconstruct the device from :meth:`to_dict` output."""
+        """Reconstruct the device from :meth:`to_dict` output.
+
+        Parameters
+        ----------
+        d : mapping
+            Serialized device record.
+        """
         d = cls._normalize_parameter_names(d)
         fields = cls.__quchip_param_fields__
         params = {
@@ -600,6 +630,15 @@ class CouplingModel(BaseCoupling, metaclass=DeclarativeMeta):
     >>> c = ExchangeCoupling("q0", "q1", g=0.01)
     >>> c.coupling_strength
     0.01
+
+    Parameters
+    ----------
+    device_a, device_b : device or str
+        Coupled devices or their labels.
+    label : str or None, keyword-only, default None
+        Stable coupling label.
+    **params : Any
+        Declared coupling parameters and settings.
     """
 
     device_a: BaseDevice | str = constructor_field()
@@ -688,6 +727,9 @@ class CouplingModel(BaseCoupling, metaclass=DeclarativeMeta):
             operators compose with ``@``; cross-endpoint operators combine
             with ``*`` (tensor product).
 
+        p : ParameterNamespace
+            Symbolic declared coupling parameters.
+
         Returns
         -------
         PhysicsExpr
@@ -704,6 +746,9 @@ class CouplingModel(BaseCoupling, metaclass=DeclarativeMeta):
         a, b : EndpointOps
             Operator namespaces for the two coupled endpoints.
 
+        p : ParameterNamespace
+            Symbolic declared coupling parameters.
+
         Returns
         -------
         tuple of TimeDependentTerm
@@ -716,6 +761,15 @@ class CouplingModel(BaseCoupling, metaclass=DeclarativeMeta):
     def parametric_interaction(self, a: Any, b: Any, p: Any) -> Any:
         """Return the parametric interaction structure, or ``None`` when this coupling is not modulable.
 
+        Parameters
+        ----------
+        a, b : EndpointOps
+            Ordered endpoint operator namespaces.
+        p : ParameterNamespace
+            Symbolic declared coupling parameters.
+
+        Notes
+        -----
         The coupling-side mirror of the device drive-dispatch protocols: a
         :class:`~quchip.control.drive.ParametricDrive` accepts any coupling
         whose hook returns a :class:`~quchip.declarative.expr.PhysicsExpr`.
@@ -724,7 +778,15 @@ class CouplingModel(BaseCoupling, metaclass=DeclarativeMeta):
         return None
 
     def dissipation(self, a: Any, b: Any, p: Any) -> tuple[CollapseChannel, ...]:
-        """Return authored two-endpoint Lindblad channels."""
+        """Return authored two-endpoint Lindblad channels.
+
+        Parameters
+        ----------
+        a, b : EndpointOps
+            Ordered endpoint operator namespaces.
+        p : ParameterNamespace
+            Symbolic declared coupling parameters.
+        """
         _ = (a, b, p)
         return ()
 
@@ -852,6 +914,13 @@ class CouplingModel(BaseCoupling, metaclass=DeclarativeMeta):
     @classmethod
     def from_dict(cls, d: dict[str, Any], device_a: Any, device_b: Any) -> "CouplingModel":
         """Reconstruct a coupling from :meth:`to_dict` output.
+
+        Parameters
+        ----------
+        d : mapping
+            Serialized coupling record.
+        device_a, device_b : device or str
+            Endpoints supplied by the containing chip.
 
         Default implementation: forward declared parameters straight into
         ``__init__``. Subclasses with bespoke serialization (e.g. envelope

--- a/quchip/declarative/ops.py
+++ b/quchip/declarative/ops.py
@@ -31,6 +31,15 @@ class LocalOps:
     >>> H = 5.0 * op.n + 0.5 * (op.adag @ op.adag @ op.a @ op.a)
     >>> H.kind
     'add'
+
+    Parameters
+    ----------
+    label : str
+        Endpoint label.
+    space : LocalSpace
+        Authored local Hilbert space.
+    device : device or None, default None
+        Owning device, required for derived energy-level operators.
     """
 
     label: str

--- a/quchip/declarative/parameters.py
+++ b/quchip/declarative/parameters.py
@@ -41,6 +41,19 @@ class Parameter:
     """Metadata for a declared parameter's validation and serialization.
 
     Sign constraints apply to concrete scalars; traced values pass unchecked.
+
+    Parameters
+    ----------
+    default : Any, default ``UNBOUND``
+        Constructor default; ``UNBOUND`` makes the field required.
+    positive, nonnegative : bool, default False
+        Reject concrete values outside the selected sign constraint.
+    serialize : bool, default True
+        Include the field in serialized model data.
+    unit, symbol : str or None
+        Display metadata for units and mathematical notation.
+    noise, kw_only, required : bool
+        Mark noise fields, force keyword-only construction, or require a value.
     """
 
     default: Any = UNBOUND
@@ -56,7 +69,17 @@ class Parameter:
 
 @dataclass(frozen=True)
 class Setting:
-    """Metadata for a serialized, non-traceable structural model choice."""
+    """Metadata for a serialized, non-traceable structural model choice.
+
+    Parameters
+    ----------
+    default : Any, default ``UNBOUND``
+        Structural default; ``UNBOUND`` makes the setting required.
+    serialize : bool, default True
+        Include the setting in serialized model data.
+    kw_only : bool, default True
+        Must remain true because settings are structural choices.
+    """
 
     default: Any = UNBOUND
     serialize: bool = True
@@ -121,6 +144,8 @@ def parameter(
     noise : bool, optional
         Whether :meth:`Chip.set_noise` may configure this field while its
         current value is unset.
+    kw_only : bool, optional
+        Place the declared field after the ``*`` in synthesized constructors.
 
     Examples
     --------
@@ -147,7 +172,17 @@ def parameter(
 
 
 def setting(*, default: Any = UNBOUND, serialize: bool = True, kw_only: bool = True) -> Any:
-    """Declare serialized structural configuration on a model class."""
+    """Declare serialized structural configuration on a model class.
+
+    Parameters
+    ----------
+    default : Any, default ``UNBOUND``
+        Structural default; omission makes the setting required.
+    serialize : bool, default True
+        Include the setting in serialized data.
+    kw_only : bool, default True
+        Must remain true for structural settings.
+    """
     if not kw_only:
         raise ValueError("Declarative settings are keyword-only.")
     return Setting(default=default, serialize=serialize, kw_only=kw_only)

--- a/quchip/devices/base.py
+++ b/quchip/devices/base.py
@@ -403,6 +403,15 @@ class BaseDevice(StateVersioned, Registrable, ABC, registry_root=True):
     def set_tunable_param(self, name: str, value: Any) -> None:
         """Update a bare parameter named in :meth:`tunable_params`.
 
+        Parameters
+        ----------
+        name : str
+            Tunable field name.
+        value : Any
+            Replacement numerical value.
+
+        Notes
+        -----
         Default implementation uses :func:`setattr` so any direct
         attribute (``freq``, ``anharmonicity``, ``E_C``, …) works
         without ceremony. Subclasses with derived properties that need
@@ -418,6 +427,15 @@ class BaseDevice(StateVersioned, Registrable, ABC, registry_root=True):
     def tunable_param_bounds(self, name: str, value: float) -> tuple[float, float]:
         """Return ``(lower, upper)`` bounds for a tunable parameter at a seed value.
 
+        Parameters
+        ----------
+        name : str
+            Tunable parameter name.
+        value : float
+            Concrete seed used to construct bounds.
+
+        Notes
+        -----
         These bounds are consumed by the inverse-design optimizer to keep
         searches physical. The default uses well-named conventions that
         cover the common circuit-QED parameters:
@@ -479,7 +497,15 @@ class BaseDevice(StateVersioned, Registrable, ABC, registry_root=True):
         return values
 
     def set_parameter_value(self, name: str, value: Any) -> None:
-        """Apply one validated local parameter value on an isolated device copy."""
+        """Apply one validated local parameter value on an isolated device copy.
+
+        Parameters
+        ----------
+        name : str
+            Declared or tunable parameter name.
+        value : Any
+            Replacement value.
+        """
         if name == "thermal_population":
             warn_renamed(name, "thermal_occupation")
             name = "thermal_occupation"
@@ -495,7 +521,13 @@ class BaseDevice(StateVersioned, Registrable, ABC, registry_root=True):
         raise KeyError(name)
 
     def set_parameter_values(self, values: Mapping[str, Any]) -> None:
-        """Validate a complete candidate before applying a local parameter group."""
+        """Validate a complete candidate before applying a local parameter group.
+
+        Parameters
+        ----------
+        values : mapping[str, Any]
+            Parameter names and replacement values, applied atomically.
+        """
         values = self._normalize_parameter_names(values)
         if not values:
             return
@@ -623,6 +655,11 @@ class BaseDevice(StateVersioned, Registrable, ABC, registry_root=True):
     def resolve(self, *, frame: FrameSpec | None = None) -> EngineResult:
         """Resolve isolated device physics with its own basis and explicit frame.
 
+        Parameters
+        ----------
+        frame : FrameSpec or None, keyword-only
+            Explicit rotating-frame specification; ``None`` uses the lab frame.
+
         The default frame is the lab frame. Chip membership does not affect
         this local calculation; use the chip for coupled-system queries.
         """
@@ -690,7 +727,13 @@ class BaseDevice(StateVersioned, Registrable, ABC, registry_root=True):
         self,
         chip_basis: Literal["native", "eigen"] = "native",
     ) -> Literal["native", "eigen"]:
-        """Return the device override or inherited chip basis policy."""
+        """Return the device override or inherited chip basis policy.
+
+        Parameters
+        ----------
+        chip_basis : {"native", "eigen"}, default "native"
+            Fallback policy when the device has no explicit basis setting.
+        """
         policy = self.basis if self.basis is not None else chip_basis
         if policy not in ("native", "eigen"):
             raise ValueError(f"basis must be 'native', 'eigen', or None, got {policy!r}.")
@@ -720,7 +763,13 @@ class BaseDevice(StateVersioned, Registrable, ABC, registry_root=True):
         self,
         chip_basis: Literal["native", "eigen"] = "native",
     ) -> int:
-        """Return the local dimension delivered to the solver."""
+        """Return the local dimension delivered to the solver.
+
+        Parameters
+        ----------
+        chip_basis : {"native", "eigen"}, default "native"
+            Fallback basis policy.
+        """
         policy = self.resolved_basis(chip_basis)
         if policy == "native":
             return self.local_space().dimension
@@ -769,6 +818,14 @@ class BaseDevice(StateVersioned, Registrable, ABC, registry_root=True):
     def local_operator(self, name: str) -> Operator:
         """Map an operator-name string to this device's own local operator.
 
+        Parameters
+        ----------
+        name : str
+            Operator vocabulary name such as ``"X"``, ``"n"``, ``"a"``,
+            ``"charge"`` or ``"I"``.
+
+        Notes
+        -----
         Recognized names: ``"X"`` / ``"Y"`` / ``"Z"`` (Pauli projections on
         the computational ``|0>, |1>`` subspace), ``"n"`` (number), ``"a"``
         (lowering), ``"a_dag"`` (raising), ``"I"`` (identity). The device owns
@@ -810,20 +867,50 @@ class BaseDevice(StateVersioned, Registrable, ABC, registry_root=True):
         )
 
     def basis_state(self, n: int) -> State:
-        """Fock basis state ``|n>`` on the truncated Hilbert space."""
+        """Return Fock basis state ``|n>``.
+
+        Parameters
+        ----------
+        n : int
+            Non-negative basis index below ``levels``.
+        """
         return get_default_backend().basis(self.levels, n)
 
     def coherent_state(self, alpha: complex) -> State:
-        """Coherent state ``|alpha>`` on the truncated Fock basis."""
+        """Return coherent state ``|alpha>`` on the truncated Fock basis.
+
+        Parameters
+        ----------
+        alpha : complex
+            Dimensionless coherent-state amplitude.
+        """
         return get_default_backend().coherent(self.levels, alpha)
 
     def plot_energy_levels(self, *, ax: Any = None, **kwargs: Any) -> Any:
-        """Plot the device's bare energy-level ladder (delegates to :mod:`quchip.viz`)."""
+        """Plot the device's bare energy-level ladder.
+
+        Parameters
+        ----------
+        ax : matplotlib Axes or None, keyword-only
+            Existing axes, or ``None`` to create one.
+        **kwargs : Any
+            Plot styling forwarded to the visualization helper.
+        """
         from quchip.viz.device import plot_energy_levels
         return plot_energy_levels(self, ax=ax, **kwargs)
 
     def plot_wavefunction(self, n: int, *, ax: Any = None, **kwargs: Any) -> Any:
-        """Plot the ``n``-th eigenstate wavefunction (delegates to :mod:`quchip.viz`)."""
+        """Plot an eigenstate wavefunction.
+
+        Parameters
+        ----------
+        n : int
+            Eigenstate index.
+        ax : matplotlib Axes or None, keyword-only
+            Existing axes, or ``None`` to create one.
+        **kwargs : Any
+            Plot styling forwarded to the visualization helper.
+        """
         from quchip.viz.device import plot_wavefunction
         return plot_wavefunction(self, n, ax=ax, **kwargs)
 
@@ -884,6 +971,11 @@ class BaseDevice(StateVersioned, Registrable, ABC, registry_root=True):
     def projector(self, i: int, j: int) -> Operator:
         """``|i><j|`` on the authored local basis.
 
+        Parameters
+        ----------
+        i, j : int
+            Ket and bra indices in the authored local basis.
+
         Use ``projector(i, i)`` for the population projector
         ``|i><i|`` and ``projector(i, j)`` for ``|i><j|``. No subspace
         approximation: the operator acts on the full authored local space.
@@ -895,6 +987,11 @@ class BaseDevice(StateVersioned, Registrable, ABC, registry_root=True):
 
     def transition(self, lower: int, upper: int) -> Operator:
         """Hermitian transition between isolated energy states.
+
+        Parameters
+        ----------
+        lower, upper : int
+            Isolated energy-level indices with ``lower < upper``.
 
         The operator ``|lower><upper| + |upper><lower|`` is returned in the
         authored local basis.
@@ -916,7 +1013,13 @@ class BaseDevice(StateVersioned, Registrable, ABC, registry_root=True):
         )
 
     def transition_frequency(self, lower: int, upper: int) -> Any:
-        """Return the isolated ``E_upper - E_lower`` transition in GHz."""
+        """Return the isolated ``E_upper - E_lower`` transition in GHz.
+
+        Parameters
+        ----------
+        lower, upper : int
+            Isolated energy-level indices with ``lower < upper``.
+        """
         from quchip.engine.basis import resolve_device_basis
 
         _validate_level_pair(
@@ -1027,7 +1130,14 @@ class BaseDevice(StateVersioned, Registrable, ABC, registry_root=True):
         self,
         basis: "BasisRecord | None" = None,
     ) -> tuple[CollapseChannel, ...]:
-        """Return normalized local collapse channels."""
+        """Return normalized local collapse channels.
+
+        Parameters
+        ----------
+        basis : BasisRecord or None, optional
+            Resolved basis for matrix-element channels; ``None`` resolves the
+            device's current basis policy.
+        """
         return tuple(channel for channel, _paths in self._collapse_channels_with_paths(basis))
 
     @classmethod
@@ -1147,6 +1257,11 @@ class BaseDevice(StateVersioned, Registrable, ABC, registry_root=True):
 
     def connect(self, drive: "BaseDrive") -> None:
         """Register a drive as connected: idempotent on identity, replace-on-relabel.
+
+        Parameters
+        ----------
+        drive : BaseDrive
+            Drive object to attach.
 
         A drive's label is its stable identity as a control line
         (``chip.wire`` already rejects duplicate labels within one

--- a/quchip/devices/fluxonium.py
+++ b/quchip/devices/fluxonium.py
@@ -16,7 +16,55 @@ from quchip.devices.spaces import PhaseGridSpace
 
 
 class Fluxonium(DeviceModel):
-    """Fluxonium with its Hamiltonian authored in a finite phase-grid basis."""
+    r"""Fluxonium in a finite phase-grid basis.
+
+    The native Hamiltonian is
+    :math:`4E_C n^2 + E_L(\varphi+2\pi\varphi_{ext})^2/2
+    -E_J\cos\varphi` in ordinary GHz.
+
+    Parameters
+    ----------
+    E_C, E_J, E_L : float
+        Positive charging, Josephson, and inductive energies in GHz.
+    phi_ext : float, default 0.0
+        External reduced flux :math:`\Phi_{ext}/\Phi_0`.
+    levels : int or None, default None
+        Number of eigenstates projected into the chip. Required when
+        ``basis="eigen"``; ``None`` uses the native dimension for the native
+        basis.
+    label : str or None, default None
+        Device label.
+    num_basis : int, keyword-only, default 400
+        Odd-or-even phase-grid size; must be at least 3.
+    phi_max : float, keyword-only, default 5*pi
+        Positive half-width of the phase grid.
+    basis : {None, "native", "eigen"}, keyword-only
+        Requested solver basis. ``None`` inherits the chip policy and uses
+        native basis for standalone resolution; ``native`` keeps the phase
+        grid, while ``eigen`` projects onto ``levels`` energy states.
+    collapse_model : {"fermi_golden", "ladder"}, default "fermi_golden"
+        Relaxation construction. The Fermi-golden-rule option requires a
+        ``coupling_channel`` when ``T1`` is set.
+    coupling_channel : {None, "charge", "flux"}, default None
+        Physical operator used for matrix-element relaxation: ``"charge"``
+        selects :math:`n`, and ``"flux"`` selects :math:`\varphi`.
+    collapse_rate_threshold : float, default 1e-8
+        Non-negative dimensionless cutoff on squared matrix-element ratios
+        relative to the selected ``0 -> 1`` transition.
+    T1, T2 : float or None
+        Relaxation and dephasing times in ns; ``None`` disables each channel.
+    thermal_occupation : float or None
+        Mean thermal occupation (dimensionless); ``None`` disables thermal
+        absorption.
+    noise : keyword arguments
+        The concrete constructor also accepts these inherited noise fields as
+        keyword arguments for compatibility with the declarative device API.
+
+    References
+    ----------
+    See Manucharyan et al., *Science* 326, 113 (2009),
+    https://doi.org/10.1126/science.1175552, for the fluxonium Hamiltonian.
+    """
 
     _type_prefix = "fluxonium"
     tunable_param_names = ("E_C", "E_J", "E_L", "phi_ext")
@@ -106,7 +154,15 @@ class Fluxonium(DeviceModel):
         return PhaseGridSpace(points=self.num_basis, extent=self.phi_max)
 
     def local_hamiltonian(self, op: LocalOps, p: Any) -> PhysicsExpr:
-        """Return the native fluxonium Hamiltonian in ordinary GHz."""
+        """Return the native fluxonium Hamiltonian in ordinary GHz.
+
+        Parameters
+        ----------
+        op : LocalOps
+            Phase-grid operator namespace.
+        p : ParameterNamespace
+            Symbolic ``E_C``, ``E_J``, ``E_L`` and ``phi_ext`` values.
+        """
         shifted_phase = op.phi + (2.0 * pi) * p.phi_ext * op.I
         return (
             4.0 * p.E_C * op.n2
@@ -190,6 +246,13 @@ class Fluxonium(DeviceModel):
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "Fluxonium":
+        """Reconstruct from serialized constructor data.
+
+        Parameters
+        ----------
+        data : mapping
+            Record produced by :meth:`to_dict`.
+        """
         return cls(
             E_C=data["E_C"],
             E_J=data["E_J"],

--- a/quchip/devices/fock.py
+++ b/quchip/devices/fock.py
@@ -16,6 +16,14 @@ class FockDevice(DeviceModel):
     Subclasses still own their Hamiltonian and approximation. This base only
     declares the standard Fock-space operators used by charge, phase, and
     frequency-modulating drives.
+    Parameters
+    ----------
+    levels : int, keyword-only, default 2
+        Fock-space truncation dimension.
+    label : str or None, keyword-only, default None
+        Device label.
+    **params : Any
+        Subclass physics and noise parameters.
     """
 
     __init__ = DeviceModel.__init__
@@ -25,7 +33,15 @@ class FockDevice(DeviceModel):
 
     @abstractmethod
     def local_hamiltonian(self, op: LocalOps, p: Any) -> PhysicsExpr:
-        """Declare this device's local Hamiltonian in its Fock space."""
+        """Declare this device's local Hamiltonian in its Fock space.
+
+        Parameters
+        ----------
+        op : LocalOps
+            Fock operator namespace.
+        p : ParameterNamespace
+            Symbolic declared parameters.
+        """
         ...
 
     def charge_coupling_operator(self) -> PhysicsExpr:

--- a/quchip/devices/kerr_cavity.py
+++ b/quchip/devices/kerr_cavity.py
@@ -74,9 +74,12 @@ class KerrCavity(FockDevice):
     label : str | None
         Human-readable label.  ``None`` → auto-generated
         ``kerr_cavity_0``, ``kerr_cavity_1``, …
-    **noise_kwargs
-        Forwarded to :class:`~quchip.devices.base.BaseDevice`:
-        ``T1``, ``T2``, ``thermal_occupation``, etc.
+    T1 : float or None, default None
+        Energy-relaxation time in ns; ``None`` disables T1 relaxation.
+    T2 : float or None, default None
+        Total 0-1 coherence time in ns; if both are set, ``T2 <= 2*T1``.
+    thermal_occupation : float or None, default None
+        Dimensionless mean bath occupation; ``None`` disables absorption.
 
     Notes
     -----
@@ -131,7 +134,14 @@ class KerrCavity(FockDevice):
         PhysicsExpr
             Declarative expression for the Hermitian operator
             ``H = omega*n - K*n*(n-1)`` (GHz), diagonal in the Fock basis.
+        Parameters
+        ----------
+        op : LocalOps
+            Fock operator namespace.
+        p : ParameterNamespace
+            Symbolic ``freq`` and ``kerr`` values.
         """
+
         n = op.n
         return p.freq * n - p.kerr * (n @ (n - op.I))
 

--- a/quchip/devices/protocols.py
+++ b/quchip/devices/protocols.py
@@ -79,5 +79,11 @@ class FrequencyControlled(Protocol):
     """
 
     def frequency_at(self, flux: Any) -> Any:
-        """Return the device's transition frequency at the given flux bias."""
+        """Return the device's transition frequency at a flux bias.
+
+        Parameters
+        ----------
+        flux : float or array-like
+            Reduced flux bias in units of ``Phi_0``.
+        """
         ...

--- a/quchip/devices/resonator.py
+++ b/quchip/devices/resonator.py
@@ -21,15 +21,15 @@ Optional dissipation
 --------------------
 Passing ``internal_quality_factor = Q`` adds a single unobserved photon-loss collapse
 operator ``sqrt(kappa) a`` with :math:`\\kappa = 2\\pi\\,f/Q`
-(angular decay rate, rad/ns).
+(energy-decay rate, 1/ns).
 
 **Quality-factor convention (physics, not a unit conversion).**
 ``internal_quality_factor`` is defined against the *ordinary* frequency
 ``freq`` (GHz) carried by this class. The resulting decay rate is
-:math:`\\kappa = 2\\pi\\,f/Q` (angular, rad/ns). The :math:`2\\pi`
+:math:`\\kappa = 2\\pi\\,f/Q` (energy decay, 1/ns). The :math:`2\\pi`
 here is intrinsic to the physical definition of Q — not an
 ordinary→angular units conversion bolted on at the engine boundary.
-Concretely, Q counts cycles of the *ordinary* oscillation per
+Concretely, ``Q/(2*pi)`` is the number of ordinary-frequency cycles per
 e-folding of energy, so energy decays as
 :math:`e^{-t/\\tau} = e^{-\\kappa t}` with
 :math:`\\kappa = \\omega/Q = 2\\pi f/Q`. For this reason the
@@ -82,8 +82,8 @@ class Resonator(FockDevice):
     internal_quality_factor : float | None, optional
         Internal Q referenced to the ordinary frequency ``freq`` in GHz.
         When set, adds a photon-loss Lindblad channel
-        ``sqrt(2*pi*freq/Q) a`` with angular decay rate
-        ``kappa = 2*pi*freq/Q`` in rad/ns. Must be positive. Like every
+        ``sqrt(2*pi*freq/Q) a`` with energy-decay rate
+        ``kappa = 2*pi*freq/Q`` in 1/ns. Must be positive. Like every
         noise parameter, it may be set after construction or cleared with
         ``None``; the next simulation reflects the current value.
     levels : int, default 10
@@ -92,9 +92,17 @@ class Resonator(FockDevice):
     label : str | None, default None
         If omitted, auto-generated as ``resonator_{idx}`` via the shared
         labeling counter.
-    **noise_kwargs
-        Forwarded verbatim to :class:`BaseDevice` — ``T1``, ``T2``,
-        ``thermal_occupation``.
+    T1 : float or None, default None
+        Energy-relaxation time in ns; ``None`` disables T1 relaxation.
+    T2 : float or None, default None
+        Total 0-1 coherence time in ns; if both are set, ``T2 <= 2*T1``.
+    thermal_occupation : float or None, default None
+        Dimensionless mean bath occupation; ``None`` disables absorption.
+
+    References
+    ----------
+    Blais et al., *Rev. Mod. Phys.* 93, 025005 (2021),
+    https://doi.org/10.1103/RevModPhys.93.025005.
 
     Example
     -------
@@ -116,7 +124,15 @@ class Resonator(FockDevice):
     approximation = "Linear harmonic oscillator with no Kerr or cross-Kerr self-interaction."
 
     def local_hamiltonian(self, op: LocalOps, p: Any) -> PhysicsExpr:
-        """Return the harmonic oscillator Hamiltonian ``H = freq * n``."""
+        """Return the harmonic oscillator Hamiltonian ``H = freq * n``.
+
+        Parameters
+        ----------
+        op : LocalOps
+            Fock operator namespace.
+        p : ParameterNamespace
+            Symbolic ``freq`` value.
+        """
         return p.freq * op.n
 
     def dissipation(self, op: LocalOps, p: Any) -> tuple[CollapseChannel, ...]:

--- a/quchip/devices/spaces.py
+++ b/quchip/devices/spaces.py
@@ -14,7 +14,17 @@ import jax.numpy as jnp
 
 @dataclass(frozen=True)
 class TruncationBoundary:
-    """Authored basis indices near a cutoff and the corresponding convergence check."""
+    """Authored basis indices near a cutoff and the corresponding convergence check.
+
+    Parameters
+    ----------
+    indices : tuple[int, ...]
+        Distinct non-negative boundary indices.
+    description : str
+        Human-readable boundary name.
+    convergence_hint : str
+        Suggested convergence comparison.
+    """
 
     indices: tuple[int, ...]
     description: str
@@ -37,14 +47,28 @@ class LocalSpace(ABC):
 
     @abstractmethod
     def matrix(self, name: str) -> Any:
-        """Return one named operator as a JAX-compatible dense array."""
+        """Return one named operator as a JAX-compatible dense array.
+
+        Parameters
+        ----------
+        name : str
+            Operator name supported by the concrete space.
+        """
 
     def truncation_boundary(self) -> TruncationBoundary | None:
         """Describe a cutoff, or return None for an intrinsically finite space."""
         raise NotImplementedError(f"{type(self).__name__} does not declare a truncation boundary")
 
     def operator(self, name: str, backend: Any) -> Any:
-        """Lower one named local operator through ``backend``."""
+        """Lower one named local operator through ``backend``.
+
+        Parameters
+        ----------
+        name : str
+            Supported local operator name.
+        backend : backend protocol
+            Object providing native operator constructors.
+        """
         return backend.from_array(
             self.matrix(name),
             dims=[[self.dimension], [self.dimension]],
@@ -53,7 +77,14 @@ class LocalSpace(ABC):
 
 @dataclass(frozen=True)
 class FockSpace(LocalSpace):
-    """Finite Fock ladder with the standard bosonic and qubit operators."""
+    """Finite Fock ladder with standard bosonic and qubit operators.
+
+    Parameters
+    ----------
+    levels : int
+        Hilbert-space dimension; must be at least 2. The ``a`` ladder is
+        truncated at ``levels - 1``.
+    """
 
     levels: int
 
@@ -69,6 +100,13 @@ class FockSpace(LocalSpace):
         return self.levels
 
     def matrix(self, name: str) -> Any:
+        """Return a named charge-space matrix.
+
+        Parameters
+        ----------
+        name : {"n", "cos_phi", "sin_phi", "I"}
+            Operator to construct.
+        """
         annihilation = jnp.diag(jnp.sqrt(jnp.arange(1, self.levels)), 1).astype(jnp.complex128)
         if name == "a":
             return annihilation
@@ -110,7 +148,14 @@ class FockSpace(LocalSpace):
 
 @dataclass(frozen=True)
 class ChargeSpace(LocalSpace):
-    """Finite integer-charge basis centered on zero charge."""
+    """Finite integer-charge basis centered on zero charge.
+
+    Parameters
+    ----------
+    num_basis : int
+        Odd basis size, at least 3; charges run from
+        ``-(num_basis-1)//2`` to ``+(num_basis-1)//2``.
+    """
 
     num_basis: int
 
@@ -127,6 +172,13 @@ class ChargeSpace(LocalSpace):
         return self.num_basis
 
     def matrix(self, name: str) -> Any:
+        """Return a named phase-grid matrix.
+
+        Parameters
+        ----------
+        name : {"phi", "n", "n2", "cos_phi", "sin_phi", "I"}
+            Operator to construct.
+        """
         plus = jnp.eye(self.num_basis, k=1, dtype=jnp.complex128)
         minus = jnp.eye(self.num_basis, k=-1, dtype=jnp.complex128)
         if name == "n":
@@ -149,6 +201,12 @@ class PhaseGridSpace(LocalSpace):
 
     The centered-difference stencil does not wrap across the grid boundary;
     values beyond either endpoint are treated as zero.
+    Parameters
+    ----------
+    points : int
+        Number of endpoint-excluded grid points; at least 3.
+    extent : float
+        Positive half-width of the grid, in dimensionless phase radians.
     """
 
     points: int
@@ -169,6 +227,13 @@ class PhaseGridSpace(LocalSpace):
         return self.points
 
     def matrix(self, name: str) -> Any:
+        """Return one custom operator matrix.
+
+        Parameters
+        ----------
+        name : str
+            Key in :attr:`operators`.
+        """
         phase = jnp.linspace(-self.extent, self.extent, self.points, endpoint=False)
         spacing = 2.0 * self.extent / self.points
         plus = jnp.eye(self.points, k=1, dtype=jnp.complex128)
@@ -192,7 +257,16 @@ class PhaseGridSpace(LocalSpace):
 
 
 class CustomSpace(LocalSpace):
-    """Named local operators supplied as matrices or zero-argument JAX callables."""
+    """Named local operators supplied as matrices or zero-argument JAX callables.
+
+    Parameters
+    ----------
+    dimension : int
+        Positive matrix dimension.
+    operators : mapping[str, array or callable]
+        Operator providers. Each resulting matrix must have shape
+        ``(dimension, dimension)``.
+    """
 
     def __init__(self, dimension: int, operators: Mapping[str, Any]) -> None:
         if index(dimension) < 1:

--- a/quchip/devices/transmon/charge_basis.py
+++ b/quchip/devices/transmon/charge_basis.py
@@ -17,7 +17,51 @@ from quchip.utils.jax_utils import maybe_concrete_scalar
 
 
 class ChargeBasisTransmon(DeviceModel):
-    """Transmon with its Hamiltonian authored in the integer-charge basis."""
+    r"""Transmon with its Hamiltonian authored in the integer-charge basis.
+
+    The native Hamiltonian is :math:`4E_C(n-n_g)^2-E_J\cos\varphi` in
+    ordinary GHz.
+
+    Parameters
+    ----------
+    E_C, E_J : float
+        Positive charging and Josephson energies in GHz.
+    n_g : float, default 0.0
+        Offset charge in Cooper-pair units.
+    levels : int or None, default None
+        Number of projected eigenstates. Required when ``basis="eigen"``;
+        ``None`` uses the native dimension for the native basis.
+    label : str or None, default None
+        Device label.
+    num_basis : int, keyword-only, default 61
+        Odd integer-charge basis size, at least 3.
+    basis : {None, "native", "eigen"}, keyword-only
+        Requested solver basis. ``None`` inherits the chip policy and uses
+        native basis for standalone resolution; ``native`` keeps the charge
+        basis, while ``eigen`` projects onto ``levels`` energy states.
+    collapse_model : {"fermi_golden", "ladder"}, default "fermi_golden"
+        Relaxation construction; Fermi-golden-rule relaxation needs
+        ``coupling_channel="charge"`` when ``T1`` is set.
+    coupling_channel : {None, "charge"}, default None
+        Physical operator for matrix-element relaxation. Only ``"charge"``
+        is supported and selects the authored charge operator :math:`n`.
+    collapse_rate_threshold : float, default 1e-8
+        Non-negative dimensionless cutoff on squared matrix-element ratios
+        relative to the selected ``0 -> 1`` transition.
+    T1, T2 : float or None
+        Relaxation and dephasing times in ns; ``None`` disables each channel.
+    thermal_occupation : float or None
+        Mean thermal occupation (dimensionless); ``None`` disables thermal
+        absorption.
+    noise : keyword arguments
+        The concrete constructor accepts inherited noise fields as keyword
+        arguments.
+
+    References
+    ----------
+    See Koch et al., *Phys. Rev. A* 76, 042319 (2007),
+    https://doi.org/10.1103/PhysRevA.76.042319.
+    """
 
     _type_prefix = "charge_basis_transmon"
     tunable_param_names = ("E_C", "E_J", "n_g")
@@ -99,7 +143,15 @@ class ChargeBasisTransmon(DeviceModel):
         return ChargeSpace(self.num_basis)
 
     def local_hamiltonian(self, op: LocalOps, p: Any) -> PhysicsExpr:
-        """Return 4 E_C (n - n_g)^2 - E_J cos(phi)."""
+        """Return the charge-basis transmon Hamiltonian.
+
+        Parameters
+        ----------
+        op : LocalOps
+            Charge-space operator namespace.
+        p : ParameterNamespace
+            Symbolic ``E_C``, ``E_J`` and ``n_g`` values.
+        """
         shifted_charge = op.n - p.n_g * op.I
         return 4.0 * p.E_C * (shifted_charge @ shifted_charge) - p.E_J * op.cos_phi
 
@@ -136,7 +188,15 @@ class ChargeBasisTransmon(DeviceModel):
         return self.local_space().matrix("sin_phi")
 
     def tunable_param_bounds(self, name: str, value: float) -> tuple[float, float]:
-        """Return the physical charge period for n_g."""
+        """Return physical bounds for a tunable parameter.
+
+        Parameters
+        ----------
+        name : str
+            Tunable parameter name.
+        value : float
+            Concrete optimizer seed.
+        """
         if name == "n_g":
             return (-0.5, 0.5)
         return super().tunable_param_bounds(name, value)
@@ -180,7 +240,25 @@ class ChargeBasisTransmon(DeviceModel):
         basis: Literal["native", "eigen"] | None = None,
         **kwargs: Any,
     ) -> "ChargeBasisTransmon":
-        """Construct from the leading transmon-regime inversion."""
+        """Construct from the leading transmon-regime inversion.
+
+        Parameters
+        ----------
+        freq, anharmonicity : float
+            Calibrated transition and anharmonicity in GHz.
+        n_g : float, default 0.0
+            Offset charge in Cooper-pair units.
+        levels : int or None, default None
+            Projected eigenstate count.
+        label : str or None, default None
+            Device label.
+        num_basis : int, keyword-only, default 61
+            Odd charge-basis dimension.
+        basis : {None, "native", "eigen"}, keyword-only
+            Basis policy.
+        **kwargs : Any
+            Noise and other constructor keyword arguments.
+        """
         E_C = -anharmonicity
         E_J = (freq + E_C) ** 2 / (8.0 * E_C)
         ratio = maybe_concrete_scalar(E_J / E_C)
@@ -213,6 +291,13 @@ class ChargeBasisTransmon(DeviceModel):
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "ChargeBasisTransmon":
+        """Reconstruct from serialized constructor data.
+
+        Parameters
+        ----------
+        data : mapping
+            Record produced by :meth:`to_dict`.
+        """
         return cls(
             E_C=data["E_C"],
             E_J=data["E_J"],

--- a/quchip/devices/transmon/duffing.py
+++ b/quchip/devices/transmon/duffing.py
@@ -106,9 +106,19 @@ class DuffingTransmon(FockDevice):
     label : str | None, default None
         If omitted, auto-generated as ``duffing_{idx}`` via the shared
         labeling counter.
-    **noise_kwargs
-        Forwarded to :class:`BaseDevice` — ``T1``, ``T2``,
-        ``thermal_occupation``.
+    T1 : float or None, default None
+        Energy-relaxation time in ns; ``None`` disables T1 relaxation.
+    T2 : float or None, default None
+        Total 0-1 coherence time in ns, not a pure-dephasing time. If both
+        are set, it must satisfy ``T2 <= 2*T1``; ``None`` disables T2 noise.
+    thermal_occupation : float or None, default None
+        Dimensionless mean bath occupation; ``None`` disables thermal
+        absorption.
+
+    References
+    ----------
+    Koch et al., *Phys. Rev. A* 76, 042319 (2007),
+    https://doi.org/10.1103/PhysRevA.76.042319.
 
     Example
     -------
@@ -133,7 +143,15 @@ class DuffingTransmon(FockDevice):
     anharmonicity: Scalar = parameter(default=UNBOUND, unit="GHz", symbol=r"\alpha")
 
     def local_hamiltonian(self, op: LocalOps, p: Any) -> PhysicsExpr:
-        """Return the local Duffing Hamiltonian ``H = omega n + (alpha/2) n (n - I)``."""
+        """Return the local Duffing Hamiltonian.
+
+        Parameters
+        ----------
+        op : LocalOps
+            Fock operator namespace.
+        p : ParameterNamespace
+            Symbolic ``freq`` and ``anharmonicity`` values.
+        """
         return duffing_expr(op, p.freq, p.anharmonicity)
 
     def physics_notes(self) -> list[str]:

--- a/quchip/devices/transmon/flux_tunable.py
+++ b/quchip/devices/transmon/flux_tunable.py
@@ -152,9 +152,12 @@ class FluxTunableTransmon(FockDevice):
         Fock-space truncation.
     label : str | None, default None
         Auto-generated as ``fluxtunable_{idx}`` when omitted.
-    **noise_kwargs
-        Forwarded to :class:`~quchip.devices.base.BaseDevice` — ``T1``,
-        ``T2``, ``thermal_occupation``.
+    T1 : float or None, default None
+        Energy-relaxation time in ns; ``None`` disables T1 relaxation.
+    T2 : float or None, default None
+        Total 0-1 coherence time in ns; if both are set, ``T2 <= 2*T1``.
+    thermal_occupation : float or None, default None
+        Dimensionless mean bath occupation; ``None`` disables absorption.
     """
 
     _type_prefix: ClassVar[str] = "fluxtunable"
@@ -209,7 +212,13 @@ class FluxTunableTransmon(FockDevice):
         super().__setattr__(name, value)
 
     def set_parameter_values(self, values: Mapping[str, Any]) -> None:
-        """Apply flux and calibration overrides without mapping-order effects."""
+        """Apply flux and calibration overrides without mapping-order effects.
+
+        Parameters
+        ----------
+        values : mapping[str, Any]
+            Parameter updates; flux-only updates retune ``freq``.
+        """
         updates = dict(values)
         if "flux_bias" in updates and "freq" not in updates:
             calibration = self.copy()
@@ -218,13 +227,28 @@ class FluxTunableTransmon(FockDevice):
         super().set_parameter_values(updates)
 
     def tunable_param_bounds(self, name: str, value: float) -> tuple[float, float]:
-        """Use one SQUID period as the default bound for explicit flux fitting."""
+        """Use one SQUID period as the default bound for explicit flux fitting.
+
+        Parameters
+        ----------
+        name : str
+            Tunable parameter name.
+        value : float
+            Concrete optimizer seed.
+        """
         if name == "flux_bias":
             return (-0.5, 0.5)
         return super().tunable_param_bounds(name, value)
 
     def local_hamiltonian(self, op: LocalOps, p: Any) -> PhysicsExpr:
         """Return the Duffing Hamiltonian built from the calibrated freq and anharmonicity.
+
+        Parameters
+        ----------
+        op : LocalOps
+            Fock operator namespace.
+        p : ParameterNamespace
+            Symbolic calibrated and flux parameters.
 
         ``H = ω n + (α/2) n(n − I)``. Rebinding ``flux_bias`` first updates
         the stored ``freq`` through the anchored SQUID dispersion.
@@ -268,6 +292,13 @@ class FluxTunableTransmon(FockDevice):
     def flux_for_frequency(self, target_freq: Any) -> Any:
         """Inverse SQUID dispersion on the monotonic lobe Φ/Φ₀ ∈ [0, 0.5).
 
+        Parameters
+        ----------
+        target_freq : float or array-like
+            Desired transition frequency in GHz.
+
+        Notes
+        -----
         Derivation:
             ω(Φ) = sqrt(8 E_C E_J_max sqrt(cos²(πΦ) + d²sin²(πΦ))) − E_C
             → let S = (ω + E_C)² / (8 E_C E_J_max)

--- a/quchip/engine/__init__.py
+++ b/quchip/engine/__init__.py
@@ -100,21 +100,48 @@ __all__ = [
 
 
 def build_steadystate_problem(chip: Any, **kwargs: Any) -> SteadyStateProblem:
-    """Build a frozen static Lindblad steady-state request."""
+    """Build a frozen static Lindblad steady-state request.
+
+    Parameters
+    ----------
+    chip : Chip
+        Chip to resolve.
+    **kwargs
+        Forwarded steady-state options, including ``e_ops``, ``options``,
+        ``frame``, and ``approximation``.
+    """
     from quchip.engine.steady_state import build_steadystate_problem as _build
 
     return _build(chip, **kwargs)
 
 
 def steadystate(chip: Any, **kwargs: Any) -> Any:
-    """Solve a chip's unique static Lindblad steady state."""
+    """Solve a chip's unique static Lindblad steady state.
+
+    Parameters
+    ----------
+    chip : Chip
+        Chip with a static resolved Hamiltonian.
+    **kwargs
+        Forwarded to :func:`build_steadystate_problem`.
+    """
     from quchip.engine.steady_state import steadystate as _solve
 
     return _solve(chip, **kwargs)
 
 
 def steadystate_batch(chip: Any, *axes: Any, **kwargs: Any) -> Any:
-    """Solve static Lindblad steady states over parameter axes."""
+    """Solve static Lindblad steady states over parameter axes.
+
+    Parameters
+    ----------
+    chip : Chip
+        Chip to rebind at each point.
+    *axes : Sweep
+        Cartesian or zipped parameter axes.
+    **kwargs
+        Forwarded steady-state options.
+    """
     from quchip.engine.steady_state import steadystate_batch as _solve_batch
 
     return _solve_batch(chip, *axes, **kwargs)
@@ -171,6 +198,16 @@ def build_problem(
         ``result.output(plane)``.
     initial_state : optional
         Initial state; ``None`` defaults to the chip ground state.
+    approximation : Approximation or None, optional
+        Approximation strategy, such as :class:`~quchip.RWA`, used during
+        assembly. ``None`` uses the chip declaration.
+    states : {"all", "final", "none"}, default="all"
+        State history retention policy. ``"all"`` stores every state,
+        ``"final"`` stores only the final state, and ``"none"`` stores no
+        state history.
+    dissipation : bool, default=True
+        Include resolved Lindblad collapse channels. Set ``False`` for a
+        unitary solve while retaining the authored Hamiltonian.
 
     Returns
     -------
@@ -262,6 +299,10 @@ def simulate(
     Hilbert-truncation safety net is inherited from :func:`solve_problem`;
     ``check_truncation`` / ``truncation_threshold`` are threaded down.
 
+    ``approximation`` selects the captured Hamiltonian approximation,
+    ``states`` is ``"all"``, ``"final"``, or ``"none"``, and ``dissipation``
+    controls whether resolved collapse channels are included.
+
     Parameters
     ----------
     chip : Chip
@@ -286,6 +327,13 @@ def simulate(
         ``{"q0": 1}``) becomes a product state in the engine's resolved
         local bases on both the joint and partitioned paths. An authored
         full-space ket is projected into that same solver space.
+    approximation : Approximation or None, optional
+        Approximation strategy captured during assembly; ``None`` uses the
+        chip declaration.
+    states : {"all", "final", "none"}, default="all"
+        Retain all states, only the final state, or no states.
+    dissipation : bool, default=True
+        Include resolved collapse channels in the solve.
     check_truncation : bool, default True
         Screen sampled populations near the model's truncation boundaries.
     truncation_threshold : float, default 1e-3
@@ -385,6 +433,15 @@ def solve_problem(
     All single-solve paths call this function. Unless
     ``check_truncation=False``, it screens the wrapped result for
     sampled boundary populations and warns above ``truncation_threshold``.
+
+    Parameters
+    ----------
+    problem : SolveProblem
+        Frozen request produced by :func:`build_problem`.
+    check_truncation : bool, default=True
+        Evaluate sampled boundary populations after solving.
+    truncation_threshold : float, default=1e-3
+        Warning threshold for boundary population.
     """
     from quchip.results.results import wrap_solver_result
 
@@ -407,6 +464,17 @@ def solve_batch(
 
     The backend converts each shared operator exactly once and stitches
     per-element coefficient data before running the parallel solve.
+
+    Parameters
+    ----------
+    batch : SolveBatch
+        Captured batch of compatible solve requests.
+    progress : bool, default=True
+        Show backend progress.
+    check_truncation : bool, default=True
+        Check sampled truncation boundaries.
+    truncation_threshold : float, default=1e-3
+        Warning threshold for boundary population.
     """
     from quchip.results.results import SimulationBatchResult, wrap_solver_results_from_batch
 
@@ -450,6 +518,17 @@ def solve_many(
     Lists may contain independent models, grids and backends. Compatible
     requests share native execution; each result keeps its own captured context.
     Mixed native array backends remain accessible through individual results.
+
+    Parameters
+    ----------
+    batch_or_problems : SolveBatch or list of SolveProblem
+        Requests to dispatch.
+    progress : bool, default=True
+        Show backend progress.
+    check_truncation : bool, default=True
+        Check sampled truncation boundaries.
+    truncation_threshold : float, default=1e-3
+        Warning threshold for boundary population.
     """
     if isinstance(batch_or_problems, SolveBatch):
         return solve_batch(batch_or_problems, progress=progress,

--- a/quchip/engine/basis.py
+++ b/quchip/engine/basis.py
@@ -82,7 +82,23 @@ def _lowest_eigenpairs(matrix: Any, levels: int) -> tuple[Any, Any]:
 
 @dataclass(frozen=True)
 class BasisRecord:
-    """One device's fixed authored-to-solver transformation."""
+    """One device's fixed authored-to-solver transformation.
+
+    Attributes
+    ----------
+    kind : {"native", "eigen"}
+        Selected solver-basis policy.
+    vectors : array_like
+        Solver basis vectors as authored-basis columns.
+    energies : array_like
+        Retained isolated eigenenergies in GHz.
+    energy_vectors : array_like
+        Isolated energy eigenvectors as authored-basis columns.
+    native_dim, resolved_dim : int
+        Authored and retained local dimensions.
+    authored_hamiltonian : array_like or None
+        Captured authored-basis Hamiltonian in GHz, when retained.
+    """
 
     kind: Literal["native", "eigen"]
     vectors: Any
@@ -93,7 +109,13 @@ class BasisRecord:
     authored_hamiltonian: Any = field(default=None, repr=False, compare=False)
 
     def energy_state(self, level: int) -> Any:
-        """Return one captured isolated energy ket in the solver basis."""
+        """Return one captured isolated energy ket in the solver basis.
+
+        Parameters
+        ----------
+        level : int
+            Zero-based isolated energy level.
+        """
         if self.kind == "eigen":
             return jnp.eye(self.resolved_dim, dtype=jnp.complex128)[:, level]
         return self.energy_vectors[:, level]
@@ -114,7 +136,13 @@ class BasisRecord:
         return self.vectors @ self.vectors.conj().T
 
     def transform_operator(self, operator: Any) -> Any:
-        """Apply the recorded authored-to-solver transformation to an operator."""
+        """Apply the recorded authored-to-solver transformation to an operator.
+
+        Parameters
+        ----------
+        operator : array_like
+            Square operator with shape ``(native_dim, native_dim)``.
+        """
         if getattr(operator, "shape", None) != (self.native_dim, self.native_dim):
             raise ValueError(
                 f"Operator must have native shape {(self.native_dim, self.native_dim)}, "

--- a/quchip/engine/frames.py
+++ b/quchip/engine/frames.py
@@ -68,6 +68,17 @@ class FrameTone:
 
     ``coefficients`` pairs each device label with its excitation-number change
     ``k_d``. ``weight`` is ``|h_band|² ∫|envelope|² dt`` when available.
+
+    Attributes
+    ----------
+    coefficients : tuple of (str, int)
+        Device labels and excitation-number changes.
+    freq : scalar
+        Constraint frequency in GHz.
+    weight : float or None
+        Integrated constraint weight, when available.
+    source : str
+        Description of the originating term or tone.
     """
 
     coefficients: tuple[tuple[str, int], ...]
@@ -84,6 +95,17 @@ class FrameResidual:
     a static coupling or ``Σ_d k_d ω_d - freq`` for a tone. ``source`` and
     ``devices`` identify its origin, and ``weight`` records its
     integrated strength when available.
+
+    Attributes
+    ----------
+    source : str
+        Description of the rejected constraint.
+    devices : tuple of str
+        Devices participating in the constraint.
+    frequency : scalar
+        Residual frequency in GHz.
+    weight : float or None
+        Integrated constraint weight, when available.
     """
 
     source: str
@@ -102,6 +124,19 @@ class FramePlan:
     lists rejected constraints that remain time dependent. ``tones`` contains
     the accepted tone constraints that fixed driven clusters, including each
     tone's source, charge coefficients, frequency, and weight.
+
+    Attributes
+    ----------
+    frequencies : mapping
+        Frame frequency in GHz for each device label.
+    clusters : tuple of tuple of str
+        Device groups linked by accepted constraints.
+    pins : tuple of (str, scalar)
+        Reference frequencies in GHz used for free variables.
+    residuals : tuple of FrameResidual
+        Rejected constraints that remain time dependent.
+    tones : tuple of FrameTone
+        Accepted driven constraints.
     """
 
     frequencies: Mapping[str, Any]

--- a/quchip/engine/ir.py
+++ b/quchip/engine/ir.py
@@ -132,6 +132,11 @@ class SignalNode:
 
         Non-child fields are preserved; nodes without children pass
         through untouched.
+
+        Parameters
+        ----------
+        transform : callable
+            Function applied to every direct signal child.
         """
         if not self._signal_child_fields:
             return self
@@ -147,7 +152,15 @@ class SignalNode:
         return replace(self, **updates)  # type: ignore[type-var]
 
     def evaluate(self, t: Any, *, xp: Any) -> Any:
-        """Evaluate the node at time(s) *t* (ns) in array namespace *xp*."""
+        """Evaluate the node in a selected array namespace.
+
+        Parameters
+        ----------
+        t : scalar or array_like
+            Evaluation times in ns.
+        xp : module
+            NumPy-like array namespace.
+        """
         raise NotImplementedError(
             f"{type(self).__name__} must implement evaluate(t, xp=...)."
         )
@@ -438,13 +451,28 @@ class Carrier(SignalNode):
     band on a ``+Δ`` detuning rotates as ``exp(−iΔt)``. Both fields are
     registered as pytree children (``freq`` may be traced; ``sign`` is
     semantically a static ``±1`` — do not map over it).
+
+    Attributes
+    ----------
+    freq : scalar
+        Angular carrier frequency in rad/ns.
+    sign : {-1, 1}
+        Sign in the complex exponential.
     """
 
     freq: float
     sign: Literal[-1, 1] = -1
 
     def evaluate(self, t: Any, *, xp: Any) -> Any:
-        """Return ``exp(sign · i · freq · t)`` at time(s) *t* (ns)."""
+        """Return ``exp(sign · i · freq · t)``.
+
+        Parameters
+        ----------
+        t : scalar or array_like
+            Evaluation times in ns.
+        xp : module
+            NumPy-like array namespace.
+        """
         t_arr = xp.asarray(t, dtype=float)
         return xp.exp(1j * self.sign * self.freq * t_arr)
 
@@ -465,7 +493,13 @@ def _contains_carrier(node: SignalNode) -> bool:
 
 @dataclass(frozen=True)
 class ScalarModulation:
-    """Typed wrapper marking a :data:`SignalProgram` as a scalar modulation on a :class:`DynamicTerm`."""
+    """Mark a :data:`SignalProgram` as a scalar modulation.
+
+    Attributes
+    ----------
+    signal : SignalProgram
+        Backend-neutral scalar time dependence.
+    """
 
     signal: SignalProgram
 
@@ -688,6 +722,25 @@ class CanonicalOperator:
     it is a 2D ``(n_diags, n_cols)`` array paired with ``offsets``.
     ``dims`` must multiply to ``shape[0]`` and ``subsystem_labels`` names
     each subsystem.
+
+    Attributes
+    ----------
+    layout : {"dense", "csr", "dia"}
+        Storage layout of ``values``.
+    values : array_like
+        Matrix or sparse payload.
+    shape : tuple of int
+        Square operator shape.
+    dims : tuple of int
+        Subsystem dimensions.
+    basis : str
+        Basis convention for the payload.
+    subsystem_labels : tuple of str
+        Labels matching ``dims``.
+    indices, indptr, offsets : array_like or None
+        Sparse CSR/DIA metadata.
+    tag : str or None
+        Optional diagnostic label.
     """
 
     layout: CanonicalLayout
@@ -770,6 +823,21 @@ class CanonicalOperator:
         subsystem_labels: tuple[str, ...],
         tag: str | None = None,
     ) -> "CanonicalOperator":
+        """Build a dense canonical operator.
+
+        Parameters
+        ----------
+        values : array_like
+            Square dense matrix.
+        dims : tuple of int
+            Subsystem dimensions.
+        basis : str
+            Basis convention for ``values``.
+        subsystem_labels : tuple of str
+            Labels matching ``dims``.
+        tag : str or None, optional
+            Diagnostic label.
+        """
         shape = tuple(values.shape)
         return cls(
             layout="dense",
@@ -794,6 +862,23 @@ class CanonicalOperator:
         subsystem_labels: tuple[str, ...],
         tag: str | None = None,
     ) -> "CanonicalOperator":
+        """Build a CSR canonical operator.
+
+        Parameters
+        ----------
+        values, indices, indptr : array_like
+            CSR payload arrays.
+        shape : tuple of int
+            Square matrix shape.
+        dims : tuple of int
+            Subsystem dimensions.
+        basis : str
+            Basis convention for the payload.
+        subsystem_labels : tuple of str
+            Labels matching ``dims``.
+        tag : str or None, optional
+            Diagnostic label.
+        """
         return cls(
             layout="csr",
             values=values,
@@ -818,6 +903,23 @@ class CanonicalOperator:
         subsystem_labels: tuple[str, ...],
         tag: str | None = None,
     ) -> "CanonicalOperator":
+        """Build a DIA canonical operator.
+
+        Parameters
+        ----------
+        values, offsets : array_like
+            Diagonal payload and integer offsets.
+        shape : tuple of int
+            Square matrix shape.
+        dims : tuple of int
+            Subsystem dimensions.
+        basis : str
+            Basis convention for the payload.
+        subsystem_labels : tuple of str
+            Labels matching ``dims``.
+        tag : str or None, optional
+            Diagnostic label.
+        """
         return cls(
             layout="dia",
             values=values,
@@ -837,7 +939,19 @@ class CanonicalOperator:
         subsystem_labels: tuple[str, ...] | None = None,
         tag: str | None = None,
     ) -> "CanonicalOperator":
-        """Return a metadata-adjusted copy (payload unchanged)."""
+        """Return a metadata-adjusted copy with unchanged payload.
+
+        Parameters
+        ----------
+        dims : tuple of int or None, optional
+            Replacement subsystem dimensions.
+        basis : str or None, optional
+            Replacement basis convention.
+        subsystem_labels : tuple of str or None, optional
+            Replacement subsystem labels.
+        tag : str or None, optional
+            Replacement diagnostic label.
+        """
         return replace(
             self,
             dims=self.dims if dims is None else dims,
@@ -847,7 +961,15 @@ class CanonicalOperator:
         )
 
     def scaled(self, factor: Any, *, tag: str | None = None) -> "CanonicalOperator":
-        """Return a scalar multiple without changing the operator layout."""
+        """Return a scalar multiple without changing the operator layout.
+
+        Parameters
+        ----------
+        factor : scalar
+            Multiplier applied to the payload.
+        tag : str or None, optional
+            Replacement diagnostic label.
+        """
         return replace(
             self,
             values=self.values * factor,
@@ -1001,6 +1123,17 @@ class StaticTerm:
     multiplies ``operator`` and may be a concrete scalar or a JAX
     tracer (sweeps over static couplings, detunings, etc.). ``origin``
     is purely advisory metadata.
+
+    Attributes
+    ----------
+    operator : CanonicalOperator
+        Angular-frequency operator payload.
+    coefficient : scalar
+        Scalar multiplier, default one.
+    origin : str
+        Component category that authored the term.
+    metadata : dict
+        Advisory term metadata.
     """
 
     operator: CanonicalOperator
@@ -1018,6 +1151,17 @@ class DynamicTerm:
     dynamiqs sampled array, etc.). The ``operator`` is 2π-scaled already
     (see module docstring). ``tag`` is an optional human label; it does
     not participate in physics.
+
+    Attributes
+    ----------
+    operator : CanonicalOperator
+        Angular-frequency operator payload.
+    time_dependence : ScalarModulation
+        Scalar coefficient evaluated in time.
+    origin : str
+        Component category that authored the term.
+    tag : str or None
+        Optional diagnostic label.
     """
 
     operator: CanonicalOperator
@@ -1028,7 +1172,23 @@ class DynamicTerm:
 
 @dataclass(frozen=True)
 class CollapseTerm:
-    """Backend-neutral Lindblad channel, optionally exposed as a port."""
+    """Backend-neutral Lindblad channel, optionally exposed as a port.
+
+    Attributes
+    ----------
+    operator : CanonicalOperator
+        Dimensionless local jump operator before rate scaling.
+    rate : scalar
+        Lindblad rate in ``1/ns``.
+    source, channel : str
+        Owning component and local channel labels.
+    parameter_paths : tuple of str
+        Parameter paths controlling the channel.
+    phase : scalar or None
+        Coupling phase in radians.
+    frame_frequency : scalar or None
+        Accessible-channel carrier in GHz; ``None`` marks a hidden channel.
+    """
 
     operator: CanonicalOperator
     rate: Any
@@ -1071,7 +1231,15 @@ ChannelAccess: TypeAlias = Literal["exposed", "hidden"]
 
 @dataclass(frozen=True)
 class HamiltonianProgram:
-    """Resolved static and time-dependent Hamiltonian contributions."""
+    """Resolved static and time-dependent Hamiltonian contributions.
+
+    Attributes
+    ----------
+    static_terms : tuple of StaticTerm
+        Time-independent contributions.
+    dynamic_terms : tuple of DynamicTerm
+        Time-dependent contributions.
+    """
 
     static_terms: tuple[StaticTerm, ...] = ()
     dynamic_terms: tuple[DynamicTerm, ...] = ()
@@ -1079,7 +1247,23 @@ class HamiltonianProgram:
 
 @dataclass(frozen=True)
 class SLHChannel:
-    """One resolved Markov channel and its boundary accessibility."""
+    """One resolved Markov channel and its boundary accessibility.
+
+    Attributes
+    ----------
+    key : str
+        Unique resolved channel key.
+    accessibility : {"exposed", "hidden"}
+        Whether the channel reaches the modeled experiment boundary.
+    collapse : CollapseTerm
+        Component-authored channel record.
+    coupling_operator : CanonicalOperator or None
+        Resolved physical coupling operator, when already composed.
+    reference : ReferencePlane
+        External reference-plane transfer.
+    input_occupation : scalar or None
+        Markov input occupation for a thermal field.
+    """
 
     key: str
     accessibility: ChannelAccess
@@ -1126,7 +1310,25 @@ class SLHChannel:
 
 @dataclass(frozen=True)
 class ResolvedSLH:
-    """Immutable, input-free normal form for resolved Markovian physics."""
+    """Immutable, input-free normal form for resolved Markovian physics.
+
+    Attributes
+    ----------
+    scattering : array_like
+        Unitary scalar channel matrix ``S``.
+    hamiltonian : HamiltonianProgram
+        Resolved Hamiltonian ``H``.
+    channels : tuple of SLHChannel
+        Coupling channels ``L`` in scattering order.
+    support : array_like or None
+        Boolean structural reachability matrix.
+    output_network : object or None
+        Captured external output processing.
+
+    Notes
+    -----
+    See :doc:`/physics` for the SLH composition and channel conventions.
+    """
 
     scattering: Any
     hamiltonian: HamiltonianProgram
@@ -1190,7 +1392,17 @@ class ResolvedSLH:
         dynamic_terms: tuple[DynamicTerm, ...],
         collapse_terms: tuple[CollapseTerm, ...],
     ) -> "ResolvedSLH":
-        """Build the current identity-scattering model from engine terms."""
+        """Build an identity-scattering model from engine terms.
+
+        Parameters
+        ----------
+        static_terms : tuple of StaticTerm
+            Static Hamiltonian contributions.
+        dynamic_terms : tuple of DynamicTerm
+            Dynamic Hamiltonian contributions.
+        collapse_terms : tuple of CollapseTerm
+            Component-authored Lindblad channels.
+        """
         exposed: list[SLHChannel] = []
         hidden: list[SLHChannel] = []
         key_counts: dict[str, int] = {}
@@ -1225,7 +1437,13 @@ class ResolvedSLH:
         return self.scattering
 
     def feeds(self, output_index: int, input_index: int) -> bool:
-        """Return whether input channel ``input_index`` structurally reaches output ``output_index``."""
+        """Return whether one input structurally reaches one output.
+
+        Parameters
+        ----------
+        output_index, input_index : int
+            Output row and input column in channel order.
+        """
         return bool(self.support[output_index, input_index])
 
     @property
@@ -1276,22 +1494,10 @@ class ResolvedSLH:
 class DroppedTerm:
     """Advisory record for a Hamiltonian term elided by an approximation.
 
-    Emitted by physics components (couplings, drives, …) whose local
-    Hamiltonian routines discard terms under an approximation such as
-    the rotating-wave approximation. Assembly aggregates these records
-    into :attr:`EngineResult.dropped_terms` so callers can
-    audit what was silently removed — in particular, compare each dropped band's amplitude
-    against its oscillation frequency, the smallness ratio that governs
-    RWA validity (leading correction ∼ amplitude²/frequency, the
-    Bloch–Siegert scale).
-
-    The string fields are static and value-free. ``amplitude`` and
-    ``frequency`` hold *raw* numeric values in GHz ordinary frequency —
-    possibly JAX-traced; they are never formatted or branched on during
-    assembly. ``band_weights`` is static
-    structure (excitation-change weights, one per mode the operator
-    acts on) that assembly uses to resolve ``frequency`` from the frame
-    without the owner knowing frame references.
+    Compare a dropped band's amplitude with its oscillation frequency to
+    assess RWA validity; the leading Bloch-Siegert correction scales as
+    amplitude²/frequency. Numeric fields use ordinary GHz and may be traced.
+    Static ``band_weights`` let assembly derive the frequency from the frame.
 
     Parameters
     ----------
@@ -1368,19 +1574,38 @@ class EngineResult:
         H(t) \\;=\\; \\sum_s c_s \\, O_s
                    \\;+\\; \\sum_d O_d \\, f_d(t)
 
-    The immutable ``slh`` value is the input-free Markov model. Scheduled
-    controls and solve-bound coherent-source Hamiltonians live in
-    ``applied_hamiltonian``; the term properties combine both programs for
-    existing backend consumers. Each static / dynamic operator already carries 2π and each
-    ``f_d(t)`` is a :class:`ScalarModulation` over a
-    :class:`SignalProgram` AST. ``metadata`` carries advisory solver
-    hints (e.g. ``max_carrier_freq_ghz``, ``max_step_ns``); a backend may
-    consult them or apply an equivalent numerical strategy of its own,
-    but remains responsible for resolving finite-support dynamics — a
-    finite-width pulse must not be silently skipped by an adaptive
-    integrator that never samples it. ``dropped_terms`` records any
-    terms that owning components elided under an approximation (RWA,
-    etc.) — advisory metadata for auditing, never consumed by backends.
+    ``slh`` is the input-free Markov model; ``applied_hamiltonian`` holds
+    scheduled controls and solve-bound coherent drives. Operators already
+    include the 2π conversion. Backends may use ``metadata`` integration
+    hints but remain responsible for resolving finite-support dynamics.
+    ``dropped_terms`` is advisory approximation metadata.
+
+    Attributes
+    ----------
+    slh : ResolvedSLH
+        Input-free resolved scattering, Hamiltonian, and channel description.
+    applied_hamiltonian : HamiltonianProgram
+        Solve-bound static and dynamic terms added after the input-free model.
+    coherent_inputs : tuple
+        Captured coherent source bindings used to assemble those terms.
+    dims : tuple of int
+        Solver Hilbert-space dimensions in chip device order.
+    metadata : dict
+        Advisory solver hints, with frequencies in GHz and time scales in ns.
+    dropped_terms : tuple of DroppedTerm
+        Terms removed by the selected approximation, retained for diagnostics.
+    bases : mapping
+        Per-device authored-to-solver basis records.
+    authored : object or None
+        Captured authored physics description.
+    resolved_frame : ResolvedFrame
+        Frame frequencies and demodulation convention used by assembly.
+    approximation : Approximation or None
+        Approximation captured by this resolved snapshot.
+    dynamical_supports : tuple of tuple of str
+        Device groups coupled by retained dynamical terms.
+    dissipation : bool
+        Whether :attr:`collapse_terms` exposes the resolved dissipators.
     """
 
     slh: ResolvedSLH
@@ -1431,6 +1656,15 @@ class EngineResult:
         the selected frame and approximation stored in this snapshot. A
         snapshot carrying dynamic Hamiltonian terms requires ``at_time``;
         the result is an instantaneous eigensystem, not a Floquet analysis.
+
+        Parameters
+        ----------
+        at_time : scalar or None, optional
+            Instant in ns for dynamic snapshots.
+        overlap_threshold : float, default=0.5
+            Minimum bare-state overlap accepted for labeling.
+        labeling : str, default="DE"
+            Bare-to-dressed assignment strategy.
         """
         from quchip.chip.analysis import dress_engine_result
 
@@ -1447,7 +1681,15 @@ class EngineResult:
         static_terms: tuple[StaticTerm, ...] | None = None,
         dynamic_terms: tuple[DynamicTerm, ...] | None = None,
     ) -> "EngineResult":
-        """Return a copy with solve-bound Hamiltonian terms replaced."""
+        """Return a copy with solve-bound Hamiltonian terms replaced.
+
+        Parameters
+        ----------
+        static_terms : tuple of StaticTerm or None, optional
+            Replacement static terms; ``None`` preserves them.
+        dynamic_terms : tuple of DynamicTerm or None, optional
+            Replacement dynamic terms; ``None`` preserves them.
+        """
         applied = replace(
             self.applied_hamiltonian,
             static_terms=(
@@ -1760,13 +2002,38 @@ StateStorage: TypeAlias = Literal["all", "final", "none"]
 class SolveProblem:
     """Immutable simulation request handed from the chip pipeline to a backend.
 
-    Bundles the :class:`EngineResult` (Hamiltonian and collapse terms), an
-    ``initial_state``, solver time grid, decomposed
-    ``e_ops`` + their :class:`BandMeta`, the :class:`ResolvedFrame`, and
-    solver options. Backend selection is captured at construction, so ``options`` must
-    not contain a ``"backend"`` key (enforced in ``__post_init__``).
-    ``e_ops_meta`` is the metadata observable reconstruction uses to recombine flattened
-    band expectations back into dict-keyed observables.
+    Backend selection is captured separately from ``options``.
+    ``e_ops_meta`` reconstructs flattened band expectations into public
+    dict-keyed observables.
+
+    Attributes
+    ----------
+    chip : Chip
+        Source chip captured by the request.
+    engine_result : EngineResult
+        Frozen resolved physics.
+    initial_state : state_like
+        Initial ket or density matrix in solver coordinates.
+    tlist : array_like
+        Solver times in ns.
+    e_ops : sequence or None
+        Backend-ready expectation operators.
+    e_ops_meta : object or None
+        Metadata used to reconstruct public observables.
+    resolved_frame : ResolvedFrame
+        Captured integration and demodulation frame.
+    solver : {"sesolve", "mesolve"} or None
+        Explicit solver selection.
+    options : dict
+        Backend solver options; a ``"backend"`` key is rejected.
+    truncation : object or None
+        Captured boundary-population plan.
+    states : {"all", "final", "none"}
+        State-retention policy.
+    backend : Backend
+        Captured backend owner.
+    device_info : tuple
+        Device labels and computational flags in subsystem order.
     """
 
     chip: Any  # Chip (typed as Any to avoid runtime import cycles)
@@ -1794,6 +2061,11 @@ class SolveProblem:
         An explicit ``solver`` takes precedence, but ``sesolve`` is rejected for a
         density matrix. Otherwise select ``sesolve`` only for a ket with no collapse
         terms; select ``mesolve`` for a density matrix or any problem with collapse terms.
+
+        Parameters
+        ----------
+        backend : Backend
+            Backend used to classify the initial state.
         """
         is_ket = backend.is_ket(self.initial_state)
         if self.solver is not None:
@@ -1853,6 +2125,25 @@ class LinearResponseProblem:
     columns. ``inbound_transfer`` and ``outbound_transfer`` contain the
     per-frequency reference factors for each external channel. Backends return
     the undecorated Markov response; the engine applies both factors.
+
+    Attributes
+    ----------
+    frequencies : array_like
+        Probe frequencies in GHz.
+    mode_labels : tuple of str
+        Linear Fock modes in matrix order.
+    hamiltonian : array_like
+        Number-conserving mode matrix in rad/ns.
+    couplings : array_like
+        Channel-to-mode coupling matrix in ``1/sqrt(ns)``.
+    scattering : array_like
+        Instantaneous SLH scattering matrix.
+    plane_indices : tuple of int
+        External channel indices used for result rows and columns.
+    inbound_transfer, outbound_transfer : array_like
+        Frequency-dependent external reference factors.
+    field_channels : tuple of FieldChannel
+        Captured input field states.
     """
 
     frequencies: Any
@@ -1868,7 +2159,27 @@ class LinearResponseProblem:
 
 @dataclass(frozen=True)
 class SteadyStateProblem:
-    """Immutable static Lindblad request handed from a chip to its backend."""
+    """Immutable static Lindblad request handed from a chip to its backend.
+
+    Attributes
+    ----------
+    chip : Chip
+        Source chip captured by the request.
+    engine_result : EngineResult
+        Frozen static resolved physics.
+    e_ops : sequence or None
+        Backend-ready expectation operators.
+    e_ops_meta : object or None
+        Metadata used to reconstruct public observables.
+    resolved_frame : ResolvedFrame
+        Captured stationary frame.
+    options : dict
+        Backend solver options.
+    backend : Backend
+        Captured backend owner.
+    device_info : tuple
+        Device labels and computational flags in subsystem order.
+    """
 
     chip: Any
     engine_result: EngineResult
@@ -1896,7 +2207,21 @@ class SteadyStateProblem:
 
 @dataclass(frozen=True)
 class SolveBatch:
-    """Explicit solve problems sharing one dispatch owner and sweep shape."""
+    """Explicit solve problems sharing one dispatch owner and sweep shape.
+
+    Attributes
+    ----------
+    chip : Chip
+        Source chip for the batch.
+    problems : tuple of SolveProblem
+        Compatible frozen requests in flat sweep order.
+    params : array_like or None
+        Bound parameter mappings on the sweep grid.
+    shape : tuple of int
+        Sweep-grid shape.
+    axes : tuple
+        Named sweep-axis metadata.
+    """
 
     chip: Any
     problems: tuple[SolveProblem, ...]
@@ -1954,7 +2279,13 @@ class SolveBatch:
         return self.problems[0].tlist
 
     def signals_for(self, slot: int) -> tuple[ScalarModulation, ...]:
-        """Return one dynamic slot across all batch points."""
+        """Return one dynamic slot across all batch points.
+
+        Parameters
+        ----------
+        slot : int
+            Dynamic-term index.
+        """
         return tuple(
             problem.engine_result.dynamic_terms[slot].time_dependence
             for problem in self.problems
@@ -1973,7 +2304,13 @@ class SolveBatch:
         return self.element(item)
 
     def params_at(self, point: int | tuple[int, ...]) -> dict[str, Any]:
-        """Return sweep values at one grid coordinate."""
+        """Return sweep values at one grid coordinate.
+
+        Parameters
+        ----------
+        point : int or tuple of int
+            Flat index or multidimensional sweep coordinate.
+        """
         if self.params is None:
             return {}
         if self.shape == ():
@@ -1984,6 +2321,13 @@ class SolveBatch:
         return dict(self.params[coordinate].items())
 
     def element(self, index: int) -> SolveProblem:
+        """Return one solve request by flat batch index.
+
+        Parameters
+        ----------
+        index : int
+            Flat batch index.
+        """
         return self.problems[index]
 
 

--- a/quchip/extensions/couplings.py
+++ b/quchip/extensions/couplings.py
@@ -12,7 +12,26 @@ from quchip.declarative.parameters import UNBOUND, Scalar, parameter
 
 
 class ModulatedCapacitive(CouplingModel):
-    """Capacitive interaction with a prescribed sinusoidal strength variation."""
+    r"""Capacitive interaction with a prescribed sinusoidal strength variation.
+
+    The static term is :math:`g_0 n_a^{(q)}n_b^{(q)}` and the modulation is
+    :math:`\delta g\cos(2\pi\nu_m t+\phi_m)n_a^{(q)}n_b^{(q)}`.
+
+    Parameters
+    ----------
+    device_a, device_b : device or str
+        Coupled endpoints or their chip labels.
+    static_strength : float
+        Static capacitive strength :math:`g_0` in GHz; may be signed.
+    modulation_amplitude : float
+        Modulation amplitude :math:`\delta g` in GHz; may be signed.
+    modulation_frequency : float
+        Modulation frequency :math:`\nu_m` in GHz; positive.
+    modulation_phase : float, default 0.0
+        Modulation phase in radians.
+    label : str or None, default None
+        Coupling label.
+    """
 
     _type_prefix = "modulated_capacitive"
 
@@ -27,9 +46,27 @@ class ModulatedCapacitive(CouplingModel):
     modulation_phase: Scalar = parameter(default=0.0, unit="rad", symbol=r"\phi_m")
 
     def interaction(self, a: Any, b: Any, p: Any) -> PhysicsExpr:
+        """Return the static capacitive interaction.
+
+        Parameters
+        ----------
+        a, b : EndpointOps
+            Ordered endpoint operator namespaces.
+        p : ParameterNamespace
+            Bound coupling parameters.
+        """
         return p.static_strength * a.charge * b.charge
 
     def time_terms(self, a: Any, b: Any, p: Any) -> tuple[TimeDependentTerm, ...]:
+        """Return the sinusoidally modulated capacitive interaction term.
+
+        Parameters
+        ----------
+        a, b : EndpointOps
+            Ordered endpoint operator namespaces.
+        p : ParameterNamespace
+            Bound coupling parameters.
+        """
         return (
             TimeDependentTerm(
                 operator=a.charge * b.charge,
@@ -43,7 +80,24 @@ class ModulatedCapacitive(CouplingModel):
 
 
 class CollectiveDecayCoupling(CouplingModel):
-    """Exchange coupling with an equal-phase collective decay channel."""
+    r"""Exchange coupling with an equal-phase collective decay channel.
+
+    Parameters
+    ----------
+    device_a, device_b : device or str
+        Coupled endpoints or their chip labels.
+    exchange_strength : float
+        Exchange rate :math:`g` in GHz.
+    decay_rate : float
+        Non-negative collective Lindblad rate :math:`\gamma_c` in 1/ns.
+    label : str or None, default None
+        Coupling label.
+
+    Notes
+    -----
+    The collapse operator is proportional to ``a + b``. This is a shared
+    bath channel, not two independent relaxation channels.
+    """
 
     _type_prefix = "collective_decay"
 
@@ -58,9 +112,27 @@ class CollectiveDecayCoupling(CouplingModel):
     )
 
     def interaction(self, a: Any, b: Any, p: Any) -> Any:
+        """Return the exchange interaction ``g(a b† + a† b)``.
+
+        Parameters
+        ----------
+        a, b : EndpointOps
+            Ordered endpoint operator namespaces.
+        p : ParameterNamespace
+            Bound coupling parameters.
+        """
         return p.exchange_strength * (a.a * b.adag + a.adag * b.a)
 
     def dissipation(self, a: Any, b: Any, p: Any) -> tuple[CollapseChannel, ...]:
+        """Return the shared-bath collapse channel proportional to ``a + b``.
+
+        Parameters
+        ----------
+        a, b : EndpointOps
+            Ordered endpoint operator namespaces.
+        p : ParameterNamespace
+            Bound coupling parameters.
+        """
         return (
             CollapseChannel(
                 a.a * b.I + a.I * b.a,

--- a/quchip/extensions/devices.py
+++ b/quchip/extensions/devices.py
@@ -14,7 +14,39 @@ from quchip.devices.kerr_cavity import KerrCavity
 
 
 class FrequencyModulatedMode(FockDevice):
-    """Harmonic mode with a prescribed sinusoidal frequency variation."""
+    r"""Harmonic mode with a prescribed sinusoidal frequency variation.
+
+    The authored Hamiltonian is :math:`H_0=\omega_0 n` and the time term is
+    :math:`\delta\omega\cos(2\pi\nu_m t+\phi_m)n`; frequencies are ordinary
+    GHz and ``t`` is in ns.
+
+    Parameters
+    ----------
+    frequency : float
+        Bare mode frequency :math:`\omega_0` in GHz; positive.
+    modulation_amplitude : float
+        Frequency excursion :math:`\delta\omega` in GHz; may be signed.
+    modulation_frequency : float
+        Modulation frequency :math:`\nu_m` in GHz; positive.
+    modulation_phase : float, default 0.0
+        Phase :math:`\phi_m` in radians.
+    levels : int, default 10
+        Fock truncation dimension.
+    label : str or None, default None
+        Device label; ``None`` selects an automatic label.
+    T1 : float or None, default None
+        Energy-relaxation time in ns; ``None`` disables T1 relaxation.
+    T2 : float or None, default None
+        Total 0-1 coherence time in ns; if both are set, ``T2 <= 2*T1``.
+    thermal_occupation : float or None, default None
+        Dimensionless mean bath occupation; ``None`` disables absorption.
+
+    References
+    ----------
+    See Didier et al., *Phys. Rev. A* 97, 022330 (2018),
+    https://doi.org/10.1103/PhysRevA.97.022330, for parametrically modulated
+    transmon models.
+    """
 
     _type_prefix = "frequency_modulated_mode"
     _default_levels = 10
@@ -39,9 +71,27 @@ class FrequencyModulatedMode(FockDevice):
         return self.frequency
 
     def local_hamiltonian(self, op: LocalOps, p: Any) -> PhysicsExpr:
+        """Return the static harmonic Hamiltonian.
+
+        Parameters
+        ----------
+        op : LocalOps
+            Local operator namespace.
+        p : ParameterNamespace
+            Bound symbolic parameters.
+        """
         return p.frequency * op.n
 
     def time_terms(self, op: LocalOps, p: Any) -> tuple[TimeDependentTerm, ...]:
+        """Return the sinusoidal frequency-modulation term.
+
+        Parameters
+        ----------
+        op : LocalOps
+            Local operator namespace.
+        p : ParameterNamespace
+            Bound symbolic parameters.
+        """
         return (
             TimeDependentTerm(
                 operator=op.n,
@@ -55,7 +105,15 @@ class FrequencyModulatedMode(FockDevice):
 
 
 class LossyKerrCavity(KerrCavity):
-    """Kerr cavity with an intrinsic two-photon-loss channel."""
+    r"""Kerr cavity with an intrinsic two-photon-loss channel.
+
+    Parameters
+    ----------
+    two_photon_loss_rate : float
+        Non-negative two-photon Lindblad rate :math:`\kappa_2` in 1/ns.
+    freq, kerr, levels, label, T1, T2, thermal_occupation
+        Inherited :class:`~quchip.devices.kerr_cavity.KerrCavity` parameters.
+    """
 
     _type_prefix = "lossy_kerr_cavity"
 
@@ -69,6 +127,15 @@ class LossyKerrCavity(KerrCavity):
     )
 
     def dissipation(self, op: Any, p: Any) -> tuple[CollapseChannel, ...]:
+        """Return inherited channels plus two-photon loss at ``kappa_2``.
+
+        Parameters
+        ----------
+        op : LocalOps
+            Local operator namespace.
+        p : ParameterNamespace
+            Bound symbolic parameters.
+        """
         return super().dissipation(op, p) + (
             CollapseChannel(op.a @ op.a, p.two_photon_loss_rate, "two_photon_loss"),
         )

--- a/quchip/extensions/drives.py
+++ b/quchip/extensions/drives.py
@@ -12,11 +12,29 @@ from quchip.devices.protocols import ChargeCoupled, PhaseCoupled
 
 
 class ChargePhaseDrive(DeviceDrive):
-    """Map delivered I and Q to charge and phase observables."""
+    """Map delivered I and Q quadratures to charge and phase observables.
+
+    Parameters
+    ----------
+    target : device or None, default None
+        Optional target device; ``None`` allows attachment through the normal
+        drive connection API.
+    label : str or None, default None
+        Drive label.
+    """
 
     _type_prefix = "charge_phase"
 
     def hamiltonian(self, target: Any, signal: Any) -> Any:
+        """Return the I/Q Hamiltonian for a charge-and-phase coupled target.
+
+        Parameters
+        ----------
+        target : device
+            Device implementing charge and phase coupling protocols.
+        signal : signal
+            Delivered I/Q signal.
+        """
         if not isinstance(target, ChargeCoupled) or not isinstance(target, PhaseCoupled):
             raise TypeError(
                 f"ChargePhaseDrive requires {type(target).__name__} to define "
@@ -29,7 +47,17 @@ class ChargePhaseDrive(DeviceDrive):
 
 
 class LossyChargeDrive(ChargeDrive):
-    """Charge-control line with an effective target-relaxation rate."""
+    """Charge-control line with an effective target-relaxation rate.
+
+    Parameters
+    ----------
+    line_loss_rate : float
+        Non-negative effective relaxation rate in 1/ns.
+    target : device or None, default None
+        Optional target passed to :class:`~quchip.control.drive.ChargeDrive`.
+    label : str or None, default None
+        Drive label.
+    """
 
     _type_prefix = "lossy_charge"
     line_loss_rate: Scalar = parameter(
@@ -41,6 +69,17 @@ class LossyChargeDrive(ChargeDrive):
     )
 
     def dissipation(self, device: BaseDevice, op: Any, p: Any) -> tuple[CollapseChannel, ...]:
+        """Return the effective line-loss collapse channel.
+
+        Parameters
+        ----------
+        device : BaseDevice
+            Target device.
+        op : operator namespace
+            Target lowering operator namespace.
+        p : ParameterNamespace
+            Bound drive parameters.
+        """
         return (
             CollapseChannel(
                 op.a,

--- a/quchip/extensions/envelopes.py
+++ b/quchip/extensions/envelopes.py
@@ -12,12 +12,31 @@ class CosineEnvelope(Envelope):
     r"""Raised-cosine pulse with zero endpoints and peak amplitude at mid-pulse.
 
     .. math:: E(t) = \frac{A}{2}\left[1-\cos(2\pi t/\tau)\right]
+    Parameters
+    ----------
+    duration : float
+        Pulse duration in ns; positive.
+    amplitude : float, default 1.0
+        Peak real amplitude. The returned envelope is complex with zero
+        quadrature.
+
+    References
+    ----------
+    See Motzoi et al., *Phys. Rev. Lett.* 103, 110501 (2009),
+    https://doi.org/10.1103/PhysRevLett.103.110501, for smooth pulse shaping.
     """
 
     duration: Scalar = parameter(default=UNBOUND, positive=True, unit="ns")
     amplitude: Scalar = parameter(default=1.0)
 
     def value(self, t: Any) -> Any:
+        """Evaluate the envelope at local times ``t`` in ns.
+
+        Parameters
+        ----------
+        t : scalar or array-like
+            Time relative to pulse start.
+        """
         return qnp.asarray(
             0.5 * self.amplitude * (1.0 - qnp.cos(2.0 * qnp.pi * t / self.duration)),
             dtype=complex,

--- a/quchip/extensions/signals.py
+++ b/quchip/extensions/signals.py
@@ -11,7 +11,16 @@ from quchip.utils.labeling import resolve_label
 
 
 class CableLoss(SignalTransform, serializable=True):
-    """Attenuate one control line by a power loss specified in dB."""
+    """Attenuate one control line by a power loss specified in dB.
+
+    Parameters
+    ----------
+    line : str or object with a label
+        Control-line label to transform; resolved once at construction.
+    loss_db : float
+        Positive power-loss value in dB. The complex amplitude is multiplied
+        by ``10**(-loss_db/20)``.
+    """
 
     line: str = setting()
     loss_db: Any = parameter()
@@ -21,6 +30,13 @@ class CableLoss(SignalTransform, serializable=True):
         object.__setattr__(self, "loss_db", loss_db)
 
     def apply(self, signals: SignalMap) -> SignalMap:
+        """Return signals with this line's amplitude attenuated.
+
+        Parameters
+        ----------
+        signals : SignalMap
+            Mapping keyed by ``(line, channel)`` signal identifiers.
+        """
         factor = qnp.power(10.0, -self.loss_db / 20.0)
         return {
             key: signal.scaled(factor) if key[0] == self.line else signal

--- a/quchip/extensions/spaces.py
+++ b/quchip/extensions/spaces.py
@@ -34,7 +34,28 @@ def _spin_operators() -> dict[str, Any]:
 
 
 class SpinHalf(DeviceModel):
-    """Two-level spin with a user-defined local operator vocabulary."""
+    r"""Two-level spin with a user-defined local operator vocabulary.
+
+    The local Hamiltonian is :math:`H=-\omega\sigma_z/2`, with ordinary
+    frequency ``freq`` in GHz.
+
+    Parameters
+    ----------
+    freq : float
+        Transition frequency :math:`\omega` in GHz; positive.
+    basis : {None, "native", "eigen"}, keyword-only
+        Solver basis request. ``None`` uses the chip default.
+    levels : int, default 2
+        Must remain exactly 2.
+    label : str or None, default None
+        Device label.
+    T1 : float or None, default None
+        Energy-relaxation time in ns; ``None`` disables T1 relaxation.
+    T2 : float or None, default None
+        Total 0-1 coherence time in ns; if both are set, ``T2 <= 2*T1``.
+    thermal_occupation : float or None, default None
+        Dimensionless mean bath occupation; ``None`` disables absorption.
+    """
 
     _type_prefix = "spin_half"
     _default_levels = 2

--- a/quchip/interop/base.py
+++ b/quchip/interop/base.py
@@ -32,6 +32,16 @@ def source_key(tp: type) -> str:
     name, e.g. ``"scqubits.Transmon"``. Only the top-level module is used so
     that a mapping registered against a package root matches classes
     re-exported from submodules.
+
+    Parameters
+    ----------
+    tp : type
+        Third-party class to identify.
+
+    Returns
+    -------
+    str
+        Top-level module and qualified class name separated by a dot.
     """
     return f"{tp.__module__.split('.')[0]}.{tp.__qualname__}"
 
@@ -121,6 +131,18 @@ class ModelMapping:
 
         Override to support import. The base implementation raises
         :class:`NotImplementedError`.
+
+        Parameters
+        ----------
+        obj : object
+            Third-party instance to convert.
+        **opts
+            Mapping-specific keyword options; subclasses must document supported keys.
+
+        Returns
+        -------
+        object
+            Converted quchip model, as defined by the subclass.
         """
         raise NotImplementedError(f"{type(self).__qualname__} does not support import.")
 
@@ -129,6 +151,18 @@ class ModelMapping:
 
         Override to support export; overriding requires setting ``target``.
         The base implementation raises :class:`NotImplementedError`.
+
+        Parameters
+        ----------
+        device : object
+            quchip device to convert.
+        **opts
+            Mapping-specific keyword options; subclasses must document supported keys.
+
+        Returns
+        -------
+        object
+            Converted third-party model, as defined by the subclass.
         """
         raise NotImplementedError(f"{type(self).__qualname__} does not support export.")
 
@@ -145,6 +179,19 @@ def import_object(obj: Any, **opts: Any) -> Any:
         No mapping is registered for ``type(obj)`` or any of its base
         classes. The message names the missing source key and shows the
         skeleton for authoring a new :class:`ModelMapping`.
+
+    Parameters
+    ----------
+    obj : object
+        Third-party object whose type selects the registered mapping.
+    **opts
+        Keywords forwarded unchanged to the mapping's conversion method.
+        See that method for supported keys and defaults.
+
+    Returns
+    -------
+    object
+        Converted quchip model.
     """
     for klass in type(obj).__mro__:
         mapping_cls = _IMPORT_REGISTRY.get(source_key(klass))
@@ -167,6 +214,21 @@ def export_object(device: Any, library: str, **opts: Any) -> Any:
     LookupError
         No mapping is registered for ``(library, type(device))`` or any base
         class. The message lists the device types *library* can export.
+
+    Parameters
+    ----------
+    device : BaseDevice
+        Device whose type selects the registered mapping.
+    library : str
+        Registered target library, such as ``"scqubits"``.
+    **opts
+        Keywords forwarded unchanged to the mapping's conversion method.
+        See that method for supported keys and defaults.
+
+    Returns
+    -------
+    object
+        Converted third-party object.
     """
     for klass in type(device).__mro__:
         mapping_cls = _EXPORT_REGISTRY.get((library, klass))

--- a/quchip/interop/eigenbasis.py
+++ b/quchip/interop/eigenbasis.py
@@ -40,12 +40,41 @@ def _operator_from_json(value: list[list[list[float]]] | None) -> np.ndarray | N
 
 
 class EigenbasisDevice(BaseDevice):
-    """Device backed by frozen energies and optional energy-basis operators.
+    """Represent a frozen source spectrum and its energy-basis operators.
 
-    This is the narrow import path for a third-party model that quchip cannot
-    reconstruct from symbolic circuit parameters. Its authored local space is
-    already the source model's energy basis, so normal engine materialization
-    applies without a device-owned diagonalization or projection path.
+    Source circuit parameters cannot be differentiated through this snapshot.
+
+    Parameters
+    ----------
+    energies : array_like, shape (n,)
+        Energy-ordered levels in GHz, with ``n >= 2``. The first energy
+        is subtracted from every level.
+    charge_operator, phase_operator : array_like, shape (n, n), or None
+        Operators in the same source eigenbasis. ``None`` leaves that drive
+        channel unavailable; supplied matrix elements retain source conventions.
+    levels : int or None, default None
+        Number of retained energy levels. ``None`` retains all supplied levels.
+    label : str or None, default None
+        Device label; omission generates ``eigenbasis_<index>``.
+    source_type : str or None, default None
+        Provenance label, such as ``"scqubits.ZeroPi"``.
+    collapse_model : {"fermi_golden", "ladder"}, default "fermi_golden"
+        Relaxation from transition matrix elements or an ideal ladder operator.
+    coupling_channel : {"charge", "flux"} or None, default None
+        Operator for matrix-element relaxation; ``"flux"`` uses
+        ``phase_operator``. Required when ``T1`` is set with ``"fermi_golden"``.
+    collapse_rate_threshold : float, default 1e-8
+        Nonnegative cutoff on normalized downward-transition strengths.
+    **noise : scalar or None
+        ``T1`` and ``T2`` in ns, and dimensionless ``thermal_occupation``.
+        ``None`` leaves the corresponding channel absent. See
+        :class:`~quchip.devices.base.BaseDevice` for noise constraints.
+
+    References
+    ----------
+    Blais et al., Rev. Mod. Phys. 93, 025005 (2021),
+    https://doi.org/10.1103/RevModPhys.93.025005, for energy-basis
+    operators and coupling to dissipative environments.
     """
 
     _type_prefix = "eigenbasis"
@@ -103,6 +132,24 @@ class EigenbasisDevice(BaseDevice):
         super().__init__(levels=dimension, label=label, **noise)
 
     def dissipation(self, op: Any, p: Any) -> tuple[CollapseChannel, ...]:
+        """Return relaxation and dephasing channels for the stored spectrum.
+
+        Parameters
+        ----------
+        op : LocalOps
+            Local operator namespace; unused because stored matrices define the basis.
+        p : parameter namespace
+            Bound noise parameters for this calculation.
+
+        Returns
+        -------
+        tuple of CollapseChannel
+            Channels selected by ``collapse_model`` and the active noise parameters.
+
+        See Also
+        --------
+        EigenbasisDevice : Dissipation choices and physics reference.
+        """
         del op
         return tuple(
             _matrix_element_emission_channel(self, p)
@@ -167,6 +214,19 @@ class EigenbasisDevice(BaseDevice):
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "EigenbasisDevice":
+        """Restore a frozen device declaration.
+
+        Parameters
+        ----------
+        data : dict
+            Output of :meth:`to_dict`, including energies and optional operator
+            matrices encoded as separate real and imaginary nested lists.
+
+        Returns
+        -------
+        EigenbasisDevice
+            Restored device with noise and reference-frequency metadata.
+        """
         return cls(
             data["energies"],
             charge_operator=_operator_from_json(data.get("charge_operator")),

--- a/quchip/interop/scqubits/__init__.py
+++ b/quchip/interop/scqubits/__init__.py
@@ -27,18 +27,40 @@ def _require_scqubits() -> None:
 
 
 def from_scqubits(obj: Any, **opts: Any) -> Any:
-    """Convert a scqubits object into the matching quchip device.
+    """Import a scqubits device or composite system.
 
-    Dispatches on ``type(obj)`` through the :class:`ModelMapping` registry.
-    Keyword options (``levels``, ``label``, noise parameters) are forwarded to
-    the mapping's ``import_model``.
+    Parameters
+    ----------
+    obj : scqubits object
+        A supported circuit, oscillator, or ``HilbertSpace``. Device mappings
+        are listed in :mod:`quchip.interop.scqubits.devices`.
+    **opts
+        Device imports accept ``levels`` (default: source ``truncated_dim``),
+        ``label`` (default: source ``id_str``), and target-device noise options
+        such as ``T1``, ``T2`` and ``thermal_occupation``. Matrix-element
+        relaxation may also require ``coupling_channel``; see the target class.
+        Composite imports accept ``frame`` (default ``"lab"``) and
+        ``approximation`` (default ``Exact()``); device options are not forwarded.
+
+    Returns
+    -------
+    BaseDevice or Chip
+        Converted device, or a composite of frozen eigenbasis snapshots.
+        Snapshot source parameters are not differentiable through quchip.
 
     Raises
     ------
     ImportError
-        scqubits is not installed.
+        The optional ``quchip[scqubits]`` dependency is unavailable.
     LookupError
-        No :class:`ModelMapping` is registered for ``type(obj)``.
+        No mapping exists for the source type.
+    NotImplementedError
+        A composite contains unsupported interactions.
+
+    References
+    ----------
+    Groszkowski and Koch, *scqubits: a Python package for superconducting
+    qubits*, Quantum 5, 583 (2021), https://doi.org/10.22331/q-2021-11-17-583.
     """
     _require_scqubits()
 
@@ -53,24 +75,39 @@ def from_scqubits(obj: Any, **opts: Any) -> Any:
 
 
 def to_scqubits(device_or_chip: Any, **opts: Any) -> Any:
-    """Convert a quchip device into the matching scqubits object.
+    """Export a quchip device or chip to scqubits.
 
-    Dispatches on ``type(device_or_chip)`` through the export registry for the
-    ``"scqubits"`` library. Parameters must be concrete: a device carrying JAX
-    tracers (inside ``jit``/``grad``) raises :class:`ValueError`.
+    Parameters
+    ----------
+    device_or_chip : BaseDevice or Chip
+        Model with concrete parameters. A chip exports subsystems and supported
+        interactions; filtered couplings require ``Exact()`` before export.
+    **opts
+        Mapping-specific options. ``DuffingTransmon`` export accepts ``ncut``
+        (integer charge cutoff, default 30) for reconstructing circuit energies.
+        Other shipped device mappings currently ignore extra options.
+        Composite export accepts no keyword options.
 
-    A :class:`~quchip.chip.chip.Chip` exports to an scqubits ``HilbertSpace``
-    (devices as subsystems, couplings as interaction terms); see
-    :func:`~quchip.interop.scqubits.composite.export_chip`.
+    Returns
+    -------
+    scqubits object
+        Corresponding device or ``HilbertSpace``. Chip control equipment and
+        baths are omitted with a warning; port networks and effective terms
+        are unsupported. See :func:`~quchip.interop.scqubits.composite.export_chip`.
 
     Raises
     ------
     ImportError
-        scqubits is not installed.
+        The optional ``quchip[scqubits]`` dependency is unavailable.
     LookupError
-        No :class:`ModelMapping` exports this device type to scqubits.
+        No export mapping exists for a device type.
     ValueError
-        A device parameter is a JAX tracer rather than a concrete value.
+        Parameters are traced or approximation filtering would change the export.
+
+    References
+    ----------
+    Groszkowski and Koch, Quantum 5, 583 (2021),
+    https://doi.org/10.22331/q-2021-11-17-583.
     """
     _require_scqubits()
 

--- a/quchip/interop/scqubits/composite.py
+++ b/quchip/interop/scqubits/composite.py
@@ -454,6 +454,12 @@ def export_chip(chip: Chip, **opts: Any) -> Any:
         A device has no registered scqubits export mapping.
     TypeError
         An unexpected keyword option is passed (composite export takes none).
+
+    Other Parameters
+    ----------------
+    **opts
+        No keyword options are accepted for composite export. Any supplied
+        key raises ``TypeError``.
     """
     import scqubits
 

--- a/quchip/interop/scqubits/devices.py
+++ b/quchip/interop/scqubits/devices.py
@@ -156,10 +156,10 @@ class FluxoniumMapping(ModelMapping):
     ==================  ======================
 
     The native discretizations differ — scqubits uses a harmonic-oscillator
-    basis of size ``cutoff``, quchip a plane-wave phase grid of ``num_basis``
+    basis of size ``cutoff``, quchip a finite-difference phase grid of ``num_basis``
     points — so quchip keeps its own default grid rather than mirroring
-    ``cutoff``. The physics is identical; only the basis is not, which is why
-    the spectrum agreement is at ``atol=1e-6`` rather than machine precision.
+    ``cutoff``. Both represent the fluxonium Hamiltonian, but convergence of
+    each discretization must be checked for the chosen parameters.
     Export uses scqubits' ``cutoff=110`` default.
     """
 

--- a/quchip/inverse_design/types.py
+++ b/quchip/inverse_design/types.py
@@ -57,7 +57,21 @@ class ObservableReport:
 
 @dataclass(frozen=True)
 class FitParameterReport:
-    """Starting point, bounds, result, and provenance for one bare parameter."""
+    """Record one fitted bare parameter.
+
+    Attributes
+    ----------
+    name : str
+        Path in ``chip.parameters``.
+    initial, final : float
+        Seed and fitted values in the parameter's native units.
+    lower_bound, upper_bound : float
+        Bounds used by the optimizer, in the same units.
+    seed_source : str
+        Origin of the starting value, as recorded by the fitter.
+    sign_choice : str or None
+        Coupling-sign decision, or ``None`` when no decision was needed.
+    """
 
     name: str
     initial: float
@@ -69,7 +83,7 @@ class FitParameterReport:
 
     @property
     def delta(self) -> float:
-        """Signed optimizer displacement, ``final - initial`` (GHz)."""
+        """Signed optimizer displacement, ``final - initial``, in the parameter's native units."""
         return self.final - self.initial
 
 

--- a/quchip/observables.py
+++ b/quchip/observables.py
@@ -10,7 +10,26 @@ from quchip.utils.labeling import resolve_label
 
 @dataclass(frozen=True)
 class OutputField:
-    r"""Request ``<b_out>`` and ``<b_out dagger b_out>`` at one exposure."""
+    r"""Request the mean field and photon flux at an exposed output.
+
+    Usually obtained as ``network.expose(...).output`` and supplied to
+    ``e_ops`` when building a simulation.
+
+    Parameters
+    ----------
+    exposure : str or NetworkPort
+        Exposed network port or its label. The calculation must contain it.
+
+    Attributes
+    ----------
+    exposure : str
+        Stored exposure label.
+
+    See Also
+    --------
+    quchip.results.results.OutputFieldTrace : Output moments, units, and conventions.
+    quchip.chip.port_network.PortNetwork : Input-output model and physics references.
+    """
 
     exposure: str
 

--- a/quchip/results/_batch.py
+++ b/quchip/results/_batch.py
@@ -143,7 +143,15 @@ class BatchResult(Generic[ResultT]):
         shape: tuple[int, ...],
         axes: tuple[tuple[str, Any], ...],
     ) -> Self:
-        """Return an equivalent batch annotated with sweep-axis metadata."""
+        """Return an equivalent batch annotated with sweep-axis metadata.
+
+        Parameters
+        ----------
+        shape : tuple of int
+            New sweep-grid shape.
+        axes : tuple
+            Named sweep-axis coordinates matching ``shape``.
+        """
         return type(self)(list(self._results), shape=shape, axes=axes)
 
     def __repr__(self) -> str:

--- a/quchip/results/input_output.py
+++ b/quchip/results/input_output.py
@@ -46,6 +46,22 @@ class SParameterResult:
     The stationary route computes both matrices from one shifted-Liouvillian
     factorization. The passive-linear route reports zero for ``T``.
     ``numpy.asarray(result)`` returns ``matrix``.
+
+    Attributes
+    ----------
+    frequencies : scalar or array_like
+        Probe frequencies in GHz.
+    ports : tuple of str
+        Port labels in output/input matrix order.
+    axes : tuple
+        Sweep-axis ``(name, values)`` pairs; ``shape`` is the sweep shape.
+    diagnostics : tuple of mapping
+        Per-point solver diagnostics.
+    matrix, conjugate_matrix : array_like
+        ``S`` and phase-conjugating ``T`` arrays with shape
+        ``(*shape, n_ports, n_ports)``.
+    shape : tuple of int
+        Sweep-grid shape preceding the matrix axes.
     """
 
     frequencies: Any
@@ -69,11 +85,23 @@ class SParameterResult:
         return tuple(name for name, _ in self.axes)
 
     def s(self, output: Any, input: Any) -> Any:
-        """Return ``S(output, input)`` over the sweep grid for two selected ports."""
+        """Return ``S(output, input)`` over the sweep grid.
+
+        Parameters
+        ----------
+        output, input : port object or str
+            Output row and input column.
+        """
         return self.matrix[..., self._index(output), self._index(input)]
 
     def t(self, output: Any, input: Any) -> Any:
-        """Return the phase-conjugating ``T(output, input)`` over the sweep grid."""
+        """Return phase-conjugating ``T(output, input)`` over the sweep grid.
+
+        Parameters
+        ----------
+        output, input : port object or str
+            Output row and input column.
+        """
         return self.conjugate_matrix[..., self._index(output), self._index(input)]
 
     @property
@@ -114,6 +142,25 @@ class MeanFieldResponseResult:
     plane and carrier, and is ``NaN`` where ``beta`` is zero. The result
     contains one stationary mean-field branch; it does not encode sweep-rate
     hysteresis or metastable branches.
+
+    Attributes
+    ----------
+    ports : tuple of str
+        Selected output labels in the final array axis.
+    input : str
+        Probe input label.
+    frequencies, amplitudes : scalar or array_like
+        Probe values in GHz and ``1/sqrt(ns)``.
+    axes : tuple
+        Sweep-axis ``(name, values)`` pairs; ``shape`` is their array shape.
+    diagnostics : tuple of mapping
+        Per-point stationary-solver diagnostics.
+    values : array_like
+        Complex output means with shape ``(*shape, n_ports)``.
+    incident : array_like
+        Incident amplitude broadcast over ``shape``.
+    shape : tuple of int
+        Sweep-grid shape preceding the port axis.
     """
 
     ports: tuple[str, ...]
@@ -139,7 +186,13 @@ class MeanFieldResponseResult:
         return tuple(name for name, _ in self.axes)
 
     def mean(self, plane: Any) -> Any:
-        """Return the stationary ``<b_out>`` at ``plane`` with shape ``shape``."""
+        """Return stationary ``<b_out>`` at ``plane`` with shape ``shape``.
+
+        Parameters
+        ----------
+        plane : port object or str
+            Output reference plane.
+        """
         label = resolve_label(plane)
         try:
             return self.values[..., self.ports.index(label)]
@@ -152,6 +205,11 @@ class MeanFieldResponseResult:
         The result is complex ``NaN`` where the incident ``beta`` is zero. Its
         zero-amplitude limit is the corresponding small-signal S-parameter when
         no fixed pump leaves a coherent mean at that plane and carrier.
+
+        Parameters
+        ----------
+        plane : port object or str
+            Output reference plane.
         """
         mean = self.mean(plane)
         xp = select_array_module(is_jax_array(mean))
@@ -172,6 +230,21 @@ class OutputSpectrumResult:
     ``signal_coherent_flux`` and ``signal_incoherent_flux``. Added noise is
     not included in these fluxes because converting a spectral density to
     flux requires a detection bandwidth.
+
+    Attributes
+    ----------
+    port : str
+        Output port label.
+    frequencies : array_like
+        Offset frequencies in GHz.
+    total_fluctuation_spectrum, signal_fluctuation_spectrum, added_noise_spectrum : array_like
+        Normal-ordered spectral densities in frequency order.
+    signal_photon_flux, signal_coherent_flux, signal_incoherent_flux : scalar
+        Propagated flux terms in photons/ns.
+    steady_state : SteadyStateResult
+        Captured stationary state used for the spectra.
+    fourier_convention : str
+        Definition of the reported two-sided spectrum.
     """
 
     port: str
@@ -188,7 +261,25 @@ class OutputSpectrumResult:
 
 @dataclass(frozen=True)
 class OutputCorrelationResult:
-    """Normalized stationary output-field correlation versus delay."""
+    """Normalized stationary output-field correlation versus delay.
+
+    Attributes
+    ----------
+    order : {1, 2}
+        Correlation order.
+    input_port, output_port : str
+        Correlation input and delayed output labels.
+    delays : array_like
+        Non-negative delays in ns.
+    values, unnormalized : array_like
+        Normalized and raw correlation values in delay order.
+    input_intensity, output_intensity : scalar
+        Mean photon fluxes used for normalization.
+    steady_state : SteadyStateResult
+        Captured stationary state.
+    normalization : str
+        Human-readable normalization convention.
+    """
 
     order: int
     input_port: str

--- a/quchip/results/measurement.py
+++ b/quchip/results/measurement.py
@@ -32,7 +32,25 @@ def _index(ports: tuple[str, ...], output: Any) -> int:
 
 @dataclass(frozen=True)
 class VNAMeasurementSamples:
-    """Synthetic Gaussian IQ draws with sample, sweep, then output axes."""
+    """Synthetic Gaussian IQ draws with sample, sweep, then output axes.
+
+    Attributes
+    ----------
+    ports : tuple of str
+        Output labels in the final array axis.
+    input : str
+        Driven input label.
+    axes : tuple
+        Named sweep-axis metadata.
+    incident : array_like
+        Incident complex field in ``1/sqrt(ns)``.
+    values : array_like
+        Sampled complex fields with leading shot and final output axes.
+    receiver : IQReceiver
+        Receiver used to integrate the physical spectra.
+    distribution : str
+        Sampling approximation.
+    """
 
     ports: tuple[str, ...]
     input: str
@@ -47,11 +65,23 @@ class VNAMeasurementSamples:
         object.__setattr__(self, "incident", _capture(self.incident))
 
     def field(self, output: Any) -> Any:
-        """Return sampled complex fields in 1/sqrt(ns)."""
+        """Return sampled complex fields in ``1/sqrt(ns)``.
+
+        Parameters
+        ----------
+        output : port object or str
+            Output plane to select.
+        """
         return self.values[..., _index(self.ports, output)]
 
     def ratio(self, output: Any) -> Any:
-        """Return sampled output/input ratios, undefined for zero input."""
+        """Return sampled output/input ratios, undefined for zero input.
+
+        Parameters
+        ----------
+        output : port object or str
+            Output plane to select.
+        """
         xp = array_namespace(self.values)
         zero = self.incident == 0
         return xp.where(zero, xp.nan + 0j, self.field(output) / xp.where(zero, 1.0, self.incident))
@@ -59,7 +89,27 @@ class VNAMeasurementSamples:
 
 @dataclass(frozen=True)
 class VNAMeasurementStatistics:
-    """Integrated output means and full covariance of (I0,Q0,I1,Q1,...)."""
+    """Integrated output means and full covariance of ``(I0,Q0,I1,Q1,...)``.
+
+    Attributes
+    ----------
+    ports : tuple of str
+        Output labels in covariance order.
+    input : str
+        Driven input label.
+    axes : tuple
+        Named sweep-axis metadata.
+    incident : array_like
+        Incident complex field in ``1/sqrt(ns)``.
+    values : array_like
+        Integrated complex output means.
+    iq_covariance : array_like
+        Full real IQ covariance with two axes per output.
+    receiver : IQReceiver
+        Receiver used for integration.
+    contributions : mapping
+        Named integrated covariance contributions.
+    """
 
     ports: tuple[str, ...]
     input: str
@@ -77,17 +127,37 @@ class VNAMeasurementStatistics:
             {key: _capture(value) for key, value in self.contributions.items()}))
 
     def mean(self, output: Any) -> Any:
-        """Return the integrated complex mean at an output."""
+        """Return the integrated complex mean at an output.
+
+        Parameters
+        ----------
+        output : port object or str
+            Output plane to select.
+        """
         return self.values[..., _index(self.ports, output)]
 
     def covariance(self, output: Any, other: Any = None) -> Any:
-        """Return a 2x2 IQ covariance or cross-output covariance block."""
+        """Return a 2x2 IQ covariance or cross-output covariance block.
+
+        Parameters
+        ----------
+        output : port object or str
+            First output plane.
+        other : port object, str, or None, optional
+            Second output plane; ``None`` selects ``output``.
+        """
         i = 2 * _index(self.ports, output)
         j = i if other is None else 2 * _index(self.ports, other)
         return self.iq_covariance[..., i:i+2, j:j+2]
 
     def noise_contributions(self, output: Any) -> Mapping[str, Any]:
-        """Return integrated source covariance blocks, including detector vacuum."""
+        """Return integrated source covariance blocks, including detector vacuum.
+
+        Parameters
+        ----------
+        output : port object or str
+            Output plane to select.
+        """
         i = 2 * _index(self.ports, output)
         return MappingProxyType({key: value[..., i:i+2, i:i+2] for key, value in self.contributions.items()})
 
@@ -97,6 +167,15 @@ class VNAMeasurementStatistics:
         Use seed for NumPy draws or an explicit JAX random key. The covariance
         includes anomalous/cross-output second moments, but does not specify
         higher-order non-Gaussian photon statistics.
+
+        Parameters
+        ----------
+        count : int
+            Positive number of samples.
+        seed : int or None, optional
+            NumPy random seed.
+        key : jax.Array or None, optional
+            JAX random key; mutually exclusive with ``seed``.
         """
         xp = array_namespace(self.values)
         mean = xp.stack((xp.real(self.values), xp.imag(self.values)), axis=-1)
@@ -106,7 +185,13 @@ class VNAMeasurementStatistics:
         return VNAMeasurementSamples(self.ports, self.input, self.axes, self.incident, values, self.receiver)
 
     def calibrate(self, factors: Mapping[Any, Any]) -> VNAMeasurementStatistics:
-        """Multiply output fields and both covariance axes by calibration factors."""
+        """Multiply output fields and covariance axes by calibration factors.
+
+        Parameters
+        ----------
+        factors : mapping
+            Complex amplitude factor keyed by output plane; omitted outputs use one.
+        """
         xp = select_array_module(is_jax_array(self.values) or contains_tracer(tuple(factors.values())))
         normalized = {resolve_label(port): value for port, value in factors.items()}
         for port in normalized:
@@ -129,6 +214,41 @@ class VNAMeasurement(MeanFieldResponseResult):
     excess spectral covariance). The latter has an offset-frequency axis
     before its two IQ axes. Device-generated excess includes input-system
     correlations and can be negative; it is not an independent random source.
+
+    Attributes
+    ----------
+    ports : tuple of str
+        Captured output labels.
+    input : str
+        Driven input label.
+    values : array_like
+        Complex output means with the output axis last.
+    incident : array_like
+        Incident complex field in ``1/sqrt(ns)``.
+    frequencies, amplitudes : array_like
+        Probe frequencies in GHz and incident amplitudes.
+    shape : tuple of int
+        Broadcast sweep shape.
+    axes : tuple
+        Named sweep-axis metadata.
+    diagnostics : mapping
+        Captured solve diagnostics.
+    noise_frequencies : array_like
+        Two-sided offsets in GHz.
+    noise_components : mapping
+        Named white and excess IQ covariance spectra.
+    output_delays : array_like
+        Output reference-plane delays in ns.
+    parameters : tuple of mapping
+        Bound parameters for each sweep point.
+    modes : tuple of str
+        Captured internal Fock-mode labels.
+    mode_amplitudes, photon_numbers : array_like
+        Internal stationary means and occupations.
+    mode_frequencies : array_like
+        Internal stationary-frame frequencies in GHz.
+    conventions : tuple of str
+        Units and statistical conventions.
     """
 
     noise_frequencies: Any
@@ -169,6 +289,11 @@ class VNAMeasurement(MeanFieldResponseResult):
         Use ``mode_frequency(mode)`` for that frame's frequency in GHz.
         This is the internal field with the full declared wiring included.
         The returned array follows the measurement's sweep axes.
+
+        Parameters
+        ----------
+        mode : device object or str
+            Captured Fock mode.
         """
         return self.mode_amplitudes[..., self._mode_index(mode)]
 
@@ -178,15 +303,32 @@ class VNAMeasurement(MeanFieldResponseResult):
         Available for authored Fock modes, including nonlinear modes. The
         general solver retains the declared basis projection and truncation.
         Receiver integration and calibration do not change this occupation.
+
+        Parameters
+        ----------
+        mode : device object or str
+            Captured Fock mode.
         """
         return self.photon_numbers[..., self._mode_index(mode)]
 
     def mode_frequency(self, mode: Any) -> Any:
-        """Return the captured stationary frame frequency of a mode in GHz."""
+        """Return the captured stationary frame frequency of a mode in GHz.
+
+        Parameters
+        ----------
+        mode : device object or str
+            Captured Fock mode.
+        """
         return self.mode_frequencies[..., self._mode_index(mode)]
 
     def noise_contributions(self, output: Any) -> Mapping[str, Any]:
-        """Return physical IQ spectral contributions at the captured offsets."""
+        """Return physical IQ spectral contributions at the captured offsets.
+
+        Parameters
+        ----------
+        output : port object or str
+            Output plane to select.
+        """
         i = 2 * _index(self.ports, output)
         return MappingProxyType({name: white[..., None, i:i+2, i:i+2] + excess[..., i:i+2, i:i+2]
                                  for name, (white, excess) in self.noise_components.items()})
@@ -198,6 +340,13 @@ class VNAMeasurement(MeanFieldResponseResult):
         This normally ordered spectrum excludes coherent signal and receiver
         vacuum. Power units use hf times occupation at the absolute sideband
         frequency and require positive physical frequencies. No solve is run.
+
+        Parameters
+        ----------
+        output : port object or str
+            Output plane to select.
+        unit : {"quanta", "W/Hz", "dBm/Hz"}, default="quanta"
+            Spectral-density unit.
         """
         xp = array_namespace(self.values)
         spectrum = normal_spectrum(sum(self.noise_contributions(output).values()), xp)
@@ -214,7 +363,13 @@ class VNAMeasurement(MeanFieldResponseResult):
         return xp.where(power > 0, 10*xp.log10(xp.where(power > 0, power, 1.0)/1e-3), -xp.inf)
 
     def statistics(self, *, receiver: IQReceiver) -> VNAMeasurementStatistics:
-        """Integrate captured spectra and detector vacuum without a solver call."""
+        """Integrate captured spectra and detector vacuum without a solver call.
+
+        Parameters
+        ----------
+        receiver : IQReceiver
+            Boxcar receiver and optional digital transfer.
+        """
         covariance, contributions, mean_gain = integrate_noise(
             self.values, self.noise_frequencies, self.noise_components, self.output_delays, receiver)
         return VNAMeasurementStatistics(self.ports, self.input, self.axes, self.incident,
@@ -223,5 +378,17 @@ class VNAMeasurement(MeanFieldResponseResult):
     def sample(
         self, count: int, *, receiver: IQReceiver, seed: int | None = None, key: Any = None,
     ) -> VNAMeasurementSamples:
-        """Integrate for a receiver and draw samples from the captured moments."""
+        """Integrate for a receiver and draw samples from the captured moments.
+
+        Parameters
+        ----------
+        count : int
+            Positive number of samples.
+        receiver : IQReceiver
+            Boxcar receiver and optional digital transfer.
+        seed : int or None, optional
+            NumPy random seed.
+        key : jax.Array or None, optional
+            JAX random key; mutually exclusive with ``seed``.
+        """
         return self.statistics(receiver=receiver).sample(count, seed=seed, key=key)

--- a/quchip/results/partitioned.py
+++ b/quchip/results/partitioned.py
@@ -20,7 +20,17 @@ _JOINT_WARNING = (
 
 
 class PartitionedSimulationResult:
-    """Result of one partitioned solve: K component results + a key plan."""
+    """Result of one partitioned solve: K component results plus a key plan.
+
+    Attributes
+    ----------
+    component_results : sequence of SimulationResult
+        Per-component results in ``partition.components`` order.
+    partition : object
+        Component and device ownership metadata.
+    key_plan : mapping
+        Mapping from requested observable keys to component traces.
+    """
 
     def __init__(self, component_results: list, partition: Any, key_plan: dict) -> None:
         """Wrap the per-component solves produced by one partitioned run.
@@ -79,6 +89,15 @@ class PartitionedSimulationResult:
         return self._results[entry.component].expect(entry.key, effective)
 
     def expect(self, key: Any, index: int | None = None) -> Any:
+        """Return one captured expectation trace.
+
+        Parameters
+        ----------
+        key : object or str
+            Captured observable key.
+        index : int or None, optional
+            Entry of a list-valued observable.
+        """
         entry = self._key_plan.get(self._normalize_key(key))
         if entry is None:
             raise KeyError(f"No observable {key!r} in this partitioned result. Known: {list(self._key_plan)}")
@@ -94,10 +113,29 @@ class PartitionedSimulationResult:
         return self._local_values(entry, index)
 
     def observable_at(self, t: Any, values: Any, *, method: str = "exact") -> Any:
-        """Select or linearly interpolate observable values on the shared grid."""
+        """Select or linearly interpolate observable values on the shared grid.
+
+        Parameters
+        ----------
+        t : scalar or array_like
+            Query times in ns.
+        values : array_like
+            Saved values with time on the final axis.
+        method : {"exact", "nearest", "interpolate"}, default="exact"
+            Time-selection rule.
+        """
         return self._results[0].observable_at(t, values, method=method)
 
     def expect_final(self, key: Any, index: int | None = None) -> Any:
+        """Return the final expectation value for an observable.
+
+        Parameters
+        ----------
+        key : object or str
+            Captured observable key.
+        index : int or None, optional
+            Entry of a list-valued observable.
+        """
         return self.expect(key, index)[-1]
 
     expect_values = expect
@@ -106,7 +144,15 @@ class PartitionedSimulationResult:
         return self._results[self._partition.owner_of(device)]
 
     def iq_readout(self, output: Any, **kwargs: Any) -> Any:
-        """Build a detector from the unique component owning an exposed output."""
+        """Build a detector from the component owning an exposed output.
+
+        Parameters
+        ----------
+        output : port object or str
+            External output reference plane.
+        **kwargs
+            Forwarded to :meth:`SimulationResult.iq_readout`.
+        """
         label = resolve_label(output)
         owners = [result for result in self._results if result._readout_wiring is not None
                   and label in result._readout_wiring.exposed]
@@ -122,11 +168,29 @@ class PartitionedSimulationResult:
         captured energy basis of the stored integration frame: one matrix for
         one device, or a device mapping. No phase-frame conversion is applied.
         Samples at different times represent independently terminated experiments.
+
+        Parameters
+        ----------
+        *devices : device object or str
+            Measured devices; an empty selection measures all devices.
+        t : scalar, array_like, or None, optional
+            Saved time or times in ns; ``None`` selects the final state.
+        basis : {"energy", "solver"}, array_like, or mapping, default="energy"
+            Captured local measurement basis.
         """
         from quchip.results.terminal import measure_result
         return measure_result(self, devices, t=t, basis=basis)
 
     def population(self, device: Any, level: int = 0) -> Any:
+        """Return occupation of a captured isolated energy level.
+
+        Parameters
+        ----------
+        device : device object or str
+            Captured device.
+        level : int, default=0
+            Zero-based isolated energy level.
+        """
         return self._owner_result(device).population(device, level)
 
     def check_truncation(self, threshold: float = 1e-3) -> dict[str, float]:
@@ -135,6 +199,11 @@ class PartitionedSimulationResult:
         Mirrors :meth:`~quchip.results.results.SimulationResult.check_truncation`'s
         return shape (a ``dict`` keyed by device label) for duck-typing parity
         between a joint and a partitioned result.
+
+        Parameters
+        ----------
+        threshold : float, default=1e-3
+            Maximum accepted boundary population.
         """
         merged: dict[str, float] = {}
         for result in self._results:
@@ -230,7 +299,15 @@ class PartitionedSimulationResult:
         return self._joint_state([r.final_state for r in self._results])
 
     def state_at(self, t: Any, *, method: str = "exact") -> Any:
-        """Reconstruct a joint state at a saved time, with optional nearest selection."""
+        """Reconstruct a joint state at a saved time.
+
+        Parameters
+        ----------
+        t : scalar
+            Query time in ns.
+        method : {"exact", "nearest"}, default="exact"
+            Time-selection rule.
+        """
         return self._joint_state([r.state_at(t, method=method) for r in self._results])
 
     def _joint_state(self, states: list) -> Any:

--- a/quchip/results/receiver.py
+++ b/quchip/results/receiver.py
@@ -12,16 +12,29 @@ from quchip.utils.jax_utils import contains_tracer, is_jax_array, select_array_m
 
 @dataclass(frozen=True)
 class IQReceiver:
-    """Configure ideal heterodyne detection after the physical calculation.
+    """Configure ideal heterodyne detection after a physical measurement.
 
+    Parameters
+    ----------
     integration_time : scalar
-        Boxcar integration duration in ns; white noise scales as 1/T.
-    transfer : callable, optional
-        Additional digital amplitude transfer at offset frequencies in GHz.
-        It must be covered by the measurement's stored spectral grid. DC gain
-        also transforms the mean. No filter is applied to the physical chip.
-    tolerance : float
-        Relative tolerance for quadrature-grid convergence checks.
+        Positive boxcar duration in ns. White detector and field noise scale
+        as ``1 / integration_time``.
+    transfer : callable or None, optional
+        Digital complex amplitude transfer function. It receives offset
+        frequencies in GHz, must be supported on the captured spectral grid,
+        and its value at zero also scales the mean field. It does not alter the
+        simulated chip or its physical noise sources.
+    tolerance : float, default=0.02
+        Relative convergence and spectral-support tolerance. Must satisfy
+        ``0 < tolerance < 1``.
+
+    Notes
+    -----
+    The receiver integrates the captured two-sided normally ordered spectrum
+    with the sinc-squared boxcar response and adds detector vacuum with
+    covariance ``1 / (2 * integration_time)`` per IQ quadrature. See Caves,
+    *Phys. Rev. D* 26, 1817 (1982), doi:10.1103/PhysRevD.26.1817, for the
+    phase-preserving amplifier noise convention.
     """
 
     integration_time: Any
@@ -40,7 +53,24 @@ class IQReceiver:
 
 
 def validate_samples(count: int, seed: Any, key: Any, values: Any) -> Any:
-    """Validate shot configuration and choose its native array namespace."""
+    """Validate Gaussian-shot arguments and choose NumPy or JAX arithmetic.
+
+    Parameters
+    ----------
+    count : int
+        Number of draws; must be positive.
+    seed : int or None
+        NumPy generator seed. Do not pass together with ``key``.
+    key : jax.Array or None
+        Explicit JAX PRNG key required when sampling traced values.
+    values : object
+        Mean and covariance values used to infer the array namespace.
+
+    Returns
+    -------
+    module
+        NumPy-like namespace selected for the draw.
+    """
     if not isinstance(count, int) or isinstance(count, bool) or count < 1:
         raise ValueError("Sample count must be a positive integer.")
     if seed is not None and key is not None:
@@ -55,7 +85,24 @@ def validate_samples(count: int, seed: Any, key: Any, values: Any) -> Any:
 
 
 def gaussian_samples(mean: Any, covariance: Any, count: int, *, seed: Any = None, key: Any = None) -> Any:
-    """Draw real Gaussian vectors with a leading shot axis and full covariance."""
+    """Draw correlated real Gaussian vectors.
+
+    Parameters
+    ----------
+    mean : array_like
+        Mean with shape ``(..., n)``.
+    covariance : array_like
+        Positive-definite covariance with shape ``(..., n, n)``.
+    count : int
+        Number of draws.
+    seed, key : optional
+        Use ``seed`` for NumPy or ``key`` for JAX; passing both is invalid.
+
+    Returns
+    -------
+    array
+        Samples with shape ``(count, ..., n)`` in the input array namespace.
+    """
     xp = validate_samples(count, seed, key, (mean, covariance))
     mean, covariance = xp.asarray(mean), xp.asarray(covariance)
     shape = (count, *mean.shape)
@@ -69,7 +116,19 @@ def gaussian_samples(mean: Any, covariance: Any, count: int, *, seed: Any = None
 
 
 def noise_grid(frequencies: Any = None) -> np.ndarray:
-    """Validate a two-sided offset grid in GHz, or supply the standard grid."""
+    """Validate or construct the two-sided spectral offset grid in GHz.
+
+    Parameters
+    ----------
+    frequencies : 1-D array_like or None, optional
+        Strictly increasing, finite, symmetric offsets containing zero. With
+        ``None``, return the default grid spanning ``-0.1`` to ``+0.1`` GHz.
+
+    Returns
+    -------
+    numpy.ndarray
+        Validated offsets in GHz.
+    """
     if frequencies is None:
         positive = np.geomspace(1e-9, 0.1, 161)
         return np.concatenate((-positive[::-1], [0.0], positive))

--- a/quchip/results/results.py
+++ b/quchip/results/results.py
@@ -58,6 +58,17 @@ class OutputFieldTrace:
     is the normally ordered ``<b_out dagger b_out>`` in photons/ns.
     ``raw_*`` retain the same moments at the Markov boundary, before propagation
     through the outbound reference run.
+
+    Attributes
+    ----------
+    exposure : str
+        External network-port label.
+    times : array_like
+        Saved times in ns.
+    amplitude, raw_amplitude : array_like
+        Propagated and Markov-boundary complex means in ``1/sqrt(ns)``.
+    photon_flux, raw_photon_flux : array_like
+        Propagated and Markov-boundary normally ordered fluxes in photons/ns.
     """
 
     exposure: str
@@ -68,7 +79,13 @@ class OutputFieldTrace:
     raw_photon_flux: Any
 
     def quadrature(self, phase: Any = 0.0) -> Any:
-        r"""Return ``Re[exp(-i phase) <b_out>]`` without another solve."""
+        r"""Return ``Re[exp(-i phase) <b_out>]`` without another solve.
+
+        Parameters
+        ----------
+        phase : scalar, default=0.0
+            Quadrature angle in radians.
+        """
         from quchip.utils.jax_utils import array_namespace
 
         xp = array_namespace(self.amplitude)
@@ -91,21 +108,24 @@ _NO_STATES_MSG = 'Full state history is unavailable; run with states="all" to re
 class SimulationResult:
     """Backend-agnostic container for the output of one solve.
 
-    A :class:`SimulationResult` bundles everything a user needs after a
-    solve finishes:
+    Stored states follow the requested storage policy; ``times`` uses ns and
+    ``dims`` follows chip order. Dict-form ``e_ops`` become
+    :class:`ObservableTrace` entries in ``observable_traces``.
 
-    - ``times`` — the time grid the solver stored (ns).
-    - ``states`` — the list of stored states (kets or density matrices),
-      available when the request used ``states="all"``.
-    - ``solver`` — the name reported by the backend.
-    - ``stats`` — a plain ``dict`` of solver statistics.
-    - ``dims`` — the per-device Hilbert-space dimensions, in chip order.
-    - ``device_info`` — ``[(label, computational), …]`` for partial-trace
-      helpers to resolve device indices by label or by object.
-
-    Expectation values live in ``observable_traces`` when ``e_ops`` was
-    passed as a dict. Each entry is an :class:`ObservableTrace` or a list
-    of them (list-valued observables, one per band, etc.).
+    Parameters
+    ----------
+    solver_result : SolverResult
+        Backend output to wrap.
+    backend : Backend
+        Backend owning native states and arrays.
+    dims : sequence of int
+        Hilbert dimensions in chip order.
+    device_info, observable_traces, output_traces, channels, bases : optional
+        Captured device, observable, output, channel, and basis metadata.
+    dissipation : bool, default=True
+        Whether collapse channels were included.
+    readout_wiring : optional
+        Captured downstream readout wiring.
     """
 
     def __init__(
@@ -179,7 +199,15 @@ class SimulationResult:
         return trace
 
     def expect(self, key: Any, index: int | None = None) -> Any:
-        """Return the full expectation-value array for observable *key* over ``self.times``."""
+        """Return an expectation trace over ``self.times``.
+
+        Parameters
+        ----------
+        key : object or str
+            Captured observable key.
+        index : int or None, optional
+            Entry of a list-valued observable.
+        """
         return self._resolve_trace(key, index).values
 
     def observable_at(self, t: Any, values: Any, *, method: str = "exact") -> Any:
@@ -189,13 +217,30 @@ class SimulationResult:
         axes followed by the query shape. ``nearest`` selects the earlier
         sample on a tie; ``interpolate`` is linear, including complex values.
         Out-of-interval queries raise. No solve or state interpolation occurs.
+
+        Parameters
+        ----------
+        t : scalar or array_like
+            Query times in ns.
+        values : array_like
+            Saved values with time on the final axis.
+        method : {"exact", "nearest", "interpolate"}, default="exact"
+            Time-selection rule.
         """
         from quchip.results._time import observable_at
 
         return observable_at(self.times, t, values, method, self._backend.array_module)
 
     def expect_final(self, key: Any, index: int | None = None) -> Any:
-        """Return the final expectation value for observable *key* (``self.expect(key)[-1]``)."""
+        """Return the final expectation value for an observable.
+
+        Parameters
+        ----------
+        key : object or str
+            Captured observable key.
+        index : int or None, optional
+            Entry of a list-valued observable.
+        """
         return self._resolve_trace(key, index).values[-1]
 
     # Alias: reads nicely at call sites that say "give me the values array".
@@ -211,7 +256,13 @@ class SimulationResult:
         return dict(self._output_data)
 
     def output(self, exposure: Any) -> OutputFieldTrace:
-        """Return one field trace by network port or label."""
+        """Return one field trace by network port or label.
+
+        Parameters
+        ----------
+        exposure : port object or str
+            External output reference plane.
+        """
         label = resolve_label(exposure)
         try:
             return self._output_data[label]
@@ -257,6 +308,11 @@ class SimulationResult:
         vacuum input. Dephasing and thermal-absorption channels can also have
         nonzero jump rates, so this quantity alone is not an excitation-loss
         rate.
+
+        Parameters
+        ----------
+        key : channel object or str
+            Resolved channel key, external port, or unambiguous local label.
         """
         name = self._channel_key(key)
         if name not in self._jump_rate_cache:
@@ -272,7 +328,13 @@ class SimulationResult:
         return self._jump_rate_cache[name]
 
     def collapse_flux(self, key: Any) -> Any:
-        """Deprecated alias for :meth:`jump_rate`."""
+        """Deprecated alias for :meth:`jump_rate`.
+
+        Parameters
+        ----------
+        key : channel object or str
+            Resolved channel key.
+        """
         from quchip.utils.deprecation import warn_renamed
 
         warn_renamed("collapse_flux()", "jump_rate()")
@@ -284,6 +346,11 @@ class SimulationResult:
         This is the cumulative trapezoid integral of :meth:`jump_rate` on
         the result grid. Its last entry is the expected number of jumps over
         the whole solve.
+
+        Parameters
+        ----------
+        key : channel object or str
+            Resolved channel key.
         """
         xp = self._backend.array_module
         flux = self.jump_rate(key)
@@ -344,6 +411,11 @@ class SimulationResult:
         matrices returns ``<target|rho(t)|target>``. Stays in the backend's
         array module so the result is differentiable. One batched op over the
         leading time axis — no per-point loop.
+
+        Parameters
+        ----------
+        target : state_like
+            Target ket in the captured full Hilbert space.
         """
         backend = self._backend
         target = backend.coerce_state(target, dims=tuple(self.dims))
@@ -357,6 +429,11 @@ class SimulationResult:
         Density-matrix trajectories raise :class:`TypeError` — there is no
         single phase-sensitive amplitude for a mixed state; use
         :meth:`overlap` instead. One batched op, no per-point loop.
+
+        Parameters
+        ----------
+        target : state_like
+            Target ket in the captured full Hilbert space.
         """
         backend = self._backend
         if not self._is_ket_trajectory():
@@ -379,14 +456,30 @@ class SimulationResult:
         raise ValueError(f"Device '{label}' not found in device_info. Available: {available}")
 
     def state(self, t: float | None = None, *, dm: bool = False) -> Any:
-        """Return the state at time *t* (or final state if *t* is ``None``); optionally coerced to a DM."""
+        """Return a retained state, optionally promoted to a density matrix.
+
+        Parameters
+        ----------
+        t : float or None, optional
+            Saved time in ns; ``None`` selects the final state.
+        dm : bool, default=False
+            Promote a ket to a density matrix.
+        """
         s = self.final_state if t is None else self.state_at(t)
         if dm and self._backend.is_ket(s):
             return self._backend.state_to_dm(s)
         return s
 
     def state_at(self, t: Any, *, method: str = "exact") -> Any:
-        """Return a retained state at a scalar time; states are never interpolated."""
+        """Return a retained state at a scalar time; states are never interpolated.
+
+        Parameters
+        ----------
+        t : scalar
+            Query time in ns.
+        method : {"exact", "nearest"}, default="exact"
+            Time-selection rule.
+        """
         from quchip.results._time import require_valid, time_selection
         from quchip.utils.jax_utils import contains_tracer
 
@@ -405,7 +498,15 @@ class SimulationResult:
         return self._states[int(index)]
 
     def dm_at(self, t: float, *, method: str = "exact") -> Any:
-        """Return the density matrix at a retained time, promoting kets on demand."""
+        """Return a density matrix at a retained time, promoting kets on demand.
+
+        Parameters
+        ----------
+        t : float
+            Query time in ns.
+        method : {"exact", "nearest"}, default="exact"
+            Time-selection rule.
+        """
         state = self.state_at(t, method=method)
         return self._backend.state_to_dm(state) if self._backend.is_ket(state) else state
 
@@ -429,6 +530,19 @@ class SimulationResult:
         This stationary coherent-state readout model excludes quantum-device
         correlations and occupied boundary inputs. Use calibrated IQReadout
         distributions when those effects are included in a detector calibration.
+
+        Parameters
+        ----------
+        output : port object or str
+            External output reference plane.
+        means : array_like or mapping
+            Conditional Markov-boundary means in ``1/sqrt(ns)``.
+        frequency : scalar
+            Carrier frequency in GHz.
+        receiver : IQReceiver
+            Boxcar receiver and optional digital transfer.
+        noise_frequencies : array_like or None, optional
+            Two-sided offsets in GHz; ``None`` uses the standard grid.
         """
         if self._readout_wiring is None:
             raise RuntimeError("No captured output wiring is available for this result.")
@@ -443,12 +557,29 @@ class SimulationResult:
         captured energy basis of the stored integration frame: one matrix for
         one device, or a device mapping. No phase-frame conversion is applied.
         Samples at different times represent independently terminated experiments.
+
+        Parameters
+        ----------
+        *devices : device object or str
+            Measured devices; an empty selection measures all devices.
+        t : scalar, array_like, or None, optional
+            Saved time or times in ns; ``None`` selects the final state.
+        basis : {"energy", "solver"}, array_like, or mapping, default="energy"
+            Captured local measurement basis.
         """
         from quchip.results.terminal import measure_result
         return measure_result(self, devices, t=t, basis=basis)
 
     def reduced_state(self, t: float, device: str | BaseDevice) -> Any:
-        """Partial-trace the state at time *t* down to *device*'s subspace."""
+        """Partial-trace a saved state down to one device.
+
+        Parameters
+        ----------
+        t : float
+            Saved time in ns.
+        device : device object or str
+            Device to retain.
+        """
         dev_idx, _ = self._resolve_device_idx(device)
         return self._backend.ptrace(self.state_at(t), dev_idx, self.dims)
 
@@ -476,7 +607,15 @@ class SimulationResult:
         return {label: all_diags[:, i] for i, label in enumerate(basis_labels)}
 
     def population(self, device: str | BaseDevice, level: int = 0) -> Any:
-        """Return occupation of a captured isolated energy level in native arrays."""
+        """Return occupation of a captured isolated energy level in native arrays.
+
+        Parameters
+        ----------
+        device : device object or str
+            Captured device.
+        level : int, default=0
+            Zero-based isolated energy level.
+        """
         backend = self._backend
         xp = backend.array_module
         dev_idx, label = self._resolve_device_idx(device)
@@ -515,7 +654,19 @@ class SimulationResult:
         ax: Any = None,
         **kwargs: Any,
     ) -> Any:
-        """Plot per-basis-state populations over time (delegates to :func:`quchip.viz.plot_populations`)."""
+        """Plot per-basis-state populations over time.
+
+        Parameters
+        ----------
+        trace_out : device object, str, sequence, or None, optional
+            Devices to trace out.
+        computational : bool, default=False
+            Restrict labels to computational levels.
+        ax : matplotlib.axes.Axes or None, optional
+            Destination axes.
+        **kwargs
+            Forwarded to :func:`quchip.viz.plot_populations`.
+        """
         from quchip.viz.results import plot_populations
 
         return plot_populations(self, trace_out=trace_out, computational=computational, ax=ax, **kwargs)
@@ -530,7 +681,23 @@ class SimulationResult:
         ax: Any = None,
         **kwargs: Any,
     ) -> Any:
-        """Plot one stored state as populations or a density matrix (delegates to :func:`quchip.viz.plot_state`)."""
+        """Plot one stored state as populations or a density matrix.
+
+        Parameters
+        ----------
+        index : int
+            Saved-state index.
+        trace_out : device object, str, sequence, or None, optional
+            Devices to trace out.
+        computational : bool, default=False
+            Restrict labels to computational levels.
+        mode : {"population", "density_matrix"}, default="population"
+            Plot representation.
+        ax : matplotlib.axes.Axes or None, optional
+            Destination axes.
+        **kwargs
+            Forwarded to :func:`quchip.viz.plot_state`.
+        """
         from quchip.viz.results import plot_state
 
         return plot_state(
@@ -538,7 +705,17 @@ class SimulationResult:
         )
 
     def plot_expectation(self, *, keys: list[Any] | None = None, ax: Any = None, **kwargs: Any) -> Any:
-        """Plot expectation-value traces over time (delegates to :func:`quchip.viz.plot_expectation`)."""
+        """Plot expectation-value traces over time.
+
+        Parameters
+        ----------
+        keys : list or None, optional
+            Observable keys; ``None`` plots every captured trace.
+        ax : matplotlib.axes.Axes or None, optional
+            Destination axes.
+        **kwargs
+            Forwarded to :func:`quchip.viz.plot_expectation`.
+        """
         from quchip.viz.results import plot_expectation
 
         return plot_expectation(self, keys=keys, ax=ax, **kwargs)
@@ -551,7 +728,19 @@ class SimulationResult:
         ax: Any = None,
         **kwargs: Any,
     ) -> Any:
-        """Plot the Wigner function of one stored state (delegates to :func:`quchip.viz.plot_wigner`)."""
+        """Plot the Wigner function of one stored state.
+
+        Parameters
+        ----------
+        index : int, default=-1
+            Saved-state index.
+        trace_out : device object, str, sequence, or None, optional
+            Devices to trace out before plotting.
+        ax : matplotlib.axes.Axes or None, optional
+            Destination axes.
+        **kwargs
+            Forwarded to :func:`quchip.viz.plot_wigner`.
+        """
         from quchip.viz.results import plot_wigner
 
         return plot_wigner(self, index, trace_out=trace_out, ax=ax, **kwargs)
@@ -563,6 +752,11 @@ class SimulationResult:
         relevant cutoff and compare observables to establish convergence. Native
         arrays remain differentiable; warning thresholds are evaluated only for
         concrete results. Boundaries are declared by the captured component model.
+
+        Parameters
+        ----------
+        threshold : float, default=1e-3
+            Maximum accepted boundary population.
         """
         from quchip.engine.truncation import evaluate_boundaries
         from quchip.utils.jax_utils import contains_tracer
@@ -621,6 +815,15 @@ class SimulationBatchResult(BatchResult[SimulationResult]):
     backend's array module, and the grid-aware :meth:`expect` /
     :meth:`population` accept ``reduce='last'`` for a final-value slice, so
     a loss function that sums over the batch stays JAX-traceable end-to-end.
+
+    Attributes
+    ----------
+    results : tuple of SimulationResult
+        Per-point results in sweep order.
+    shape : tuple of int
+        Sweep-grid shape.
+    axes : tuple
+        Named sweep-axis metadata.
     """
 
     def measure(self, *devices: Any, t: Any = None, basis: Any = "energy") -> Any:
@@ -631,6 +834,15 @@ class SimulationBatchResult(BatchResult[SimulationResult]):
         captured energy basis of the stored integration frame: one matrix for
         one device, or a device mapping. No phase-frame conversion is applied.
         Samples at different times represent independently terminated experiments.
+
+        Parameters
+        ----------
+        *devices : device object or str
+            Measured devices; an empty selection measures all devices.
+        t : scalar, array_like, or None, optional
+            Saved time or times in ns; ``None`` selects final states.
+        basis : {"energy", "solver"}, array_like, or mapping, default="energy"
+            Captured local measurement basis.
         """
         from quchip.results.terminal import measure_result
         return measure_result(self, devices, t=t, basis=basis)
@@ -677,11 +889,27 @@ class SimulationBatchResult(BatchResult[SimulationResult]):
         raise ValueError("reduce must be one of None, 'last', 'max', or 'mean'.")
 
     def expect(self, key: Any, index: int | None = None, *, reduce: str | None = None) -> Any:
-        """Return expectation traces reshaped to the natural sweep grid."""
+        """Return expectation traces on the natural sweep grid.
+
+        Parameters
+        ----------
+        key : object or str
+            Captured observable key.
+        index : int or None, optional
+            Entry of a list-valued observable.
+        reduce : {None, "last", "max", "mean"}, optional
+            Reduction along the time axis.
+        """
         return self._trace_values([r.expect(key, index=index) for r in self._results], reduce)
 
     def output(self, exposure: Any) -> OutputFieldTrace:
-        """Return one complete field trace reshaped to the natural sweep grid."""
+        """Return one complete field trace on the natural sweep grid.
+
+        Parameters
+        ----------
+        exposure : port object or str
+            External output reference plane.
+        """
         traces = [result.output(exposure) for result in self._results]
         if not traces:
             raise RuntimeError("Empty batch has no output fields.")
@@ -699,7 +927,17 @@ class SimulationBatchResult(BatchResult[SimulationResult]):
         )
 
     def population(self, device: str | BaseDevice, level: int = 0, *, reduce: str | None = None) -> Any:
-        """Return population traces reshaped to the natural sweep grid."""
+        """Return population traces on the natural sweep grid.
+
+        Parameters
+        ----------
+        device : device object or str
+            Captured device.
+        level : int, default=0
+            Zero-based isolated energy level.
+        reduce : {None, "last", "max", "mean"}, optional
+            Reduction along the time axis.
+        """
         return self._trace_values([r.population(device, level) for r in self._results], reduce)
 
     def jump_rate(self, key: Any, *, reduce: str | None = None) -> Any:
@@ -707,11 +945,26 @@ class SimulationBatchResult(BatchResult[SimulationResult]):
 
         ``reduce`` accepts ``None``, ``"last"``, ``"max"``, or ``"mean"``
         and acts on the time axis.
+
+        Parameters
+        ----------
+        key : channel object or str
+            Resolved channel key.
+        reduce : {None, "last", "max", "mean"}, optional
+            Reduction along the time axis.
         """
         return self._trace_values([r.jump_rate(key) for r in self._results], reduce)
 
     def collapse_flux(self, key: Any, *, reduce: str | None = None) -> Any:
-        """Deprecated alias for :meth:`jump_rate`."""
+        """Deprecated alias for :meth:`jump_rate`.
+
+        Parameters
+        ----------
+        key : channel object or str
+            Resolved channel key.
+        reduce : {None, "last", "max", "mean"}, optional
+            Reduction along the time axis.
+        """
         from quchip.utils.deprecation import warn_renamed
 
         warn_renamed("collapse_flux()", "jump_rate()")
@@ -723,6 +976,13 @@ class SimulationBatchResult(BatchResult[SimulationResult]):
         ``reduce`` accepts ``None``, ``"last"``, ``"max"``, or ``"mean"``
         and acts on the time axis. ``reduce="last"`` returns the expected
         number of jumps in each solve.
+
+        Parameters
+        ----------
+        key : channel object or str
+            Resolved channel key.
+        reduce : {None, "last", "max", "mean"}, optional
+            Reduction along the time axis.
         """
         return self._trace_values([r.collapse_integral(key) for r in self._results], reduce)
 
@@ -745,11 +1005,23 @@ class SimulationBatchResult(BatchResult[SimulationResult]):
         return self._stack(values)
 
     def final_overlap_magnitudes(self, targets: list[Any] | tuple[Any, ...]) -> Any:
-        """Return final target-state populations for each result, without requiring histories."""
+        """Return final target-state populations without requiring histories.
+
+        Parameters
+        ----------
+        targets : sequence of state_like
+            One target ket per batch result.
+        """
         return self._final_projections(targets, amplitude=False)
 
     def final_amplitudes(self, targets: list[Any] | tuple[Any, ...]) -> Any:
-        """Return final complex ket amplitudes for each result, without requiring histories."""
+        """Return final complex ket amplitudes without requiring histories.
+
+        Parameters
+        ----------
+        targets : sequence of state_like
+            One target ket per batch result.
+        """
         return self._final_projections(targets, amplitude=True)
 
 # ---------------------------------------------------------------------------
@@ -802,6 +1074,15 @@ def wrap_solver_result(solver_result: SolverResult, problem: SolveProblem, backe
     metadata needed to rebuild dict-form observables
     (:func:`~quchip.engine.observables.build_observable_traces`)
     and to label devices for partial-trace helpers.
+
+    Parameters
+    ----------
+    solver_result : SolverResult
+        Raw backend solve output.
+    problem : SolveProblem
+        Frozen request carrying result metadata.
+    backend : Backend
+        Backend that owns the native states and arrays.
     """
     from quchip.engine.truncation import boundary_traces
 

--- a/quchip/results/steady_state.py
+++ b/quchip/results/steady_state.py
@@ -15,7 +15,23 @@ from quchip.utils.labeling import resolve_label
 
 @dataclass(frozen=True)
 class SteadyStateResult:
-    """One normalized stationary density matrix and its diagnostics."""
+    """One normalized stationary density matrix and its diagnostics.
+
+    Attributes
+    ----------
+    state : backend state
+        Stationary density matrix in solver basis.
+    residual : scalar
+        Residual norm of the stationary equation.
+    nullity : scalar
+        Null-space dimension of the trace-constrained generator.
+    dims : tuple of int
+        Hilbert-space dimensions in chip order.
+    device_info : tuple
+        ``(label, computational)`` records used by accessors.
+    stats : mapping
+        Backend solver statistics.
+    """
 
     state: Any
     residual: Any
@@ -70,7 +86,15 @@ class SteadyStateResult:
         return self.nullity == 1
 
     def expect(self, key: Any, index: int | None = None) -> Any:
-        """Return one named stationary expectation value."""
+        """Return one named stationary expectation value.
+
+        Parameters
+        ----------
+        key : object or str
+            Captured observable key.
+        index : int or None, optional
+            Entry of a list-valued observable.
+        """
         resolved = tuple(resolve_label(item) for item in key) if isinstance(key, tuple) else resolve_label(key)
         value = self._expectations[resolved]
         if isinstance(value, tuple):
@@ -84,7 +108,13 @@ class SteadyStateResult:
         return value
 
     def reduced_state(self, device: str | BaseDevice) -> Any:
-        """Partial-trace the stationary state down to one device."""
+        """Partial-trace the stationary state down to one device.
+
+        Parameters
+        ----------
+        device : device object or str
+            Device to retain.
+        """
         label = resolve_label(device)
         for index, (candidate, _) in enumerate(self.device_info):
             if candidate == label:
@@ -132,8 +162,26 @@ def build_steady_state_result(
 
 
 class SteadyStateBatchResult(BatchResult[SteadyStateResult]):
-    """Immutable stationary results reshaped to their declared sweep grid."""
+    """Immutable stationary results reshaped to their declared sweep grid.
+
+    Attributes
+    ----------
+    results : tuple of SteadyStateResult
+        Per-point stationary results.
+    shape : tuple of int
+        Sweep-grid shape.
+    axes : tuple
+        Named sweep-axis metadata.
+    """
 
     def expect(self, key: Any, index: int | None = None) -> Any:
-        """Return one expectation value reshaped to the sweep grid."""
+        """Return one expectation value on the sweep grid.
+
+        Parameters
+        ----------
+        key : object or str
+            Captured observable key.
+        index : int or None, optional
+            Entry of a list-valued observable.
+        """
         return self._reshape([result.expect(key, index=index) for result in self._results])

--- a/quchip/results/terminal.py
+++ b/quchip/results/terminal.py
@@ -40,6 +40,15 @@ class IQReadout:
     distributions: do not add apparatus noise already included in calibration.
     Covariances must be positive definite. Wiring-derived readouts use fields
     in 1/sqrt(ns) and retain their integrated noise contributions.
+
+    Attributes
+    ----------
+    means : array_like
+        Complex conditional means, one per physical outcome.
+    iq_covariance : array_like
+        Covariance with shape ``(outcomes, 2, 2)``.
+    contributions : mapping or None
+        Optional named integrated noise contributions.
     """
 
     means: Any
@@ -74,6 +83,21 @@ class IQReadout:
         Use the same boundary-field units and vacuum assumptions as
         SimulationResult.iq_readout(). This captures the chip's current wiring;
         the result method instead uses the wiring retained by that simulation.
+
+        Parameters
+        ----------
+        chip : Chip
+            Chip whose current output wiring is captured.
+        output : port object or str
+            Output reference plane.
+        means : array_like
+            Conditional coherent fields in ``1/sqrt(ns)``.
+        frequency : scalar
+            Carrier frequency in GHz.
+        receiver : IQReceiver
+            Boxcar receiver and optional digital transfer.
+        noise_frequencies : array_like or None, optional
+            Two-sided offsets in GHz; ``None`` uses the standard grid.
         """
         from quchip.analysis.field_noise import ReadoutWiring
         wiring = ReadoutWiring.capture(chip.resolve().slh, chip.backend.array_module)
@@ -87,11 +111,23 @@ class IQReadout:
         return weights
 
     def mean(self, probabilities: Any) -> Any:
-        """Return the mean of the conditional IQ mixture."""
+        """Return the mean of the conditional IQ mixture.
+
+        Parameters
+        ----------
+        probabilities : array_like
+            Physical-outcome probabilities on the final axis.
+        """
         return self._weights(probabilities) @ self.means
 
     def covariance(self, probabilities: Any) -> Any:
-        """Return mixture covariance, including separation between conditional means."""
+        """Return mixture covariance, including conditional-mean separation.
+
+        Parameters
+        ----------
+        probabilities : array_like
+            Physical-outcome probabilities on the final axis.
+        """
         weights = self._weights(probabilities)
         xp = _namespace(weights, self.means)
         centers = xp.stack((xp.real(self.means), xp.imag(self.means)), axis=-1)
@@ -107,6 +143,19 @@ class StateSamples:
     physical_indices are Born draws. indices additionally includes assignment
     errors, if requested. iq is present only for a conditional IQ readout.
     Sweep axes follow the leading shot axis. No conditional state is returned.
+
+    Attributes
+    ----------
+    devices : tuple of str
+        Measured device labels.
+    outcomes : tuple of tuple of int
+        Ordered outcome tuples.
+    axes : tuple
+        Sweep-axis metadata.
+    physical_indices, indices : array_like
+        Born and recorded outcome indices.
+    iq : array_like or None
+        Conditional IQ draws, when requested.
     """
 
     devices: tuple[str, ...]
@@ -128,7 +177,19 @@ class StateSamples:
 
 @dataclass(frozen=True)
 class StateMeasurement:
-    """Born probabilities in a captured local product measurement basis."""
+    """Born probabilities in a captured local product measurement basis.
+
+    Attributes
+    ----------
+    devices : tuple of str
+        Measured device labels.
+    outcomes : tuple of tuple of int
+        Ordered product-basis outcomes.
+    probabilities : array_like
+        Normalized probabilities with outcomes on the final axis.
+    axes : tuple
+        Sweep-axis metadata.
+    """
 
     devices: tuple[str, ...]
     outcomes: tuple[tuple[int, ...], ...]
@@ -155,7 +216,13 @@ class StateMeasurement:
         return matrix
 
     def recorded_probabilities(self, assignment: Any) -> Any:
-        """Apply A[recorded, physical], with each column summing to one."""
+        """Apply ``A[recorded, physical]`` to the Born probabilities.
+
+        Parameters
+        ----------
+        assignment : array_like
+            Column-stochastic ``(recorded, physical)`` assignment matrix.
+        """
         return self.probabilities @ self._assignment(assignment).T
 
     def sample(self, count: int, *, seed: int | None = None, key: Any = None,
@@ -165,6 +232,19 @@ class StateMeasurement:
         Assignment and IQ are separate detector models. IQ samples remain
         unclassified; no threshold or assignment matrix is inferred from them.
         Discrete labels are not differentiable. Use an explicit key under JAX.
+
+        Parameters
+        ----------
+        count : int
+            Positive number of independent shots.
+        seed : int or None, optional
+            NumPy random seed.
+        key : jax.Array or None, optional
+            JAX random key; mutually exclusive with ``seed``.
+        assignment : array_like or None, optional
+            Column-stochastic ``(recorded, physical)`` assignment matrix.
+        readout : IQReadout or None, optional
+            Conditional IQ calibration for each physical outcome.
         """
         if assignment is not None and readout is not None:
             raise ValueError("Choose assignment or IQ readout; IQ samples are not automatically classified.")

--- a/quchip/sweep.py
+++ b/quchip/sweep.py
@@ -32,11 +32,21 @@ if TYPE_CHECKING:
 
 
 class ZippedSweep:
-    """Element-wise pairing of sweep axes.
+    """Pair sweep axes element by element.
 
-    Built via :meth:`Sweep.zip`. All bundled axes must share the same
-    ``size``; iteration steps through them together, producing one
-    parameter dict per element rather than a Cartesian-product grid.
+    Use :meth:`Sweep.zip` to validate lengths before constructing this bundle.
+
+    Parameters
+    ----------
+    sweeps : tuple of Sweep
+        Nonempty axes with equal lengths and distinct names.
+
+    Attributes
+    ----------
+    sweeps : tuple of Sweep
+        Axes advanced together.
+    size : int
+        Length of the first axis.
     """
 
     def __init__(self, sweeps: tuple[Sweep, ...]) -> None:
@@ -49,29 +59,25 @@ class ZippedSweep:
 
 
 class Sweep:
-    """Declarative 1-D sweep axis over a named parameter.
+    """Declare a one-dimensional parameter axis.
 
-    ``values`` are in the swept parameter's own physical units (the
-    package-wide contract: GHz for frequencies and couplings, ns for
-    times, mK for temperatures).
+    Parameters
+    ----------
+    values : array_like, shape (n,)
+        Values in the parameter's units. JAX arrays are preserved; other
+        inputs are converted to NumPy arrays. Scalar inputs are unsupported.
+    name : str or None, default None
+        Parameter path such as ``"q.freq"``; omission gives ``"unnamed"``.
+        Names must be unique when axes are combined.
 
-    ``values`` may be a Python sequence, a NumPy array, or a JAX array;
-    JAX arrays are preserved as-is so any consumer that threads the
-    sweep through a JAX-traced path keeps full differentiability.
-    Non-JAX inputs are normalized through :func:`numpy.asarray` for
-    uniform ``len``/indexing behavior.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from quchip.sweep import Sweep
-    >>> freqs = Sweep(np.linspace(4.9, 5.1, 5), name="freq")
-    >>> freqs.size
-    5
-    >>> drives = Sweep([0.01, 0.02, 0.03], name="amp")
-    >>> points = Sweep.expand([freqs, drives])
-    >>> len(points)
-    15
+    Attributes
+    ----------
+    values : array_like
+        Stored axis values.
+    name : str
+        Parameter path or axis name.
+    size : int
+        Number of values.
     """
 
     def __init__(self, values: Any, *, name: str | None = None) -> None:
@@ -115,8 +121,16 @@ class Sweep:
     def expand(axes: Sequence[Sweep | ZippedSweep]) -> list[dict[str, Any]]:
         """Expand independent axes as a Cartesian product and zipped axes pairwise.
 
-        Return one parameter dict per grid point in C-order (last axis fastest).
-        Every axis name, including each member of a zipped group, must be unique.
+        Parameters
+        ----------
+        axes : sequence of Sweep or ZippedSweep
+            Axes in output order. Names must be unique across all groups.
+
+        Returns
+        -------
+        list of dict
+            Parameter mappings in C order (last axis fastest). No axes gives
+            one empty mapping; an empty axis gives no points.
         """
         _shape, points = _iter_axis_points(axes)
         return [params for _coord, params in points]
@@ -354,15 +368,39 @@ class SpectrumSweepResult:
         n_components: int = 5,
         **device_state_kwargs: int,
     ) -> dict[tuple[int, ...], float]:
-        """Top-``n_components`` bare-state probabilities of a dressed eigenstate.
+        """Return the largest bare-state probabilities of one dressed state.
 
-        ``state`` may either be an explicit dressed index (``int``) or
-        a bare-label specification that is resolved via the same
-        overlap-based map used by :meth:`dressed_index`. Requires the
-        sweep to have been run with ``store_eigenstates=True``.
+        Requires ``store_eigenstates=True`` when running the sweep.
 
-        Returns a dict mapping bare labels to squared-amplitude
-        probabilities, ordered from largest to smallest.
+        Parameters
+        ----------
+        point : int, tuple of int, or None
+            Grid coordinate; an integer selects a one-dimensional sweep.
+            ``None`` is valid only for a result with no sweep axes.
+        state : int, mapping, or None, default None
+            Dressed index, or device-object/label to bare-level mapping.
+            A mapping is resolved through the stored overlap assignment.
+            Omitted devices have level zero.
+        n_components : int, default 5
+            Positive maximum number of components returned.
+        **device_state_kwargs : int
+            Bare levels keyed by device label, as an alternative to a mapping.
+            Do not combine with a nonempty mapping.
+
+        Returns
+        -------
+        dict
+            Bare occupation tuples mapped to squared amplitudes, in descending order.
+
+        Raises
+        ------
+        ValueError
+            Eigenvectors were not saved, a coordinate is invalid, the requested
+            count is nonpositive, or the bare label has no confident assignment.
+
+        See Also
+        --------
+        SpectrumSweep : Dressed-spectrum conventions and physics reference.
         """
         if self.eigenvector_matrices is None:
             raise ValueError(
@@ -394,30 +432,32 @@ class SpectrumSweepResult:
 
 
 class SpectrumSweep:
-    """Sequential dressed-spectrum sweep driver.
+    """Compute dressed spectra over a parameter grid.
 
-    Each sweep name is a path from :attr:`Chip.parameters`. At every grid
-    point :meth:`Chip.with_params` creates an isolated chip and
-    :meth:`Chip.dress` computes its dressed spectrum. The
-    per-point eigenvalues and overlap-based bare→dressed assignments
-    are collected into a :class:`SpectrumSweepResult`.
+    Each point uses a fresh :meth:`Chip.with_params` clone and independent
+    bare-state overlap assignment; labels are not transported along the path.
 
-    This is the standard tool for two-tone spectroscopy maps, avoided
-    crossings, and any study that requires following dressed states
-    across parameter space. See Blais, Grimsmo, Girvin & Wallraff,
-    Rev. Mod. Phys. 93, 025005 (2021), for the dressed-state picture;
-    the overlap-based labeling follows the usual practice of assigning
-    a dressed eigenstate to the bare state with which it has maximum
-    overlap.
+    Parameters
+    ----------
+    chip : Chip
+        Model to dress in the lab frame.
+    axes : sequence of Sweep or ZippedSweep
+        Nonempty axes named by paths in ``chip.parameters``. Independent
+        axes form a Cartesian product; zipped axes advance together.
+    evals_count : int or None, default None
+        Number of lowest eigenvalues stored, from 1 to ``chip.total_dim``.
+        ``None`` stores all. Dressing still computes the full eigensystem.
+    store_eigenstates : bool, default False
+        Retain eigenvectors and backend states for component inspection.
+    overlap_threshold : float, default 0.5
+        Minimum squared overlap for a confident bare-state assignment.
+        Use a value between 0 and 1. Unassigned labels yield ``NaN``.
 
-    Examples
-    --------
-    >>> # Sweep a qubit frequency and record dressed levels
-    >>> # sweep = SpectrumSweep(
-    >>> #     chip,
-    >>> #     [Sweep(np.linspace(4.8, 5.2, 41), name="q.freq")],
-    >>> # )
-    >>> # result = sweep.run()  # doctest: +SKIP
+    References
+    ----------
+    Blais et al., *Circuit quantum electrodynamics*, Rev. Mod. Phys. 93,
+    025005 (2021), https://doi.org/10.1103/RevModPhys.93.025005.
+    The reference describes dressed states; grid traversal is quchip policy.
     """
 
     def __init__(

--- a/quchip/utils/labeling.py
+++ b/quchip/utils/labeling.py
@@ -16,7 +16,13 @@ _label_counters: dict[str, int] = {}
 
 
 def auto_label(prefix: str) -> str:
-    """Return the next ``"{prefix}_{n}"`` label; each prefix starts at zero."""
+    r"""Return the next ``"{prefix}_{n}"`` label; each prefix starts at zero.
+
+    Parameters
+    ----------
+    prefix : str
+        Component-type prefix used by its independent process-wide counter.
+    """
     idx = _label_counters.get(prefix, 0)
     _label_counters[prefix] = idx + 1
     return f"{prefix}_{idx}"
@@ -28,9 +34,14 @@ def reset_label_counters() -> None:
 
 
 def resolve_label(obj: str | Any) -> str:
-    """Return a string label from a string or labeled component.
+    r"""Return a string label from a string or labeled component.
 
     Raise ``TypeError`` if the object has no usable label.
+
+    Parameters
+    ----------
+    obj : str or object
+        Label string, returned unchanged, or an object with a non-None label attribute.
     """
     if isinstance(obj, str):
         return obj

--- a/quchip/utils/registry.py
+++ b/quchip/utils/registry.py
@@ -75,12 +75,21 @@ class Registrable:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any], *args: Any, **kwargs: Any) -> Any:
-        """Reconstruct from :meth:`to_dict` output.
+        r"""Reconstruct from :meth:`to_dict` output.
 
         On the registry root, dispatch to the concrete subclass named by
         ``data["type"]`` (forwarding ``*args`` / ``**kwargs``). On a concrete
         subclass, defer to :meth:`_from_dict_payload`. Concrete subclasses
         that carry payload override this method directly.
+
+        Parameters
+        ----------
+        data : dict
+            Serialized declaration containing the fully qualified type key.
+        *args : object
+            Additional positional reconstruction arguments, such as coupling endpoints.
+        **kwargs : object
+            Keyword reconstruction arguments accepted by the registered class.
         """
         if cls is cls._registry_root:
             type_key = str(data["type"])

--- a/tests/test_api_doc_coverage.py
+++ b/tests/test_api_doc_coverage.py
@@ -1,0 +1,63 @@
+"""Verify that documentation coverage detects missing descriptions and drift."""
+
+from __future__ import annotations
+
+import inspect
+import unittest
+from dataclasses import dataclass
+from importlib.util import find_spec
+
+if find_spec("sphinx") is None:
+    raise unittest.SkipTest("API documentation checks require the docs extra")
+
+from tools.check_api_docs import check_callable, documented_fields
+
+
+class DocumentationCoverageTests(unittest.TestCase):
+    """Exercise parsed docstrings and runtime signatures, including generated ones."""
+
+    def test_prose_or_types_alone_do_not_count_as_descriptions(self):
+        """A mentioned parameter or a type-only entry remains undocumented."""
+        fields, _ = documented_fields(
+            "Use duration in ns.\n\nParameters\n----------\nduration : float\n"
+        )
+        self.assertEqual(fields, set())
+
+    def test_variadic_and_grouped_fields_are_recognized(self):
+        """Escaped variadics and grouped attributes map to each real name."""
+        params, attrs = documented_fields(
+            "Parameters\n----------\n*axes\n    Independent axes.\n"
+            "**options\n    Solver options.\n\nAttributes\n----------\n"
+            "initial, final : float\n    Endpoint values.\n"
+        )
+        self.assertEqual(params, {"axes", "options"})
+        self.assertEqual(attrs, {"initial", "final"})
+
+    def test_runtime_signature_detects_added_and_obsolete_parameters(self):
+        """Synthesized signatures are checked rather than the generic Python wrapper."""
+        def model(**kwargs):
+            """Parameters
+            ----------
+            old_name : float
+                Retired argument.
+            """
+        model.__signature__ = inspect.Signature([
+            inspect.Parameter("frequency", inspect.Parameter.KEYWORD_ONLY)
+        ])
+        issue = check_callable("model", model)
+        self.assertEqual(issue["missing"], ["frequency"])
+        self.assertEqual(issue["extra"], ["old_name"])
+
+    def test_result_attributes_cover_public_fields(self):
+        """Result attributes cover public dataclass fields without exposing storage internals."""
+        @dataclass
+        class Result:
+            """Attributes
+            ----------
+            values : object
+                Observable values on the saved time grid.
+            """
+            values: object
+            _cache: object = None
+
+        self.assertIsNone(check_callable("Result", Result))

--- a/tests/test_ci_classification.py
+++ b/tests/test_ci_classification.py
@@ -1,0 +1,84 @@
+"""Verify that lightweight CI cannot hide executable changes or invalid diffs."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+CLASSIFIER = Path(__file__).resolve().parents[1] / ".github/actions/classify-pr/classify.sh"
+
+
+class ChangeClassificationTests(unittest.TestCase):
+    """Exercise the CI classifier against real commit pairs."""
+
+    def setUp(self):
+        """Create an isolated repository with a source file and baseline commit."""
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.git("init", "-q")
+        self.git("config", "user.name", "CI policy test")
+        self.git("config", "user.email", "ci@example.invalid")
+        self.write("quchip/model.py", "value = 1\n")
+        self.base = self.commit()
+
+    def git(self, *args):
+        """Run Git only inside the isolated fixture repository."""
+        return subprocess.check_output(["git", *args], cwd=self.root, text=True).strip()
+
+    def write(self, name, content):
+        """Write one fixture path, including any parent directories."""
+        path = self.root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+    def commit(self):
+        """Capture fixture edits as the comparison commit."""
+        self.git("add", ".")
+        self.git("commit", "-qm", "Fixture")
+        return self.git("rev-parse", "HEAD")
+
+    def classify(self, head, event="pull_request"):
+        """Return classifier output without hiding failures."""
+        return subprocess.run(
+            ["bash", str(CLASSIFIER)], cwd=self.root, text=True, capture_output=True,
+            env={**os.environ, "BASE_SHA": self.base, "HEAD_SHA": head, "EVENT_NAME": event},
+        )
+
+    def test_documentation_is_lightweight(self):
+        """Documentation and release metadata require no physics test environment."""
+        self.write("docs/guide.md", "Guide\n")
+        self.write("RELEASE_NOTES_1.0.md", "Notes\n")
+        result = self.classify(self.commit())
+        self.assertEqual((result.returncode, result.stdout), (0, "full_ci=false\n"))
+
+    def test_executable_markdown_and_ci_policy_require_tests(self):
+        """Example notebooks, test resources, and CI policy cannot use the Markdown exemption."""
+        for name in ("examples/demo.md", "tests/fixture.md", "tools/helper.md", ".github/rulesets/main.json"):
+            with self.subTest(name=name):
+                self.git("reset", "--hard", self.base)
+                self.write(name, "Changed\n")
+                result = self.classify(self.commit())
+                self.assertEqual((result.returncode, result.stdout), (0, "full_ci=true\n"))
+
+    def test_moving_source_into_docs_still_requires_tests(self):
+        """Renaming a source file cannot disguise its removal as a docs-only edit."""
+        (self.root / "docs").mkdir()
+        self.git("mv", "quchip/model.py", "docs/model.md")
+        result = self.classify(self.commit())
+        self.assertEqual((result.returncode, result.stdout), (0, "full_ci=true\n"))
+
+    def test_invalid_revision_fails_without_a_lightweight_result(self):
+        """An unreadable diff fails instead of silently reporting no changed files."""
+        result = self.classify("missing-revision")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertNotIn("full_ci=false", result.stdout)
+
+    def test_manual_runs_request_full_coverage(self):
+        """Explicit runs bypass PR path classification and request the test lanes."""
+        result = self.classify(self.base, event="workflow_dispatch")
+        self.assertEqual((result.returncode, result.stdout), (0, "full_ci=true\n"))

--- a/tools/check_api_docs.py
+++ b/tools/check_api_docs.py
@@ -1,0 +1,157 @@
+"""Check parameter descriptions on the supported user-facing Python surface.
+
+Run with the docs extra installed. This checks structure, not scientific
+accuracy: units, options, defaults, shapes, and references still need review.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import inspect
+import json
+import re
+from collections.abc import Iterator
+from importlib.util import find_spec
+from typing import Any
+
+from sphinx.ext.napoleon import Config
+from sphinx.ext.napoleon.docstring import NumpyDocstring
+
+
+# Package exports are authoritative. These additional types are returned by
+# public workflows without being re-exported at the package root.
+PUBLIC_MODULES = (
+    "quchip", "quchip.analysis", "quchip.approximations", "quchip.backend",
+    "quchip.chip", "quchip.control", "quchip.declarative", "quchip.devices",
+    "quchip.engine", "quchip.extensions", "quchip.inverse_design",
+    "quchip.interop", "quchip.results", "quchip.utils", "quchip.viz",
+)
+RETURNED_TYPES = (
+    "quchip.sweep.SpectrumSweepResult",
+    "quchip.control.batch.BatchAxis",
+    "quchip.control.batch.ZippedBatchAxis",
+    "quchip.control.batch.PulseHandle",
+    "quchip.control.batch.DelayHandle",
+    "quchip.control.field.CoherentInput",
+    "quchip.chip.analysis.ChipAnalysis",
+    "quchip.chip.port_network.FieldTerminal",
+    "quchip.chip.port_network.SLHComponent",
+    "quchip.chip.port_network.IncludedNetwork",
+    "quchip.observables.OutputField",
+    "quchip.backend.containers.LinearResponseSolverResult",
+    "quchip.backend.containers.PreparedStationary",
+)
+
+
+def documented_fields(doc: str) -> tuple[set[str], set[str]]:
+    """Read nonempty parameter and attribute descriptions using Sphinx's parser."""
+    rendered = str(NumpyDocstring(doc, config=Config(napoleon_use_ivar=True)))
+    params, attributes = set(), set()
+    # Field bodies may wrap onto subsequent indented lines.
+    pattern = r"^:(param|ivar) ([^:]+):([^\n]*(?:\n[ \t]+[^\n]*)*)"
+    for kind, name, body in re.findall(pattern, rendered, flags=re.MULTILINE):
+        if body.strip():
+            target = params if kind == "param" else attributes
+            target.update(part.strip().lstrip("\\*") for part in name.split(","))
+    return params, attributes
+
+
+def public_objects() -> Iterator[tuple[str, Any]]:
+    """Yield exports and explicitly listed returned types, deduplicated by identity."""
+    seen = set()
+    for module_name in PUBLIC_MODULES:
+        module = importlib.import_module(module_name)
+        for name in module.__all__:
+            obj = getattr(module, name)
+            if id(obj) not in seen:
+                seen.add(id(obj))
+                yield f"{module_name}.{name}", obj
+    extra_types = list(RETURNED_TYPES)
+    if find_spec("dynamiqs") is not None:
+        extra_types.append("quchip.backend.dynamiqs.DynamiqsBackend")
+    for path in extra_types:
+        module_name, name = path.rsplit(".", 1)
+        obj = getattr(importlib.import_module(module_name), name)
+        if id(obj) not in seen:
+            seen.add(id(obj))
+            yield path, obj
+
+
+def check_callable(name: str, obj: Any) -> dict[str, Any] | None:
+    """Compare a callable's real signature with its authored descriptions."""
+    if inspect.isclass(obj) and getattr(obj, "_is_protocol", False):
+        return None  # Protocols describe structural interfaces, not constructors.
+    try:
+        signature = inspect.signature(obj)
+    except (TypeError, ValueError):
+        return None
+    parameters = {
+        key: value for key, value in signature.parameters.items()
+        if key not in {"self", "cls"} and not key.startswith("_")
+    }
+    doc = inspect.getdoc(obj) or ""
+    documented, attributes = documented_fields(doc)
+    if inspect.isclass(obj):
+        documented |= attributes
+    missing = sorted(set(parameters) - documented)
+    accepts_keywords = any(p.kind == p.VAR_KEYWORD for p in parameters.values())
+    # Expanded keyword descriptions are valid when **kwargs accepts them.
+    extra = sorted(documented - set(parameters)) if not accepts_keywords else []
+    if inspect.isclass(obj):
+        extra = sorted(set(extra) - attributes)
+    if not missing and not extra:
+        return None
+    return {"name": name, "file": inspect.getsourcefile(obj), "missing": missing, "extra": extra}
+
+
+def audit() -> tuple[int, list[dict[str, Any]]]:
+    """Check public callables and inherited methods once per implementation."""
+    issues = []
+    checked = 0
+    seen_methods = set()
+    for name, obj in public_objects():
+        if not (inspect.isclass(obj) or inspect.isfunction(obj)):
+            continue
+        if not getattr(obj, "__module__", "").startswith("quchip"):
+            continue  # Re-exported typing aliases do not define quchip callables.
+        checked += 1
+        issue = check_callable(name, obj)
+        if issue:
+            issues.append(issue)
+        if not inspect.isclass(obj):
+            continue
+        for member_name, member in inspect.getmembers(obj, inspect.isroutine):
+            if member_name.startswith("_") or not getattr(member, "__module__", "").startswith("quchip"):
+                continue
+            identity = (member.__module__, member.__qualname__)
+            if identity in seen_methods:
+                continue
+            seen_methods.add(identity)
+            checked += 1
+            issue = check_callable(f"{name}.{member_name}", member)
+            if issue:
+                issues.append(issue)
+    return checked, issues
+
+
+def main() -> int:
+    """Print missing or obsolete entries and fail when any remain."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Print the complete report as JSON.")
+    parser.add_argument("--path", help="Only report files containing this path fragment.")
+    args = parser.parse_args()
+    checked, issues = audit()
+    if args.path:
+        issues = [issue for issue in issues if args.path in (issue["file"] or "")]
+    if args.json:
+        print(json.dumps({"checked": checked, "issues": issues}, indent=2))
+    else:
+        for issue in issues:
+            print(f"{issue['name']}: missing={issue['missing']}, obsolete={issue['extra']}")
+        print(f"{checked} public callables inspected; {len(issues)} with parameter-documentation gaps.")
+    return bool(issues)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Public API pages had missing parameter descriptions, stale constructor arguments, and empty type-only tables. Document parameter choices, defaults, units, `None` behavior, result shapes, and physics references. Shared backend contracts are inherited, and a coverage check detects missing or obsolete parameter entries.

Prepare **quchip 0.3.2** (latest published version: 0.3.1), including citation metadata, installation guidance, and release notes covering changes since v0.3.1. Tag `v0.3.2` only after this PR merges.

CI now validates changes before merging without repeating the same test selections:

- Remove post-merge lint/test runs; retain docs deployment and release publishing.
- Run `core or physics_sentinel` on Python 3.11/3.12. The on-demand pre-merge job runs its complement on Python 3.11, completing coverage without repeating fast tests. Manual pre-merge runs still execute the full suite.
- Make benchmarks manual and cancel superseded PR documentation builds. Keep the weekly fresh-dependency canary.
- Treat executable example Markdown as code and fail classification when Git cannot read the compared revisions.

Upstream ruleset **21738854** has already been updated and verified: branches must include current `main` before merging. Required check names and bypass settings are unchanged. The configuration is recorded in `.github/rulesets/main.json`.

## Verification

- Based on upstream `main` at `7cfea03208b65b58d782d614598de8a88251d875` (merged PR #42).
- 880 API callables inspected; zero parameter-documentation gaps.
- Strict Sphinx build, rendered API checks, Ruff, Actionlint, shell syntax, and whitespace checks passed.
- Five classifier tests and four documentation-checker tests passed.
- Collected 1,971 tests: actual workflow selections cover 1,785 fast tests and 186 remaining tests, with zero overlap or omissions. This verifies selection; the numerical suite was not rerun for these workflow changes.
- Package changes are docstrings and the version constant; numerical implementation is unchanged.
- Built the 0.3.2 wheel and sdist; package metadata and citation versions agree, Twine validation and strict Sphinx passed.
- The release-preparation commit omits `[skip ci]` so PR validation can start. The on-demand remaining-test lane uses the `ready-to-merge` label. No merge or tag has been performed.

## Checklist

- [x] This pull request is focused and contains no unrelated changes.
- [x] Changed behavior is covered by tests, or no behavior changed.
- [x] Relevant documentation and examples are updated.
- [x] Generated files and paired notebooks are synchronized, if applicable. No tracked generated files or notebooks changed.
- [x] `PHYSICS.md` is updated, or is not relevant: numerical models are unchanged; API conventions and references are documented at their entry points.

## AI assistance

AI agents drafted and trimmed documentation and implemented CI policy changes. Verification included source review, classifier regressions, test collection, executable AST comparison, and rendered documentation. Commits and PR updates use `ibralyousef`; the authorized `quchip` account was used only to update the upstream ruleset.
