### PR TITLE
Simplify acquisition, constructor, and batch bookkeeping

### DIFF
--- a/quchip/analysis/measurement.py
+++ b/quchip/analysis/measurement.py
@@ -131,8 +131,8 @@ def measure(
     offsets = noise_grid(noise_frequencies)
     xp = vna.chip.backend.array_module
     modes = tuple(device.label for device in vna.chip.devices if isinstance(device.local_space(), FockSpace))
-    captured, means, incident, diagnostics, delays, parameters = [], [], [], [], [], []
-    mode_amplitudes, photon_numbers, mode_frequencies = [], [], []
+    captured: list[_Acquisition] = []
+    incident, parameters = [], []
     points: list[Any] = []
     for _, params in variation_points:
         chip = vna._chip_at(params)
@@ -161,31 +161,27 @@ def measure(
         else:
             acquired = capture_linear(
                 linear, chip.backend, labels, input_label, frequency, amplitude, xp.asarray(offsets))
-        means.append(acquired.mean)
-        captured.append(acquired.components)
-        delays.append(acquired.delays)
-        mode_amplitudes.append(acquired.mode_amplitudes)
-        photon_numbers.append(acquired.photon_numbers)
-        mode_frequencies.append(acquired.mode_frequencies)
+        captured.append(acquired)
         incident.append(xp.asarray(amplitude))
-        diagnostics.append(acquired.diagnostics)
     size = 2 * len(labels)
-    names = tuple(captured[0])
-    if any(tuple(point) != names for point in captured):
+    names = tuple(captured[0].components)
+    if any(tuple(point.components) != names for point in captured):
         raise ValueError("Measurement variations must preserve noise source structure.")
     components = {
-        name: (xp.stack([point[name][0] for point in captured]).reshape((*shape, size, size)),
-               xp.stack([point[name][1] for point in captured]).reshape((*shape, len(offsets), size, size)))
+        name: (xp.stack([point.components[name][0] for point in captured]).reshape((*shape, size, size)),
+               xp.stack([point.components[name][1] for point in captured]).reshape((*shape, len(offsets), size, size)))
         for name in names
     }
     return VNAMeasurement(
         ports=labels, input=resolve_label(input_label),
         frequencies=frequency_values if frequency_axis else frequency_values[0],
         amplitudes=amplitude_values if amplitude_axis else amplitude_values[0], axes=axes, shape=shape,
-        diagnostics=tuple(diagnostics), values=xp.stack(means).reshape((*shape, len(labels))),
+        diagnostics=tuple(point.diagnostics for point in captured),
+        values=xp.stack([point.mean for point in captured]).reshape((*shape, len(labels))),
         incident=xp.stack(incident).reshape(shape), noise_frequencies=offsets, noise_components=components,
-        output_delays=xp.stack(delays).reshape((*shape, len(labels))), parameters=tuple(parameters),
-        modes=modes, mode_amplitudes=xp.stack(mode_amplitudes).reshape((*shape, len(modes))),
-        photon_numbers=xp.stack(photon_numbers).reshape((*shape, len(modes))),
-        mode_frequencies=xp.stack(mode_frequencies).reshape((*shape, len(modes))),
+        output_delays=xp.stack([point.delays for point in captured]).reshape((*shape, len(labels))),
+        parameters=tuple(parameters), modes=modes,
+        mode_amplitudes=xp.stack([point.mode_amplitudes for point in captured]).reshape((*shape, len(modes))),
+        photon_numbers=xp.stack([point.photon_numbers for point in captured]).reshape((*shape, len(modes))),
+        mode_frequencies=xp.stack([point.mode_frequencies for point in captured]).reshape((*shape, len(modes))),
     )

--- a/quchip/chip/transformations/result.py
+++ b/quchip/chip/transformations/result.py
@@ -31,19 +31,6 @@ class ChipTransform(Protocol):
     def chip(self) -> "Chip": ...
 
 
-class _HasFreq(Protocol):
-    """Typing-only view of ``freq`` on concrete device subclasses."""
-
-    freq: Any
-
-
-class _HasG(Protocol):
-    """Typing-only view of the scalar coupling strength every Capacitive-like
-    coupling exposes; not declared on BaseCoupling itself."""
-
-    g: Any
-
-
 @dataclass(frozen=True)
 class ReductionMap:
     """A captured subspace map in the source and target lab-frame solver bases.

--- a/quchip/control/batch.py
+++ b/quchip/control/batch.py
@@ -199,20 +199,10 @@ def _expand_axis_overrides(
     """
     axis_slices: list[list[dict[tuple[int | None, str], Any]]] = []
     for axis in axes:
-        if isinstance(axis, ZippedBatchAxis):
-            slice_: list[dict[tuple[int | None, str], Any]] = []
-            for i in range(axis.size):
-                point: dict[tuple[int | None, str], Any] = {}
-                for subaxis in axis.axes:
-                    point[subaxis.override_key] = subaxis.values[i]
-                slice_.append(point)
-            axis_slices.append(slice_)
-        else:
-            axis_slices.append(
-                [
-                    {axis.override_key: axis.values[i]}
-                    for i in range(axis.size)
-                ]
-            )
+        members = axis.axes if isinstance(axis, ZippedBatchAxis) else (axis,)
+        axis_slices.append([
+            {member.override_key: member.values[i] for member in members}
+            for i in range(axis.size)
+        ])
 
     return expand_axis_groups(axis_slices)

--- a/quchip/control/envelopes.py
+++ b/quchip/control/envelopes.py
@@ -61,9 +61,7 @@ def _synthesize_envelope_init(cls: type["Envelope"]) -> Any:
     def __init__(self: Envelope, *args: Any, **kwargs: Any) -> None:
         bound = signature.bind(self, *args, **kwargs)
         bound.apply_defaults()
-        arguments = dict(bound.arguments)
-        arguments.pop("self")
-        Envelope.__init__(self, **arguments)
+        Envelope.__init__(**bound.arguments)
 
     __init__.__signature__ = signature  # type: ignore[attr-defined]
     __init__.__qualname__ = f"{cls.__qualname__}.__init__"

--- a/quchip/declarative/models.py
+++ b/quchip/declarative/models.py
@@ -193,11 +193,7 @@ def _synthesize_device_init(cls: Any) -> Any:
         kwargs = BaseDevice._normalize_parameter_names(kwargs)
         bound = signature.bind(self, *args, **kwargs)
         bound.apply_defaults()
-        arguments = dict(bound.arguments)
-        arguments.pop("self")
-        levels = arguments.pop("levels")
-        label = arguments.pop("label")
-        DeviceModel.__init__(self, levels=levels, label=label, **arguments)
+        DeviceModel.__init__(**bound.arguments)
 
     __init__.__signature__ = signature  # type: ignore[attr-defined]
     __init__.__qualname__ = f"{cls.__qualname__}.__init__"
@@ -244,18 +240,7 @@ def _synthesize_coupling_init(cls: Any) -> Any:
     def __init__(self: Any, *args: Any, **kwargs: Any) -> None:
         bound = signature.bind(self, *args, **kwargs)
         bound.apply_defaults()
-        arguments = dict(bound.arguments)
-        arguments.pop("self")
-        device_a = arguments.pop("device_a")
-        device_b = arguments.pop("device_b")
-        label = arguments.pop("label")
-        CouplingModel.__init__(
-            self,
-            device_a,
-            device_b,
-            label=label,
-            **arguments,
-        )
+        CouplingModel.__init__(**bound.arguments)
 
     __init__.__signature__ = signature  # type: ignore[attr-defined]
     __init__.__qualname__ = f"{cls.__qualname__}.__init__"


### PR DESCRIPTION
Measurement collection unpacked each acquisition into parallel lists, generated constructors copied and rebuilt arguments they had already bound, and batch expansion duplicated the same loop for ordinary and zipped axes. Reuse acquisition records and bound arguments, share the batch expansion loop, and remove two unused private typing protocols. Public signatures and numerical behavior are preserved; the diff removes 44 net lines across five files.

Validation: 198 focused tests passed; Ruff passed on tracked Python files; mypy passed for `quchip` and the external declarative-model typing fixture (140 files); `git diff --check` passed. A full suite run is in progress in an isolated checkout.

AI assistance: implemented and checked with Codex.
